### PR TITLE
Updated src/2D.js src/controls.js

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -478,7 +478,9 @@ Crafty.c("2D", {
 	* an object can't be passed. The arguments require the x and y value
 	*/
 	isAt: function (x, y) {
-		if (this.map) {
+		if (this.mapArea) {
+      		return this.mapArea.containsPoint(x, y);
+		} else if (this.map) {
 			return this.map.containsPoint(x, y);
 		}
 		return this.x <= x && this.x + this.w >= x &&

--- a/src/controls.js
+++ b/src/controls.js
@@ -275,9 +275,10 @@ Crafty.c("Mouse", {
 		}
 
 		poly.shift(this._x, this._y);
-		this.map = poly;
+		//this.map = poly;
+		this.mapArea = poly;
 
-		this.attach(this.map);
+		this.attach(this.mapArea);
 		return this;
 	}
 });


### PR DESCRIPTION
areaMap polygon overrides .collision(polygon)

issue #243

https://github.com/craftyjs/Crafty/issues/243

Added mapArea as the new variable for isAt and areaMap to read and set values, respectively, making it possible to handle mouse events separate from collisions, defaults to collision .map if .mapArea not present.

Patch does not work for canvas, it defaults to the collision polygon, as I don't understand how it gets the polygon  data. (specifically it seems like the search function is the one that gets the polygon data)
