### PR TITLE
Workaround webkit bug for image onload event when image is already loaded

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -201,6 +201,7 @@ Crafty.extend({
                     Crafty.asset(current, obj);   
                 }
                 obj.onload=pro;
+				obj.src = ""; // workaround for webkit bug
                 obj.src = current; //setup src after onload function Opera/IE Bug
              
             } else {


### PR DESCRIPTION
There's a bug in webkit that means the on load event is never fired (http://code.google.com/p/chromium/issues/detail?id=7731)

This implements the workaround suggested in comment 5 of that bug -- set the image src to "" and back again.
