### PR TITLE
Touch events

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -25,6 +25,7 @@ Crafty.extend({
 
 	mouseDispatch: function (e) {
 		if (!Crafty.mouseObjs) return;
+		if(window.TouchEvent && e instanceof TouchEvent) { this._mockMouseEvent(e); return; }
 		Crafty.lastEvent = e;
 
 		var maxz = -1,
@@ -36,10 +37,6 @@ Crafty.extend({
 			dupes = {},
 			tar = e.target ? e.target : e.srcElement,
 			type = e.type;
-
-		if (type === "touchstart") type = "mousedown";
-		else if (type === "touchmove") type = "mousemove";
-		else if (type === "touchend") type = "mouseup";
 
 		//Normalize button according to http://unixpapa.com/js/mouse.html
 		if (e.which == null) {
@@ -133,6 +130,38 @@ Crafty.extend({
 			this.lastEvent = e;
 		}
 
+	},
+
+
+	/**@
+	* #Crafty._mockMouseEvent
+	* @category Input
+	* TouchEvents have a different structure then MouseEvents.
+	* The relevant data lives in e.changedTouches[0].
+	* To normalize TouchEvents we catch em and dispatch a mock MouseEvent instead.
+	* @see Crafty.mouseDispatch
+	*/
+
+	_mockMouseEvent: function(e) {
+
+		var type;
+		if (e.type === "touchstart") type = "mousedown";
+		else if (e.type === "touchmove") type = "mousemove";
+		else if (e.type === "touchend") type = "mouseup";
+
+		var touch = e.changedTouches[0];
+
+		var mockup = document.createEvent("MouseEvents");
+		mockup.initMouseEvent(type, true, true, window, 0,
+			touch.screenX,
+			touch.screenY,
+			touch.clientX,
+			touch.clientY,
+			false, false, false, false, 0, e.target
+		);
+		mockup.target = e.target;
+
+		e.target.dispatchEvent(mockup);
 	},
 
 

--- a/src/controls.js
+++ b/src/controls.js
@@ -25,7 +25,6 @@ Crafty.extend({
 
 	mouseDispatch: function (e) {
 		if (!Crafty.mouseObjs) return;
-		if(window.TouchEvent && e instanceof TouchEvent) { this._mockMouseEvent(e); return; }
 		Crafty.lastEvent = e;
 
 		var maxz = -1,
@@ -134,7 +133,7 @@ Crafty.extend({
 
 
 	/**@
-	* #Crafty._mockMouseEvent
+	* #Crafty.touchDispatch
 	* @category Input
 	* TouchEvents have a different structure then MouseEvents.
 	* The relevant data lives in e.changedTouches[0].
@@ -142,7 +141,7 @@ Crafty.extend({
 	* @see Crafty.mouseDispatch
 	*/
 
-	_mockMouseEvent: function(e) {
+	touchDispatch: function(e) {
 
 		var type;
 		if (e.type === "touchstart") type = "mousedown";
@@ -236,9 +235,9 @@ Crafty.bind("Load", function () {
 	Crafty.addEvent(this, Crafty.stage.elem, "click", Crafty.mouseDispatch);
 	Crafty.addEvent(this, Crafty.stage.elem, "dblclick", Crafty.mouseDispatch);
 
-	Crafty.addEvent(this, Crafty.stage.elem, "touchstart", Crafty.mouseDispatch);
-	Crafty.addEvent(this, Crafty.stage.elem, "touchmove", Crafty.mouseDispatch);
-	Crafty.addEvent(this, Crafty.stage.elem, "touchend", Crafty.mouseDispatch);
+	Crafty.addEvent(this, Crafty.stage.elem, "touchstart", Crafty.touchDispatch);
+	Crafty.addEvent(this, Crafty.stage.elem, "touchmove", Crafty.touchDispatch);
+	Crafty.addEvent(this, Crafty.stage.elem, "touchend", Crafty.touchDispatch);
 });
 
 /**@

--- a/tests/touchevents.html
+++ b/tests/touchevents.html
@@ -1,0 +1,28 @@
+<html>
+<head>
+	<script type="text/javascript" src="../crafty-local.js"></script>
+	<style>
+		#cr-stage {
+			background-color: grey;
+		}
+	</style>
+</head>
+<body>
+</body>
+<script type="text/javascript">
+	Crafty.init(200, 200);
+	Crafty.c("Test", {
+		init: function() {
+			this.requires('2D, DOM, Color, Mouse, Draggable');
+		},
+	});
+	
+	Crafty.scene('main', function() {
+		Crafty.e("Test")
+			  .attr({x: 100, y: 100, w:100, h:100})
+			  .color('red');
+	});
+	
+	Crafty.scene('main');
+</script>
+</html>


### PR DESCRIPTION
Fix for broken TouchEvents (#23): Don't handle TouchEvents in mouseDispatch but in the new touchDispatch which dispatches a mocked MouseEvent for normalization. Tested with tests/touchevents.html.

P.S.: Kudos for your great work. Just working on a Breakout clone to get my hands dirty. Works like a charm.
