### PR TITLE
Fixed typos in docs/comments

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -1,7 +1,7 @@
 /**@
 * #Crafty.map
 * @category 2D
-* Functions related with quering entities. 
+* Functions related with querying entities. 
 * @see Crafty.HashMap
 */
 Crafty.map = new Crafty.HashMap();
@@ -217,7 +217,7 @@ Crafty.c("2D", {
 					//update the MBR
 					var mbr = this._mbr, moved = false;
 					// If the browser doesn't have getters or setters,
-					// {x, y, w, h, z} and {_x, _y, _w, _h, _z} may be out of synce,
+					// {x, y, w, h, z} and {_x, _y, _w, _h, _z} may be out of sync,
 					// in which case t checks if they are different on tick and executes the Change event.
 					if (mbr) { //check each value to see which has changed
 						if (this.x !== this._x) { mbr._x -= this.x - this._x; moved = true; }
@@ -722,7 +722,7 @@ Crafty.c("2D", {
 		if (name === '_rotation') {
 			this._rotate(value);
 			this.trigger("Rotate");
-			//set the global Z and trigger reorder just incase
+			//set the global Z and trigger reorder just in case
 		} else if (name === '_z') {
 			this._globalZ = parseInt(value + Crafty.zeroFill(this[0], 5), 10); //magic number 10e5 is the max num of entities
 			this.trigger("reorder");
@@ -998,7 +998,7 @@ Crafty.circle = function (x, y, radius) {
 	this.y = y;
 	this.radius = radius;
 
-	// Creates an octogon that aproximate the circle for backward compatibility.
+	// Creates an octagon that approximate the circle for backward compatibility.
 	this.points = [];
 	var theta;
 

--- a/src/HashMap.js
+++ b/src/HashMap.js
@@ -31,7 +31,7 @@
     * @sign public Object Crafty.map.insert(Object obj)
 	* @param obj - An entity to be inserted.
 	* 
-    * `obj` is instered in '.map' of the corresponding broad phase cells. An object of the following fields is returned.
+    * `obj` is inserted in '.map' of the corresponding broad phase cells. An object of the following fields is returned.
     * ~~~
     * - the object that keep track of cells (keys)
     * - `obj`
@@ -67,7 +67,7 @@
 	* 
     * - If `filter` is `false`, just search for all the entries in the give `rect` region by broad phase collision. Entity may be returned duplicated.
     * - If `filter` is `true`, filter the above results by checking that they actually overlap `rect`.
-    * The easier usage is with `filter`=`true`. For performance reason, you may use `filter`=`false`, and filter the result youself. See examples in drawing.js and collision.js
+    * The easier usage is with `filter`=`true`. For performance reason, you may use `filter`=`false`, and filter the result yourself. See examples in drawing.js and collision.js
 	*/
 		search: function (rect, filter) {
 			var keys = HashMap.key(rect),

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -4,7 +4,7 @@
 * @trigger Draw - when the entity is ready to be drawn to the stage - {type: "canvas", pos, co, ctx}
 * @trigger NoCanvas - if the browser does not support canvas
 * 
-* Draws itself onto a canvas. Crafty.canvas.init() will be automatically called it is not called already (hence the canvas element dosen't exist).
+* Draws itself onto a canvas. Crafty.canvas.init() will be automatically called it is not called already (hence the canvas element doesn't exist).
 */
 Crafty.c("Canvas", {
 
@@ -38,7 +38,7 @@ Crafty.c("Canvas", {
 	* @param ctx - Canvas 2D context if drawing on another canvas is required
 	* @param x - X offset for drawing a segment
 	* @param y - Y offset for drawing a segment
-	* @param w - Width of the segement to draw
+	* @param w - Width of the segment to draw
 	* @param h - Height of the segment to draw
 	* 
 	* Method to draw the entity on the canvas element. Can pass rect values for redrawing a segment of the entity.

--- a/src/controls.js
+++ b/src/controls.js
@@ -185,7 +185,7 @@ Crafty.extend({
 
         first.target.dispatchEvent(simulatedEvent);
 
-        // trigger click when it shoud be triggered
+        // trigger click when it should be triggered
         if (lastEvent != null && lastEvent.type == 'mousedown' && type == 'mouseup') {
             type = 'click';
 
@@ -207,7 +207,7 @@ Crafty.extend({
 	/**@
 	* #KeyboardEvent
 	* @category Input
-    * Keyboard Event triggerd by Crafty Core
+    * Keyboard Event triggered by Crafty Core
 	* @trigger KeyDown - is triggered for each entity when the DOM 'keydown' event is triggered.
 	* @trigger KeyUp - is triggered for each entity when the DOM 'keyup' event is triggered.
 	* 
@@ -236,7 +236,7 @@ Crafty.extend({
 	* #Crafty.eventObject
 	* @category Input
 	* 
-	* Event Object used in Crafty for cross browser compatiblity
+	* Event Object used in Crafty for cross browser compatibility
 	*/
 
 	/**@
@@ -459,7 +459,7 @@ Crafty.c("Draggable", {
 	* #.dragDirection
 	* @comp Draggable
 	* @sign public this .dragDirection()
-    * Remove any previously specifed direction.
+    * Remove any previously specified direction.
     *
 	* @sign public this .dragDirection(vector)
     * @param vector - Of the form of {x: valx, y: valy}, the vector (valx, valy) denotes the move direction.
@@ -471,7 +471,7 @@ Crafty.c("Draggable", {
 	* @example
 	* ~~~
 	* this.dragDirection()
-	* this.dragDirection({x:1, y:0}) //Horizonatal
+	* this.dragDirection({x:1, y:0}) //Horizontal
 	* this.dragDirection({x:0, y:1}) //Vertical
     * // Note: because of the orientation of x and y axis,
     * // this is 45 degree clockwise with respect to the x axis.
@@ -599,7 +599,7 @@ Crafty.c("Keyboard", {
 /**@
 * #Multiway
 * @category Input
-* Used to bind keys to directions and have the entity move acordingly
+* Used to bind keys to directions and have the entity move accordingly
 * @trigger NewDirection - triggered when direction changes - { x:Number, y:Number } - New direction
 * @trigger Moved - triggered on movement on either x or y axis. If the entity has moved on both axes for diagonal movement the event is triggered twice - { x:Number, y:Number } - Old position
 */
@@ -814,7 +814,7 @@ Crafty.c("Twoway", {
 	* ~~~
 	* 
 	* The key presses will move the entity in that direction by the speed passed in
-	* the argument. Pressing the `Up Arrow` or `W` will cause the entiy to jump.
+	* the argument. Pressing the `Up Arrow` or `W` will cause the entity to jump.
 	* 
 	* @see Gravity, Fourway
 	*/

--- a/src/core.js
+++ b/src/core.js
@@ -13,7 +13,7 @@
     *    Crafty("Hello, 2D, Component")
     * ~~~
     * 
-    * The first selector will return all entities that has the component `MyComponent`. The second will return all entities that has `Hello` and `2D` and `Component` whereas the last will return all entities that has at least one of those components (or).
+    * The first selector will return all entities that have the component `MyComponent`. The second will return all entities that have `Hello` and `2D` and `Component` whereas the last will return all entities that have at least one of those components (or).
     * ~~~
     *   Crafty(1)
     * ~~~
@@ -184,7 +184,7 @@
         * #.addComponent
         * @comp Crafty Core
         * @sign public this .addComponent(String componentList)
-        * @param componentList - A string of components to add seperated by a comma `,`
+        * @param componentList - A string of components to add separated by a comma `,`
         * @sign public this .addComponent(String Component1[, .., String ComponentN])
         * @param Component# - Component ID to add.
         * Adds a component to the selected entities or entity.
@@ -505,7 +505,7 @@
         * @param callback - Function to unbind
         * Removes binding with an event from current entity.
         *
-        * Passing an event name will remove all events binded to
+        * Passing an event name will remove all events bound to
         * that event. Passing a reference to the callback will
         * unbind only that callback.
         * @see .bind, .trigger
@@ -739,7 +739,7 @@
         * #.getVersion
         * @comp Crafty Core
         * @sign public this .getVersion()
-        * @returns Actualy crafty version
+        * @returns Actually crafty version
         *
         * @example
         * ~~~
@@ -784,7 +784,7 @@
         * @trigger Unpause - when the game is unpaused
         * @sign public this Crafty.pause(void)
         * 
-        * Pauses the game by stoping the EnterFrame event from firing. If the game is already paused it is unpaused.
+        * Pauses the game by stopping the EnterFrame event from firing. If the game is already paused it is unpaused.
         * You can pass a boolean parameter if you want to pause or unpause mo matter what the current state is.
         * Modern browsers pauses the game when the page is not visible to the user. If you want the Pause event
         * to be triggered when that happens you can enable autoPause in `Crafty.settings`.
@@ -976,8 +976,8 @@
         * - Properties or methods that start with an underscore are considered private.
         * - A method called `init` will automatically be called as soon as the
         * component is added to an entity.
-        * - A methid called `uninit` will be called when the component is removed from an entity. 
-        * A sample use case for this is the native DOM component that removes its div element wehen removed from an entity.
+        * - A method called `uninit` will be called when the component is removed from an entity. 
+        * A sample use case for this is the native DOM component that removes its div element when removed from an entity.
         * - A method with the same name as the component is considered to be a constructor
         * and is generally used when you need to pass configuration data to the component on a per entity basis.
         *

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -74,7 +74,7 @@ Crafty.c("Tint", {
 	* @comp Tint
 	* @trigger Change - when the tint is applied
 	* @sign public this .tint(String color, Number strength)
-	* @param color - The color in hexidecimal
+	* @param color - The color in hexadecimal
 	* @param strength - Level of opacity
 	* 
 	* Modify the color and level opacity to give a tint on the entity.

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -21,7 +21,7 @@
     * 
     * If Crafty.mobile is equal true Crafty does some things under hood:
     * ~~~
-    * - set viewport on max device width and heigh
+    * - set viewport on max device width and height
     * - set Crafty.stage.fullscreen on true
     * - hide window scrollbars
     * ~~~
@@ -148,8 +148,8 @@ Crafty.extend({
     * @param tile - Tile size of the sprite map, defaults to 1
     * @param url - URL of the sprite image
     * @param map - Object where the key is what becomes a new component and the value points to a position on the sprite map
-    * @param paddingX - Horizontal space inbetween tiles. Defaults to 0.
-    * @param paddingY - Vertical space inbetween tiles. Defaults to paddingX.
+    * @param paddingX - Horizontal space in between tiles. Defaults to 0.
+    * @param paddingY - Vertical space in between tiles. Defaults to paddingX.
     * Generates components based on positions in a sprite image to be applied to entities.
     *
     * Accepts a tile size, URL and map for the name of the sprite and it's position.
@@ -319,7 +319,7 @@ Crafty.extend({
             obj = window.document;
         }
 
-        //retrieve anonymouse function
+        //retrieve anonymous function
         var id = ctx[0] || "",
             afn = this._events[id + obj + type + callback];
 
@@ -487,7 +487,7 @@ Crafty.extend({
          * @sign public void Crafty.viewport.follow(Object target, Number offsetx, Number offsety)
          * @param Object target - An entity with the 2D component
          * @param Number offsetx - Follow target should be offsetx pixels away from center
-         * @param Number offsety - Positive puts targ to the right of center
+         * @param Number offsety - Positive puts target to the right of center
          *
          * Follows a given entity with the 2D component. If following target will take a portion of
          * the viewport out of bounds of the world, following will stop until the target moves away.

--- a/src/isometric.js
+++ b/src/isometric.js
@@ -22,7 +22,7 @@ Crafty.extend({
         * @param tileSize - The size of the tiles to place.
         * 
         * Method used to initialize the size of the isometric placement.
-        * Recommended to use a size alues in the power of `2` (128, 64 or 32).
+        * Recommended to use a size values in the power of `2` (128, 64 or 32).
         * This makes it easy to calculate positions and implement zooming.
         * 
         * @example
@@ -34,13 +34,13 @@ Crafty.extend({
         */
         size: function (width, height) {
             this._tile.width = width;
-            this._tile.height = height > 0 ? height : width/2; //Setup width/2 if height doesnt set
+            this._tile.height = height > 0 ? height : width/2; //Setup width/2 if height isn't set
             return this;
         },
         /**@
         * #Crafty.isometric.place
         * @comp Crafty.isometric
-        * @sign public this Crafty.isometric.size(Number x, Number y, Number z, Entity tile)
+        * @sign public this Crafty.isometric.place(Number x, Number y, Number z, Entity tile)
         * @param x - The `x` position to place the tile
         * @param y - The `y` position to place the tile
         * @param z - The `z` position or height to place the tile
@@ -51,7 +51,7 @@ Crafty.extend({
         * @example
         * ~~~
         * var iso = Crafty.isometric.size(128);
-        * isos.place(2, 1, 0, Crafty.e('2D, DOM, Color').color('red').attr({w:128, h:128}));
+        * iso.place(2, 1, 0, Crafty.e('2D, DOM, Color').color('red').attr({w:128, h:128}));
         * ~~~
         * 
         * @see Crafty.isometric.size
@@ -73,7 +73,7 @@ Crafty.extend({
          * @param y
          * @return Object {left Number,top Number}
          * 
-         * This method calculate the X and Y Coordiantes to Pixel Positions
+         * This method calculate the X and Y Coordinates to Pixel Positions
          * 
          * @example
          * ~~~
@@ -95,7 +95,7 @@ Crafty.extend({
          * @param left
          * @return Object {x Number,y Number}
          * 
-         * This method calculate pixel top,left positions to x,y coordiantes
+         * This method calculate pixel top,left positions to x,y coordinates
          * 
          * @example
          * ~~~
@@ -145,7 +145,7 @@ Crafty.extend({
          * @sign public this Crafty.isometric.area()
          * @return Object {x:{start Number,end Number},y:{start Number,end Number}}
          * 
-         * This method get the Area surounding by the centerpoint depends on viewport height and width
+         * This method get the Area surrounding by the centerpoint depends on viewport height and width
          * 
          * @example
          * ~~~

--- a/src/loader.js
+++ b/src/loader.js
@@ -73,7 +73,7 @@ Crafty.extend({
 	*
 	* `onError` will be passed with the asset that couldn't load.
     *
-	* When `onError` is not provided, the onLoad is loaded even some assests are not successfully loaded. Otherwise, onLoad will be called no matter whether there are errors or not. 
+	* When `onError` is not provided, the onLoad is loaded even some assets are not successfully loaded. Otherwise, onLoad will be called no matter whether there are errors or not. 
 	* 
 	* @example
 	* ~~~

--- a/src/particles.js
+++ b/src/particles.js
@@ -157,7 +157,7 @@ Crafty.c("Particles", {
 			this.position = this.vectorHelpers.create(0, 0);
 			if (typeof options == 'undefined') var options = {};
 
-			//Create current config by mergin given options and presets.
+			//Create current config by merging given options and presets.
 			for (key in this.presets) {
 				if (typeof options[key] != 'undefined') this[key] = options[key];
 				else this[key] = this.presets[key];

--- a/src/sound.js
+++ b/src/sound.js
@@ -47,7 +47,7 @@ Crafty.extend({
         * #Crafty.audio.add
         * @comp Crafty.audio
         * @sign public this Crafty.audio.add(String id, String url)
-        * @param id - A string to reffer to sounds
+        * @param id - A string to refer to sounds
         * @param url - A string pointing to the sound file
         * @sign public this Crafty.audio.add(String id, Array urls)
         * @param urls - Array of urls pointing to different format of the same sound, selecting the first that is playable
@@ -169,7 +169,7 @@ Crafty.extend({
         * @sign public this Crafty.audio.play(String id)
         * @sign public this Crafty.audio.play(String id, Number repeatCount)
         * @sign public this Crafty.audio.play(String id, Number repeatCount,Number volume)
-        * @param id - A string to reffer to sounds
+        * @param id - A string to refer to sounds
         * @param repeatCount - Repeat count for the file, where -1 stands for repeat forever.
         * @param volume - volume can be a number between 0.0 and 1.0
         * 
@@ -207,7 +207,7 @@ Crafty.extend({
         * #Crafty.audio.stop
         * @sign public this Crafty.audio.stop([Number ID])
         * 
-        * Stops any playnig sound. if id is not set, stop all sounds which are playing
+        * Stops any playing sound. if id is not set, stop all sounds which are playing
         * 
         * @example
         * ~~~

--- a/src/storage.js
+++ b/src/storage.js
@@ -122,7 +122,7 @@
 	 * 
 	 * Handlers for processing any data that needs more than straight assignment
 	 *
-	 * Note that data stord in the .attr object is automatically added to the entity.
+	 * Note that data stored in the .attr object is automatically added to the entity.
 	 * It does not need to be handled here
 	 *
 	 * @example

--- a/src/text.js
+++ b/src/text.js
@@ -88,7 +88,7 @@ Crafty.c("Text", {
     * #.textColor
     * @comp Text
     * @sign public this .textColor(String color, Number strength)
-    * @param color - The color in hexidecimal
+    * @param color - The color in hexadecimal
     * @param strength - Level of opacity
     *
     * Modify the text color and level of opacity.


### PR DESCRIPTION
While learning to use Crafty I came across a few typos in the docs and decided to fork and fix them. This pull request is for those fixes. It only affects comments.
