### PR TITLE
bug fix -- destroying parent does not destroy all children

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -290,6 +290,9 @@ Crafty.c("2D", {
 			if (this._children) {
 				for (var i = 0; i < this._children.length; i++) {
 					if (this._children[i].destroy) {
+						// delete the child's _parent link, or else the child will splice itself out of
+						// this._children while destroying itself (which messes up this for-loop iteration).
+						delete this._children[i]._parent;
 						this._children[i].destroy();
 					}
 				}
@@ -564,12 +567,18 @@ Crafty.c("2D", {
 	* #.attach
 	* @comp 2D
 	* @sign public this .attach(Entity obj[, .., Entity objN])
-	* @param obj - Entity(s) to attach
-	* Attaches an entities position and rotation to current entity. When the current entity moves,
-	* the attached entity will move by the same amount. Attached entities stored in _children array,
-	* the parent object is stored in _parent on the child entities.
+	* @param obj - Child entity(s) to attach
+	* Sets one or more entities to be children, with the current entity (`this`)
+	* as the parent. When the parent moves or rotates, its children move or
+	* rotate by the same amount. (But not vice-versa: If you move a child, it
+	* will not move the parent.) When the parent is destroyed, its children are
+	* destroyed.
+	* 
+	* For any entity, `this._children` is the array of its children entity
+	* objects (if any), and `this._parent` is its parent entity object (if any).
 	*
-	* As many objects as wanted can be attached and a hierarchy of objects is possible by attaching.
+	* As many objects as wanted can be attached, and a hierarchy of objects is
+	* possible by attaching.
 	*/
 	attach: function () {
 		var i = 0, arg = arguments, l = arguments.length, obj;

--- a/src/2D.js
+++ b/src/2D.js
@@ -289,10 +289,13 @@ Crafty.c("2D", {
 		this.bind("Remove", function () {
 			if (this._children) {
 				for (var i = 0; i < this._children.length; i++) {
+					// delete the child's _parent link, or else the child will splice itself out of
+					// this._children while destroying itself (which messes up this for-loop iteration).
+					delete this._children[i]._parent;
+					
+					// Destroy child if possible (It's not always possible, e.g. the polygon attached
+					// by areaMap has no .destroy(), it will just get garbage-collected.)
 					if (this._children[i].destroy) {
-						// delete the child's _parent link, or else the child will splice itself out of
-						// this._children while destroying itself (which messes up this for-loop iteration).
-						delete this._children[i]._parent;
 						this._children[i].destroy();
 					}
 				}

--- a/tests/core.html
+++ b/tests/core.html
@@ -193,6 +193,34 @@ $(document).ready(function() {
 		equal(circle.radius, 10, "circle.radius didn't change");
 	});
 
+	test("child", function () {
+		var parent0 = Crafty.e("2D, DOM, Color").attr({x:0, y:0, w:50, h:50}).color("red");
+		var child0 = Crafty.e("2D, DOM, Color").attr({x:1, y:1, w:50, h:50}).color("red");
+		var child1 = Crafty.e("2D, DOM, Color").attr({x:2, y:2, w:50, h:50}).color("red");
+		var child2 = Crafty.e("2D, DOM, Color").attr({x:3, y:3, w:50, h:50}).color("red");
+		var child3 = Crafty.e("2D, DOM, Color").attr({x:4, y:4, w:50, h:50}).color("red");
+		var child0_ID = child0[0];
+		var child1_ID = child1[0];
+		var child2_ID = child2[0];
+		var child3_ID = child3[0];
+		parent0.attach(child0);
+		parent0.attach(child1);
+		parent0.attach(child2);
+		parent0.attach(child3);
+		parent0.x += 50;
+		equal(child0._x, 51, 'child0 shifted when parent did');
+		equal(child1._x, 52, 'child1 shifted when parent did');
+		child0.x += 1;
+		child1.x += 1;
+		equal(parent0._x, 50, 'child shifts do not move the parent');
+		child1.destroy();
+		deepEqual(parent0._children, [child0,child2,child3], 'child1 cleared itself from parent0._children when destroyed');
+		parent0.destroy();
+		equal(Crafty(child0_ID).length, 0, 'destruction of parent killed child0');
+		equal(Crafty(child2_ID).length, 0, 'destruction of parent killed child2');
+		equal(Crafty(child3_ID).length, 0, 'destruction of parent killed child3');
+	});
+
 	test("SAT", function () {
 		var e = Crafty.e("2D, Collision");
 		var c1 = new Crafty.circle(100, 100, 10);


### PR DESCRIPTION
See https://github.com/craftyjs/Crafty/issues/360#issuecomment-13108664

Added unit test to confirm all behavior.

Edited documentation of this.attach to be more explicit, and
particularly to mention that destroying the parent will destroy
the child.
