### PR TITLE
For autoPause = true, check that game is actually paused on window blur before pausing.

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -836,7 +836,7 @@ Crafty.extend({
 
             Crafty.addEvent(this, window, "blur", function () {
                 if (Crafty.settings.get("autoPause")) {
-                    Crafty.pause();
+                    if(!Crafty._paused) Crafty.pause();
                 }
             });
             Crafty.addEvent(this, window, "focus", function () {


### PR DESCRIPTION
Ensures that if the game is already in a paused state, it isn't unpaused on blur instead.
