### PR TITLE
Mouse.areaMap() bug fixing

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -93,6 +93,9 @@ Crafty.c("mouse", {
 				args[i][0] += this.x;
 				args[i][1] += this.y;
 			}
+			else {
+			    poly.shift(this.x, this.y);
+			}
 			
 			poly = new Crafty.polygon(args);
 		}


### PR DESCRIPTION
In mouse.areaMap(), if arrays are passed (for example, areaMap([0,0], [0,10], [10,10], [10,0]); ), points are modified to offset from the origin of the screen and not the origin of the object. This is explained in the API : http://craftyjs.com/api/mouse-9/-areaMap--.html

But, it is not the case when you give a polygon to areaMap. I guess it is a mistake, so here is a simple patch to this bug. 

Simply adding : 
poly.shift(this.x, this.y);

When there is only a single parameter, meaning a Polygon object. 

Thanks for this brilliant framework ! :)

Adrian
