### PR TITLE
Fix for SpriteAnimation.isPlaying()

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -242,7 +242,7 @@ Crafty.c("SpriteAnimation", {
 	* ~~~
 	*/
 	isPlaying: function (reelId) {
-		if (!reelId) return !!this._interval;
+		if (!reelId) return !!this._currentReelId;
 		return this._currentReelId === reelId;
 	}
 });


### PR DESCRIPTION
The SpriteAnimation component's .isPlaying() function would return false no matter what animation was or wasn't playing. The function was referencing a variable called !!this._interval which was never defined or set anywhere else. Changing it to !!this._currentReelId yielded intended results.
