### PR TITLE
improve documentation of Crafty.scenes (and minor code edits)

### DIFF
--- a/src/drawing.js
+++ b/src/drawing.js
@@ -199,7 +199,7 @@ Crafty.c("Image", {
 });
 
 Crafty.extend({
-	_scenes: [],
+	_scenes: {},
 	_current: null,
 
 	/**@
@@ -216,22 +216,50 @@ Crafty.extend({
 	* Method to create scenes on the stage. Pass an ID and function to register a scene.
 	*
 	* To play a scene, just pass the ID. When a scene is played, all
-	* entities with the `2D` component on the stage are destroyed.
+	* previously-created entities with the `2D` component are destroyed. The
+	* viewport is also reset.
 	*
-	* If you want some entities to persist over scenes (as in not be destroyed)
+	* If you want some entities to persist over scenes (as in, not be destroyed)
 	* simply add the component `Persist`.
 	*
 	* @example
 	* ~~~
-	* Crafty.scene("loading", function() {});
+	* Crafty.scene("loading", function() {
+	*     Crafty.background("#000");
+	*     Crafty.e("2D, DOM, Text")
+	*           .attr({ w: 100, h: 20, x: 150, y: 120 })
+	*           .text("Loading")
+	*           .css({ "text-align": "center", "color": "#FFF" });
+	* });
 	*
-	* Crafty.scene("loading", function() {}, function() {});
-	*
+	* Crafty.scene("UFO_dance",
+	*              function() {Crafty.background("#444"); Crafty.e("UFO");},
+	*              function() {...send message to server...});
+	* ~~~
+	* This defines (but does not play) two scenes as discussed below.
+	* ~~~
 	* Crafty.scene("loading");
 	* ~~~
+	* This command will clear the stage by destroying all `2D` entities (except
+	* those with the `Persist` component). Then it will set the background to
+	* black and display the text "Loading".
+	* ~~~
+	* Crafty.scene("UFO_dance");
+	* ~~~
+	* This command will clear the stage by destroying all `2D` entities (except
+	* those with the `Persist` component). Then it will set the background to
+	* gray and create a UFO entity. Finally, the next time the game encounters
+	* another command of the form `Crafty.scene(scene_name)` (if ever), then the
+	* game will send a message to the server.
 	*/
 	scene: function (name, intro, outro) {
-		//play scene
+		// ---FYI---
+		// this._current is the name (ID) of the scene in progress.
+		// this._scenes is an object like the following:
+		// {'Opening scene': {'initialize': fnA, 'uninitialize': fnB},
+		//  'Another scene': {'initialize': fnC, 'uninitialize': fnD}}
+		
+		// If there's one argument, play the scene
 		if (arguments.length === 1) {
 			Crafty.viewport.reset();
 			Crafty("2D").each(function () {
@@ -248,9 +276,10 @@ Crafty.extend({
 			Crafty.trigger("SceneChange", { oldScene: oldScene, newScene: name });
 			return;
 		}
-		//add scene
-		this._scenes[name] = {}
-		this._scenes[name].initialize = intro
+		
+		// If there is more than one argument, add the scene information to _scenes
+		this._scenes[name] = {};
+		this._scenes[name].initialize = intro;
 		if (typeof outro !== 'undefined') {
 			this._scenes[name].uninitialize = outro;
 		}


### PR DESCRIPTION
Added more detailed examples and explanations to the public
documentation. Also added internal code documentation explaining
_current and _scenes. My minor code edits should not affect any
behavior: I added missing semicolons, and set _scenes to inherit from
Object instead of Array, in accordance with how it's used. (Therefore it
makes the code intention clearer, a good thing for both humans and
javascript engines.)
