### PR TITLE
Return normal from _SAT, passed up through onhit's hitdata

### DIFF
--- a/src/collision.js
+++ b/src/collision.js
@@ -150,6 +150,8 @@ Crafty.c("Collision", {
 			max1, max2,
 			interval,
 			MTV = null,
+      MTV2 = 0,
+      MN = null,
 			dot,
 			nextPoint,
 			currentPoint;
@@ -236,8 +238,12 @@ Crafty.c("Collision", {
 				return false;
 			}
 			if(interval > MTV || MTV === null) MTV = interval;
+      if (interval < MTV2) {
+        MTV2 = interval;
+        MN = {x: normal.x, y: normal.y};
+      }
 		}
 		
-		return {overlap: MTV};
+		return {overlap: MTV, normal: MN};
 	}
 });


### PR DESCRIPTION
Changes _SAT to return the normal vector of the side of the object that was hit (i.e. the side of poly2 that's normal has the greatest intersection with poly1), which is passed up through onhit to the hitdata object pass in to the onhit callback function.
