### PR TITLE
Internet Explorer throws an error on 'pos' not being defined. I guess tha

### DIFF
--- a/src/sprite.js
+++ b/src/sprite.js
@@ -38,7 +38,7 @@ Crafty.c("Sprite", {
 		};
 		
 		this.bind("Draw", draw).bind("RemoveComponent", function(id) {
-			if(id === pos) this.unbind("Draw", draw);  
+			if(id === "Sprite") this.unbind("Draw", draw);  
 		});
 	},
 	


### PR DESCRIPTION
Internet Explorer throws an error on 'pos' not being defined. I guess that there should be "Sprite" instead "pos"
