### PR TITLE
Bug in IE9: 'parent' and 'numChildren' properties not working

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -186,6 +186,16 @@ Crafty.c("2D", {
 			, get: function () { return this._visible; }
 			, configurable: true
 		});
+		
+		Object.defineProperty(this, 'parent', {		
+			get: function () { return this._parent; }
+			, configurable: true
+		});
+		
+		Object.defineProperty(this, 'numChildren', {		
+			get: function () { return this._children.length; }
+			, configurable: true
+		});
 	},
 
 	_defineGetterSetter_fallback: function() {

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -422,6 +422,41 @@ Crafty.extend({
 		 * on the stage.
          */
         bounds:null,
+		
+		/**@
+         * #Crafty.viewport.moveTo
+         * @comp Crafty.viewport
+         * @sign Crafty.viewport.moveTo(Number x, Number y)
+         * @param x - The new absolute position on the horizontal axis
+         * @param y - The new absolute position on the vertical axis
+         *
+         * Will move the viewport to the new position
+         */
+		moveTo: function (x, y) {		
+            var new_x = Math.floor(x),
+				new_y = Math.floor(y),
+				dx = new_x - this['_x'],
+                dy = new_y - this['_y'],
+				context = Crafty.canvas.context,
+                style = Crafty.stage.inner.style,
+                canvas;
+
+            //update viewport and DOM scroll
+			if (dx !== 0) {
+				this._x = new_x;			
+				style.left = new_x + 'px';
+			}
+			if (dy !== 0) {
+				this._y = new_y;
+				style.top = new_y + 'px';				
+			}
+			
+			//only redraw if there was some movement
+			if (context && (dx !== 0 || dy !== 0)) {
+				context.translate(dx, dy);				
+				Crafty.DrawManager.drawAll();
+			}			
+		},
 
         /**@
          * #Crafty.viewport.scroll

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -1028,8 +1028,10 @@ Crafty.extend({
                 Crafty.stage.elem.style.height = h + "px";
 
                 if (Crafty.canvas._canvas) {
+                    Crafty.canvas.context.translate(-this._x, -this._y);
                     Crafty.canvas._canvas.width = w;
                     Crafty.canvas._canvas.height = h;
+					Crafty.canvas.context.translate(this._x, this._y);
                     Crafty.DrawManager.drawAll();
                 }
             }


### PR DESCRIPTION
Hi, I noticed the 'parent' and 'numChildren' properties aren't working in IE9.
I think I fixed it by simply adding the corresponding Object.defineProperty(...) into the "_defineGetterSetter_defineProperty" function.
