### PR TITLE
Use round instead of ceil/floor to correct inconsistencies

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -1,7 +1,7 @@
 /**@
 * #Crafty.map
 * @category 2D
-* Functions related with querying entities. 
+* Functions related with querying entities.
 * @see Crafty.HashMap
 */
 Crafty.map = new Crafty.HashMap();
@@ -329,10 +329,10 @@ Crafty.c("2D", {
 			y2 = o.y - (this._x + this._w - o.x) * st + (this._y + this._h - o.y) * ct,
 			x3 = o.x + (this._x - o.x) * ct + (this._y + this._h - o.y) * st,
 			y3 = o.y - (this._x - o.x) * st + (this._y + this._h - o.y) * ct,
-			minx = Math.floor(Math.min(x0, x1, x2, x3)),
-			miny = Math.floor(Math.min(y0, y1, y2, y3)),
-			maxx = Math.ceil(Math.max(x0, x1, x2, x3)),
-			maxy = Math.ceil(Math.max(y0, y1, y2, y3));
+			minx = Math.round(Math.min(x0, x1, x2, x3)),
+			miny = Math.round(Math.min(y0, y1, y2, y3)),
+			maxx = Math.round(Math.max(x0, x1, x2, x3)),
+			maxy = Math.round(Math.max(y0, y1, y2, y3));
 
 		this._mbr = { _x: minx, _y: miny, _w: maxx - minx, _h: maxy - miny };
 
@@ -617,7 +617,7 @@ Crafty.c("2D", {
 	* @sign public this .origin(String offset)
 	* @param offset - Combination of center, top, bottom, middle, left and right
 	* Set the origin point of an entity for it to rotate around.
-	* 
+	*
 	* @example
 	* ~~~
 	* this.origin("top left")
@@ -625,7 +625,7 @@ Crafty.c("2D", {
 	* this.origin("bottom right")
 	* this.origin("middle right")
 	* ~~~
-	* 
+	*
 	* @see .rotation
 	*/
 	origin: function (x, y) {
@@ -658,9 +658,9 @@ Crafty.c("2D", {
 	* @trigger Change - when the entity has flipped
 	* @sign public this .flip(String dir)
 	* @param dir - Flip direction
-	* 
+	*
 	* Flip entity on passed direction
-	* 
+	*
 	* @example
 	* ~~~
 	* this.flip("X")
@@ -673,16 +673,16 @@ Crafty.c("2D", {
                     this.trigger("Change");
                 }
 	},
-        
+
         /**@
 	* #.unflip
 	* @comp 2D
 	* @trigger Change - when the entity has unflipped
 	* @sign public this .unflip(String dir)
 	* @param dir - Unflip direction
-	* 
+	*
 	* Unflip entity on passed direction (if it's flipped)
-	* 
+	*
 	* @example
 	* ~~~
 	* this.unflip("X")
@@ -775,12 +775,12 @@ Crafty.c("Gravity", {
 	* @comp Gravity
 	* @sign public this .gravity([comp])
 	* @param comp - The name of a component that will stop this entity from falling
-	* 
-	* Enable gravity for this entity no matter whether comp parameter is not specified, 
+	*
+	* Enable gravity for this entity no matter whether comp parameter is not specified,
 	* If comp parameter is specified all entities with that component will stop this entity from falling.
 	* For a player entity in a platform game this would be a component that is added to all entities
 	* that the player should be able to walk on.
-	* 
+	*
 	* @example
 	* ~~~
 	* Crafty.e("2D, DOM, Color, Gravity")
@@ -802,9 +802,9 @@ Crafty.c("Gravity", {
 	* @comp Gravity
 	* @sign public this .gravityConst(g)
 	* @param g - gravitational constant
-	* 
+	*
 	* Set the gravitational constant to g. The default is .2. The greater g, the faster the object falls.
-	* 
+	*
 	* @example
 	* ~~~
 	* Crafty.e("2D, DOM, Color, Gravity")
@@ -882,7 +882,7 @@ Crafty.c("Gravity", {
 /**@
 * #Crafty.polygon
 * @category 2D
-* 
+*
 * Polygon object used for hitboxes and click maps. Must pass an Array for each point as an
 * argument where index 0 is the x position and index 1 is the y position.
 *
@@ -914,9 +914,9 @@ Crafty.polygon.prototype = {
 	* @sign public Boolean .containsPoint(Number x, Number y)
 	* @param x - X position of the point
 	* @param y - Y position of the point
-	* 
+	*
 	* Method is used to determine if a given point is contained by the polygon.
-	* 
+	*
 	* @example
 	* ~~~
 	* var poly = new Crafty.polygon([50,0],[100,100],[0,100]);
@@ -942,9 +942,9 @@ Crafty.polygon.prototype = {
 	* @sign public void .shift(Number x, Number y)
 	* @param x - Amount to shift the `x` axis
 	* @param y - Amount to shift the `y` axis
-	* 
+	*
 	* Shifts every single point in the polygon by the specified amount.
-	* 
+	*
 	* @example
 	* ~~~
 	* var poly = new Crafty.polygon([50,0],[100,100],[0,100]);
@@ -1016,9 +1016,9 @@ Crafty.circle.prototype = {
 	* @sign public Boolean .containsPoint(Number x, Number y)
 	* @param x - X position of the point
 	* @param y - Y position of the point
-	* 
+	*
 	* Method is used to determine if a given point is contained by the circle.
-	* 
+	*
 	* @example
 	* ~~~
 	* var circle = new Crafty.circle(0, 0, 10);
@@ -1041,9 +1041,9 @@ Crafty.circle.prototype = {
 	* @sign public void .shift(Number x, Number y)
 	* @param x - Amount to shift the `x` axis
 	* @param y - Amount to shift the `y` axis
-	* 
+	*
 	* Shifts the circle by the specified amount.
-	* 
+	*
 	* @example
 	* ~~~
 	* var poly = new Crafty.circle(0, 0, 10);


### PR DESCRIPTION
Math.cos(90), effectively Math.cos(Math.PI/2), returns
6.123031769111886e-17 when 0 is the expected result. This value is close
to zero and it is safer to use the Math#round method which will round it
to the nearest whole number rather than Math#ceil/Math.floor which are
affected by the negative numbers.

Math.floor(-6.123031769111886e-17) will resut in -1

while

Math.round(-6.123031769111886e-17) will resut in 0 (expected)
