### PR TITLE
Fix for the IE9 bug "Cannot redefine non-configurable property '...' "

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -114,22 +114,22 @@ Crafty.c("2D", {
 		//IE9 supports Object.defineProperty
 		} else if(Crafty.support.defineProperty) {
 			
-			Object.defineProperty(this, 'x', { set: function(v) { this._attr('_x',v); }, get: function() { return this._x; } });
-			Object.defineProperty(this, 'y', { set: function(v) { this._attr('_y',v); }, get: function() { return this._y; } });
-			Object.defineProperty(this, 'w', { set: function(v) { this._attr('_w',v); }, get: function() { return this._w; } });
-			Object.defineProperty(this, 'h', { set: function(v) { this._attr('_h',v); }, get: function() { return this._h; } });
-			Object.defineProperty(this, 'z', { set: function(v) { this._attr('_z',v); }, get: function() { return this._z; } });
+			Object.defineProperty(this, 'x', { set: function(v) { this._attr('_x',v); }, get: function() { return this._x; }, configurable:true });
+			Object.defineProperty(this, 'y', { set: function(v) { this._attr('_y',v); }, get: function() { return this._y; }, configurable:true });
+			Object.defineProperty(this, 'w', { set: function(v) { this._attr('_w',v); }, get: function() { return this._w; }, configurable:true });
+			Object.defineProperty(this, 'h', { set: function(v) { this._attr('_h',v); }, get: function() { return this._h; }, configurable:true });
+			Object.defineProperty(this, 'z', { set: function(v) { this._attr('_z',v); }, get: function() { return this._z; }, configurable:true });
 			
 			Object.defineProperty(this, 'rotation', { 
-				set: function(v) { this._attr('_rotation',v); }, get: function() { return this._rotation; } 
+				set: function(v) { this._attr('_rotation',v); }, get: function() { return this._rotation; }, configurable: true 
 			});
 			
 			Object.defineProperty(this, 'alpha', { 
-				set: function(v) { this._attr('_alpha',v); }, get: function() { return this._alpha; } 
+				set: function(v) { this._attr('_alpha',v); }, get: function() { return this._alpha; }, configurable: true 
 			});
 			
 			Object.defineProperty(this, 'visible', { 
-				set: function(v) { this._attr('_visible',v); }, get: function() { return this._visible; } 
+				set: function(v) { this._attr('_visible',v); }, get: function() { return this._visible; }, configurable: true 
 			});
 			
 		} else {


### PR DESCRIPTION
Fix the "can't redefine non-configurable property ..." error that appears in IE9. According to MDC documentation when you use 'get' or 'set', you need a flag 'configurable' set to true when calling Object.defineProperty.

https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineProperty
