### PR TITLE
fix Delay component

### DIFF
--- a/src/time.js
+++ b/src/time.js
@@ -7,13 +7,24 @@ Crafty.c("Delay", {
 		this._delays = [];
 		this.bind("EnterFrame", function() {
 			var now = new Date().getTime();
+      var prune = false;
 			for(var index in this._delays) {
 				var item = this._delays[index];
-				if(!item.triggered && item.start + item.delay + item.pause < now) {
+				if(item.start + item.delay + item.pause < now) {
 					item.triggered=true;
+          prune = true;
 					item.func.call(this);
 				}
 			}
+      if (prune) {
+        var new_delays = [];
+        for(var index in this._delays) {
+          var item = this._delays[index];
+          if (!item.triggered)
+            new_delays.push(item);
+        }
+        this._delays = new_delays;
+      }
 		});
 		this.bind("Pause", function() {
 			var now = new Date().getTime();

--- a/src/time.js
+++ b/src/time.js
@@ -53,7 +53,7 @@ Crafty.c("Delay", {
 	* ~~~
 	*/
 	delay : function(func, delay) {
-		return this._delays.push({
+		this._delays.push({
 			start : new Date().getTime(),
 			func : func,
 			delay : delay,
@@ -61,5 +61,7 @@ Crafty.c("Delay", {
 			pauseBuffer: 0,
 			pause: 0
 		});
+
+    return this;
 	}
 });


### PR DESCRIPTION
Hello, and first of all thanks for Crafty :)

I've had two issues with the Delay component:
- The .delay() method returns the length of the _delays array (return value of push()), instead of the entity itself. That means that developers can't chain more methods after the .delay(). Try this in the console:

``` javascript
Crafty.e("2D, Color, Delay")
      .color("#ff0000")
      .attr({ x: 10, y: 10, w: 10, h: 10 }
      .delay(function(){this.attr({ x: 20, y: 20 });}, 1000)

// returns 1

Crafty.e("2D, Color, Delay")
      .color("#ff0000")
      .delay(function(){this.attr({ x: 20, y: 20 });}, 1000)
      .attr({ x: 10, y: 10, w: 10, h: 10 })

// returns TypeError: Object 1 has no method 'attr'
```
- The component keeps all of its triggered delays in the _delays array and doesn't delete them. That takes up too much memory when you have repeated delays (see below). BTW, feature request - maybe make them easier to create? Or am I missing something here?

``` javascript
var repeatedFunc = function () {
  // do something and then:
  this.delay(function(){repeatedFunc.call(this);},1000);
};
// start the madness
this.delay(function(){repeatedFunc.call(this);},1000);
```

I'm trying to fix this in my two commits.

The return one is easy, just do the push and then return this.

The other one works by setting a purge flag when we mark a delay as triggered, then after the whole loop has run, creating a new array with untriggered delays if the flag is set.

---

Just as a side question: is there some kind of these delays defined in terms of frames, not milliseconds, built in Crafty at the moment? I had to create my own FrameDelay component ... :) If you'd like, I can document it and share it in next Pull Request.
