### PR TITLE
Mobile ipad support

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -883,6 +883,11 @@ Crafty.extend({
                 elem.left = "0px";
                 elem.top = "0px";
 
+                // remove default gray highlighting after touch
+                if (typeof elem.webkitTapHighlightColor != undefined) {
+                    elem.webkitTapHighlightColor = "rgba(0,0,0,0)";
+                }
+
                 var meta = document.createElement("meta"),
                     head = document.getElementsByTagName("HEAD")[0];
 


### PR DESCRIPTION
Remove default gray highlighting after touch on mobile (ipad).
