### PR TITLE
bug fix: disableDrag shouldn't necessarily trigger StopDrag

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -581,7 +581,9 @@ Crafty.c("Draggable", {
 	*/
 	disableDrag: function () {
 		this.unbind("MouseDown", this._ondown);
-		this.stopDrag();
+		if (this._dragging) {
+			this.stopDrag();
+		}
 		return this;
 	}
 });


### PR DESCRIPTION
It is possible and often useful to call disableDrag() while the entity is not being dragged. In that case, there's no reason to call stopDrag(). Actually, there is a good reason NOT to call stopDrag(): It will set off the "StopDrag" trigger which is obviously inappropriate.
