### PR TITLE
[Retry] That bug with runaway tweens: misused 'delete'

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -235,7 +235,7 @@ function tweenEnterFrame(e) {
 		this[k] += prop.val;
 		if (prop.rem-- == 0) {
 			this.trigger("TweenEnd", k);
-			delete prop;
+			delete this._step[k];
 			this._numProps--;
 		}
 	}


### PR DESCRIPTION
Got the right file this time. Changed src/animation.js to fix those runaway tweens that I mentioned on Twitter. Changed 'delete prop;' to 'delete this._step[k];' inside a 'for prop in...' loop. Here's some info from people who understand JS a lot better than me:

http://stackoverflow.com/questions/208105/how-to-remove-a-property-from-a-javascript-object
http://perfectionkills.com/understanding-delete/
