### PR TITLE
Fixing key press detection for Opera

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -250,13 +250,14 @@ Crafty.extend({
 		// Use a Crafty-standard event object to avoid cross-browser issues
 		var original = e,
 			evnt = {},
-			props = "char charCode keyCode type".split(" ");
-		for (i = props.length; i;) {
-			prop = props[--i];
+			props = "char charCode keyCode type shiftKey ctrlKey metaKey timestamp".split(" ");
+		for (var i = props.length; i;) {
+			var prop = props[--i];
 			evnt[prop] = original[prop];
 		}
 		evnt.which = original.charCode != null ? original.charCode : original.keyCode;
 		evnt.key = original.keyCode || original.which;
+		evnt.originalEvent = original;
 		e = evnt;
 
 		if (e.type === "keydown") {

--- a/src/controls.js
+++ b/src/controls.js
@@ -247,7 +247,18 @@ Crafty.extend({
 	* Unicode of the key pressed
 	*/
 	keyboardDispatch: function (e) {
-		e.key = e.keyCode || e.which;
+		// Use a Crafty-standard event object to avoid cross-browser issues
+		var original = e,
+			evnt = {},
+			props = "char charCode keyCode type".split(" ");
+		for (i = props.length; i;) {
+			prop = props[--i];
+			evnt[prop] = original[prop];
+		}
+		evnt.which = original.charCode != null ? original.charCode : original.keyCode;
+		evnt.key = original.keyCode || original.which;
+		e = evnt;
+
 		if (e.type === "keydown") {
 			if (Crafty.keydown[e.key] !== true) {
 				Crafty.keydown[e.key] = true;


### PR DESCRIPTION
Resolves #400

I based this on how the jQuery Event object works. This should help protect us from similar issues in the future.

If we need to copy more properties from the original event object, add them to the "props" variable.
