### PR TITLE
Add support for Samsung SmartTV remote control (pult)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/api/*
 .*.sw?
 .DS_store
 .project
+.idea

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -1080,7 +1080,11 @@ Crafty.extend({
     * PLUS: 187,
     * COMMA: 188,
     * MINUS: 189,
-    * PERIOD: 190
+    * PERIOD: 190,
+    * PULT_UP: 29460,
+    * PULT_DOWN: 29461,
+    * PULT_LEFT: 4,
+    * PULT_RIGHT': 5
     * ~~~
     */
     keys: {
@@ -1170,7 +1174,12 @@ Crafty.extend({
         'PLUS': 187,
         'COMMA': 188,
         'MINUS': 189,
-        'PERIOD': 190
+        'PERIOD': 190,
+        'PULT_UP': 29460,
+        'PULT_DOWN': 29461,
+        'PULT_LEFT': 4,
+        'PULT_RIGHT': 5
+
     },
 
     /**@


### PR DESCRIPTION
Add support for Samsung SmartTV remote control (pult)
and add ignore for JetBrains ice files (WebStorm)

Samsung SmartTv (samsungdforum.com) allow use JavaScript as language for create application 
