### PR TITLE
Sprite scaling for DOM with backgroundSize=cover

### DIFF
--- a/src/sprite.js
+++ b/src/sprite.js
@@ -48,6 +48,7 @@ Crafty.c("Sprite", {
 				);
 			} else if (e.type === "DOM") {
 				this._element.style.background = "url('" + this.__image + "') no-repeat -" + co.x + "px -" + co.y + "px";
+				this._element.style.backgroundSize = 'cover';
 			}
 		};
 


### PR DESCRIPTION
Currently it's not possible to scale sprites - they get clipped. Default behaviour should be to scale.
https://groups.google.com/forum/?fromgroups=#!topic/craftyjs/BFo8K3FgySc
