### PR TITLE
Fix rAF with FF and event errors with IE

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -200,7 +200,8 @@ Crafty.extend({
             first.target.dispatchEvent(simulatedEvent);
         }
 
-        e.preventDefault();
+        if(e.preventDefault) e.preventDefault();
+        else e.returnValue = false;
     },
 
 
@@ -261,7 +262,9 @@ Crafty.extend({
 		//Among others this prevent the arrow keys from scrolling the parent page
 		//of an iframe hosting the game
 		if(Crafty.selected && !(e.key == 8 || e.key >= 112 && e.key <= 135)) {
-			e.stopPropagation();
+			if(e.stopPropagation) e.stopPropagation();
+            else e.cancelBubble = true;
+
 			if(e.preventDefault) e.preventDefault();
 			else e.returnValue = false;
 			return false;

--- a/src/core.js
+++ b/src/core.js
@@ -802,13 +802,13 @@
                 this.trigger('Pause');
                 this._paused = true;
 
-                Crafty.timer.stop();
+                setTimeout(function(){ Crafty.timer.stop(); }, 0);
                 Crafty.keydown = {};
             } else {
                 this.trigger('Unpause');
                 this._paused = false;
 
-                Crafty.timer.init();
+                setTimeout(function(){ Crafty.timer.init(); }, 0);
             }
             return this;
         },


### PR DESCRIPTION
...and stopPropagation with MSIE.

I re based and cleaned up my edits. Now the entire commit does not rewrite the entire file.

While pausing a game from inside an EnterFrame event, Firefox returns the following error:

NS_ERROR_XPC_BAD_CONVERT_JS: Component returned failure code: 0x80570009 (NS_ERROR_XPC_BAD_CONVERT_JS) [nsIDOMWindow.mozRequestAnimationFrame]

The following psuedo code gives this error.
Crafty.bind("EnterFrame", function()
{
if(GameOver == true)
{
Crafty.pause();
}
});

This is fixed by adding a 0ms setTimeout to the timer.stop() and timer.init() functions, which essentially means the pause/stop will not be run until after the JS Compiler has finished running the last EnterFrame function call.

When using the Keyboard dispatch I get the following errors in IE7 and 8:

Object doesn't support property or method 'preventDefault' in IE8.
Object doesn't support property or method 'stopPropogation'

I created a simple solution in this pull request.
