### PR TITLE
Separated CSS background assignment into indivudual properties

### DIFF
--- a/src/drawing.js
+++ b/src/drawing.js
@@ -119,7 +119,8 @@ Crafty.c("Image", {
 				context.restore();
 			} else if (e.type === "DOM") {
 				if (this.__image)
-					e.style.background = "url(" + this.__image + ") " + this._repeat;
+					e.style.backgroundImage = "url(" + this.__image + ") "; 
+          e.style.backgroundRepeat = this._repeat;
 			}
 		};
 

--- a/src/sprite.js
+++ b/src/sprite.js
@@ -47,7 +47,9 @@ Crafty.c("Sprite", {
 								 pos._h //height on canvas
 				);
 			} else if (e.type === "DOM") {
-				this._element.style.background = "url('" + this.__image + "') no-repeat -" + co.x + "px -" + co.y + "px";
+				this._element.style.backgroundImage = "url('" + this.__image + "')"; 
+        this._element.style.backgroundRepeat = "no-repeat"; 
+        this._element.style.backgroundPosition = "-" + co.x + "px -" + co.y + "px";
 			}
 		};
 


### PR DESCRIPTION
The reason for doing this is .css( { 'background-size': 'whatever' } ) will not work as background assignment clobbers all other CSS properties
