### PR TITLE
Fix some documentation omissions

### DIFF
--- a/src/collision.js
+++ b/src/collision.js
@@ -152,10 +152,10 @@ Crafty.c("Collision", {
 	* @comp Collision
 	* @sign public this .onHit(String component, Function hit[, Function noHit])
 	* @param component - Component to check collisions for
-	* @param hit - Callback method to execute when collided with component
+	* @param hit - Callback method to execute upon collision with component.  Will be passed the results of the collision check in the same format documented for hit().
 	* @param noHit - Callback method executed once as soon as collision stops
 	* 
-	* Creates an enterframe event calling .hit() each time and if collision detected will invoke the callback.
+	* Creates an EnterFrame event calling .hit() each frame.  When a collision is detected the callback will be invoked.  
 	* 
 	* @see .hit
 	*/

--- a/src/core.js
+++ b/src/core.js
@@ -489,6 +489,8 @@
         *
         * Events are arbitrary and provide communication between components.
         * You can trigger or bind an event even if it doesn't exist yet.
+        *
+        * Unlike DOM events, Crafty events are exectued synchronously.
         * 
         * @example
         * ~~~
@@ -576,6 +578,8 @@
         *
         * The first argument is the event name to trigger and the optional
         * second argument is the arbitrary event data. This can be absolutely anything.
+        *
+        * Unlike DOM events, Crafty events are exectued synchronously.
         */
         trigger: function (event, data) {
             if (this.length === 1) {


### PR DESCRIPTION
Just a couple of changes to documentation:
- The callback for .onHit()
- The synchronous nature of Crafty events

The first came up in the forum, and the second is something that confused me when I was learning crafty.  (I'd at first assumed it worked like a DOM event.)
