### PR TITLE
Fixes

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -51,7 +51,7 @@ Crafty.c("DOM", {
 		}
 
 		this.bind("Remove", this.undraw);
-		this.bind("RemoveComponent", this.undraw);
+		this.bind("RemoveComponent", function(){ if(!this.has('DOM')) this.undraw.call(this); });
 	},
 
 	/**@


### PR DESCRIPTION
When you remove ANY component form a DOM entity it gets undrawn, resulting in an error when you try to change the appearance of the entity later.
