### PR TITLE
Change to addComponent

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -225,7 +225,6 @@
             if (arguments.length > 1) {
                 l = arguments.length;
                 for (; i < l; i++) {
-                    this.__c[arguments[i]] = true;
                     uninit.push(arguments[i]);
                 }
                 //split components if contains comma
@@ -233,21 +232,21 @@
                 comps = id.split(rlist);
                 l = comps.length;
                 for (; i < l; i++) {
-                    this.__c[comps[i]] = true;
                     uninit.push(comps[i]);
                 }
                 //single component passed
             } else {
-                this.__c[id] = true;
                 uninit.push(id);
             }
 
             //extend the components
             ul = uninit.length;
             for (; c < ul; c++) {
+                if (this.__c[uninit[c]] == true)
+                    continue
+                this.__c[uninit[c]] = true
                 comp = components[uninit[c]];
                 this.extend(comp);
-
                 //if constructor, call it
                 if (comp && "init" in comp) {
                     comp.init.call(this);


### PR DESCRIPTION
A change to addComponent, as discussed [here](https://groups.google.com/forum/?fromgroups=#!topic/craftyjs/JMPNyq61KlA).
- Only toggles the __c[id] flag when the component is actually added.
- Doesn't add the component if the flag is already true.

The second change might break some code that was relying on the old behavior, but is clearly the better behavior, and without the first change would break things badly.
