### PR TITLE
Fix sharing of textFont object in Text component

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -7,16 +7,16 @@
 */
 Crafty.c("Text", {
 	_text: "",
-	_textFont: {
-		"type": "",
-		"weight": "",
-		"size": "",
-		"family": ""
-	},
 	ready: true,
 
 	init: function () {
 		this.requires("2D");
+		this._textFont = {
+			"type": "",
+			"weight": "",
+			"size": "",
+			"family": ""
+		};
 
 		this.bind("Draw", function (e) {
 			var font = this._textFont["type"] + ' ' + this._textFont["weight"] + ' ' +


### PR DESCRIPTION
The Text component was creating a this._textFont object outside of init.
This was causing the structure to be shared with all instances of Text.
Whenever one instance changed the font it would be changed for all
instances.

This commit moves the initialization into init() so each instance will
get its own copy.
