### PR TITLE
Update src/loader.js

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -34,7 +34,7 @@ Crafty.extend({
 	* load and a percentage of the progress.
   *
   *
-  *           { loaded: j, total: total, percent: (j / total * 100) })
+  *           { loaded: j, total: total, percent: (j / total * 100) ,src:src})
 	*
 	* `onError` will be passed with the asset that couldn't load.
   *
@@ -45,6 +45,7 @@ Crafty.extend({
 	*     function() {
 	*         //when loaded
 	*         Crafty.scene("main"); //go to main scene
+	*         Crafty.audio.play("jump.mp3"); //Play the audio file
 	*     },
 	*
 	*     function(e) {
@@ -58,52 +59,91 @@ Crafty.extend({
 	* ~~~
 	* @see Crafty.assets
 	*/
-	load: function (data, oncomplete, onprogress, onerror) {
-		var i, l = data.length, current, obj, total = l, j = 0, ext;
-		for (i = 0; i < l; ++i) {
-			current = data[i];
-			ext = current.substr(current.lastIndexOf('.') + 1).toLowerCase();
-
-			if (Crafty.support.audio && (ext === "mp3" || ext === "wav" || ext === "ogg" || ext === "mp4")) {
-				obj = new Audio(current);
-				//Chrome doesn't trigger onload on audio, see http://code.google.com/p/chromium/issues/detail?id=77794
-				if (navigator.userAgent.indexOf('Chrome') != -1) j++;
-			} else if (ext === "jpg" || ext === "jpeg" || ext === "gif" || ext === "png") {
-				obj = new Image();
-				obj.src = current;
-			} else {
-				total--;
-				continue; //skip if not applicable
-			}
-
-			//add to global asset collection
-			this.assets[current] = obj;
-
-			obj.onload = function () {
-				++j;
-
-				//if progress callback, give information of assets loaded, total and percent
-				if (onprogress) {
-					onprogress.call(this, { loaded: j, total: total, percent: (j / total * 100) });
-				}
-				if (j === total) {
-					if (oncomplete) oncomplete();
-				}
-			};
-
-			//if there is an error, pass it in the callback (this will be the object that didn't load)
-			obj.onerror = function () {
-				if (onerror) {
-					onerror.call(this, { loaded: j, total: total, percent: (j / total * 100) });
-				} else {
-					j++;
-					if (j === total) {
-						if (oncomplete) oncomplete();
-					}
-				}
-			};
-		}
-	},
+    load: function (data, oncomplete, onprogress, onerror) {
+            
+        var i = 0, l = data.length, current, obj, total = l, j = 0, ext = "" ;
+  
+        //Progress function
+        function pro(){
+            var src = this.src;
+           
+            //Remove events cause audio trigger this event more than once(depends on browser)
+            if (this.removeEventListener) {  
+                this.removeEventListener('canplaythrough', pro, false);     
+            }
+           
+            ++j;
+            //if progress callback, give information of assets loaded, total and percent
+            if (onprogress) 
+                onprogress({
+                    loaded: j, 
+                    total: total, 
+                    percent: (j / total * 100),
+                    src:src
+                });
+				
+            if(j === total && oncomplete) oncomplete();
+        };
+        //Error function
+        function err(){
+            var src = this.src;
+            if (onerror) 
+                onerror({
+                    loaded: j, 
+                    total: total, 
+                    percent: (j / total * 100),
+                    src:src
+                });
+           		
+            j++;
+            if(j === total && oncomplete) oncomplete();
+        };
+           
+        for (; i < l; ++i) {       
+            current = data[i];
+            ext = current.substr(current.lastIndexOf('.') + 1).toLowerCase();
+           
+            obj = this.assets[current] || null;   
+          
+            if (Crafty.support.audio && Crafty.audio.supported[ext]) {   
+                //Create new object if not exists
+                if(!obj){
+                    var name = current.substr(current.lastIndexOf('/') + 1).toLowerCase();
+                    obj = Crafty.audio.audioElement();
+                    obj.id = name;
+                    obj.src = current;
+                    obj.preload = "auto";
+                    obj.volume = Crafty.audio.volume;
+                    if (!Crafty.assets[current]) Crafty.assets[current] = obj; 
+                    Crafty.audio.sounds[name] = {
+                        obj:obj,
+                        played:0
+                    } 
+                }
+        
+                //addEventListener is supported on IE9 , Audio as well
+                if (obj.addEventListener) {  
+                    obj.addEventListener('canplaythrough', pro, false);     
+                }
+                   
+                 
+            } else if (ext === "jpg" || ext === "jpeg" || ext === "gif" || ext === "png") { 
+                if(!obj) {
+                    obj = new Image();
+                    if (!Crafty.assets[current]) Crafty.assets[current] = obj;   
+                }
+                obj.onload=pro;
+                obj.src = current; //setup src after onload function Opera/IE Bug
+             
+            } else {
+                total--;
+                continue; //skip if not applicable
+            }
+            obj.onerror = err;
+        }
+       
+       
+    },
 	/**@
 	* #Crafty.modules
 	* @category Assets


### PR DESCRIPTION
Fixed loader. Loader creates new Image objects only if there are not exists, also for audio. 
Src paramerter was added to onprogress and onerror. so you know which file is loaded or had errors.

known bug: Opera trigger canplaythrough just on first start, after refresh canplaythrough will not be triggered everytime
