### PR TITLE
Change Crafty('*') output to follow style of Crafty(componentname)

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -107,10 +107,10 @@
                         i++;
                     }
                     this.length = i;
-			        // if there's only one entity, return the actual entity
-			        if (i === 1) {
-				        return entities[this[0]];
-			        }
+                    // if there's only one entity, return the actual entity
+                    if (i === 1) {
+                        return entities[this[0]];
+                    }
                     return this;
                 }
 

--- a/src/core.js
+++ b/src/core.js
@@ -6,6 +6,8 @@
     *
     * Crafty uses syntax similar to jQuery by having a selector engine to select entities by their components.
     *
+    * If there is more than one match, the return value is an Array-like object listing the ID numbers of each matching entity. If there is exactly one match, the entity itself is returned. If you're not sure how many matches to expect, check the number of matches via Crafty(...).length. Alternatively, use Crafty(...).each(...), which works in all cases.
+    *
     * @example
     * ~~~
     *    Crafty("MyComponent")
@@ -96,11 +98,19 @@
                 i, l;
 
                 if (selector === '*') {
+                    i = 0;
                     for (e in entities) {
-                        this[+e] = entities[e];
-                        elem++;
+                        // entities is something like {2:entity2, 3:entity3, 11:entity11, ...}
+                        // The for...in loop sets e to "2", "3", "11", ... i.e. all
+                        // the entity ID numbers. e is a string, so +e converts to number type.
+                        this[i] = +e;
+                        i++;
                     }
-                    this.length = elem;
+                    this.length = i;
+			        // if there's only one entity, return the actual entity
+			        if (i === 1) {
+				        return entities[this[0]];
+			        }
                     return this;
                 }
 


### PR DESCRIPTION
Prior behavior: Crafty('_') returns {2:{...entity2...},
3:{...entity3...}, ...} New behavior: Crafty('_') behaves exactly like
Crafty(componentname), i.e. {0:2, 1:3, 2:6, ...}  if the first three
entities are index 2,3,6, or just return the component if there's only
one match. Documented the new behavior.

Crafty('*').each(...) now works, it didn't before.

WARNING: NOT BACK-COMPATIBLE.
