### PR TITLE
Update src/loader.js

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -138,7 +138,7 @@ Crafty.extend({
            
         for (; i < l; ++i) {       
             current = data[i];
-            ext = current.substr(current.lastIndexOf('.') + 1).toLowerCase();
+            ext = current.substr(current.lastIndexOf('.') + 1, 3).toLowerCase();
            
             obj = Crafty.asset(current) || null;   
           


### PR DESCRIPTION
The extension should be limited to 3 characters in order to allow GET vars to be added to the src paths.  This is useful for cache-busting for browsers that don't fire the onload event when assets are pulled from browser cache.
