### PR TITLE
Fix for text excepting number 0 and empty string

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -75,7 +75,7 @@ Crafty.c("Text", {
     * ~~~
     */
 	text: function (text) {
-		if (!text) return this._text;
+		if (!(typeof text !== "undefined" && text !== null)) return this._text;
 		if (typeof(text) == "function")
 			this._text = text.call(this);
 		else


### PR DESCRIPTION
Changed text method to test if parameter is undefined or null instead of testing falsy

Fix to this [issue](https://github.com/craftyjs/Crafty/issues/351)
