### PR TITLE
On destroy of 2D entity, destroy all children

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -212,8 +212,15 @@ Crafty.c("2D", {
 			this._cascade(e);
 		});
 		
-		//when object is removed, remove from HashMap
+		//when object is removed, remove from HashMap and destroy attached children
 		this.bind("Remove", function() {
+  	  if (this._children) {
+        for (var i = 0; i < this._children.length; i++) {
+          this._children[i].destroy();
+        }
+        this._children = [];
+      }
+  	  
 			Crafty.map.remove(this);
 			
 			this.detach();


### PR DESCRIPTION
Louis/team, added code to automatically destroy 2D's children when parent is destroyed.  Seems like the right thing to do, fixes some odd behavior.  5 lines changed... let me know if this works for you, or if there's another method you'd like me to pursue for contributing to Crafty.

Thanks!
