### PR TITLE
Dirty rectangle rewrite

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -23,7 +23,7 @@ Crafty.c("DOM", {
 		this.bind("Change", function () {
 			if (!this._changed) {
 				this._changed = true;
-				Crafty.DrawManager.add(this);
+				Crafty.DrawManager.addDom(this);
 			}
 		});
 

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -29,21 +29,13 @@ Crafty.c("Canvas", {
 		Crafty.DrawManager.addCanvas(this);
 
 		this.bind("Change", function (e) {
-			//if within screen, add to list
+			//flag if changed
 			this._changed = true
 			if (this._dirtyFlag === false){
 				this._dirtyFlag = true;
 				Crafty.DrawManager.addCanvas(this);
-
 			}
-				
 			
-			return
-			if (this._changed === false) {
-				this._changed = Crafty.DrawManager.add(e || this, this);
-			} else {
-				if (e) this._changed = Crafty.DrawManager.add(e, this);
-			}
 		});
 
 
@@ -51,7 +43,6 @@ Crafty.c("Canvas", {
 			Crafty.DrawManager.total2D--;
 			this._dirtyFlag = true;
 			Crafty.DrawManager.addCanvas(this);
-			//Crafty.DrawManager.add(this, this);
 		});
 	},
 

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -23,8 +23,8 @@ Crafty.c("Canvas", {
 
 		//increment the amount of canvas objs
 		Crafty.DrawManager.total2D++;
-
-		this.newRect = {};
+		//Allocate an object to hold this components current region
+		this.currentRect = {};
 		this._dirtyFlag = true;
 		Crafty.DrawManager.addCanvas(this);
 

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -49,7 +49,9 @@ Crafty.c("Canvas", {
 
 		this.bind("Remove", function () {
 			Crafty.DrawManager.total2D--;
-			Crafty.DrawManager.add(this, this);
+			this._dirtyFlag = true;
+			Crafty.DrawManager.addCanvas(this);
+			//Crafty.DrawManager.add(this, this);
 		});
 	},
 
@@ -75,6 +77,7 @@ Crafty.c("Canvas", {
 			ctx = Crafty.canvas.context;
 		}
 
+
 		var pos = { //inlined pos() function, for speed
 			_x: (this._x + (x || 0)),
 			_y: (this._y + (y || 0)),
@@ -89,6 +92,7 @@ Crafty.c("Canvas", {
 			w: w || coord[2],
 			h: h || coord[3]
 		};
+
 
 		if (this._mbr) {
 			context.save();

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -24,14 +24,28 @@ Crafty.c("Canvas", {
 		//increment the amount of canvas objs
 		Crafty.DrawManager.total2D++;
 
+		this.newRect = {};
+		this._dirtyFlag = true;
+		Crafty.DrawManager.addCanvas(this);
+
 		this.bind("Change", function (e) {
 			//if within screen, add to list
+			this._changed = true
+			if (this._dirtyFlag === false){
+				this._dirtyFlag = true;
+				Crafty.DrawManager.addCanvas(this);
+
+			}
+				
+			
+			return
 			if (this._changed === false) {
 				this._changed = Crafty.DrawManager.add(e || this, this);
 			} else {
 				if (e) this._changed = Crafty.DrawManager.add(e, this);
 			}
 		});
+
 
 		this.bind("Remove", function () {
 			Crafty.DrawManager.total2D--;

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -25,14 +25,13 @@ Crafty.c("Canvas", {
 		Crafty.DrawManager.total2D++;
 		//Allocate an object to hold this components current region
 		this.currentRect = {};
-		this._dirtyFlag = true;
+		this._changed = true;
 		Crafty.DrawManager.addCanvas(this);
 
 		this.bind("Change", function (e) {
 			//flag if changed
-			this._changed = true
-			if (this._dirtyFlag === false){
-				this._dirtyFlag = true;
+			if (this._changed === false){
+				this._changed = true;
 				Crafty.DrawManager.addCanvas(this);
 			}
 			
@@ -41,7 +40,7 @@ Crafty.c("Canvas", {
 
 		this.bind("Remove", function () {
 			Crafty.DrawManager.total2D--;
-			this._dirtyFlag = true;
+			this._changed = true;
 			Crafty.DrawManager.addCanvas(this);
 		});
 	},

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -409,23 +409,22 @@ Crafty.DrawManager = (function () {
 		*
 		* The order of set isn't strictly meaningful, 
 		* but overlapping objects will often cause each other to change, 
-		* and will might be consecutive.
+		* and so might be consecutive.
 		*/
 		mergeSet: function (set) {
- 
-			do {
-				var didMerge = false, i = 0;
-				while (i < set.length-1) {
-					// If current and next overlap, merge them together, and skip the index forward
-					if (rectManager.overlap(set[i], set[i+1]) ){
-						rectManager.merge(set[i], set[i+1], set[i]);
-						//Remove merged rect from array
-						set.splice(i+1, 1);
-						didMerge = true;
-					}
+			var i = 0;
+			while (i < set.length-1) {
+				// If current and next overlap, merge them together into the first, removing the second
+				// Then skip the index backwards to compare the previous pair.
+				// Otherwise skip forward
+				if (rectManager.overlap(set[i], set[i+1])){
+					rectManager.merge(set[i], set[i+1], set[i]);
+					set.splice(i+1, 1);
+					if (i>0) i--
+				} else
 					i++;
-				}
-			} while (didMerge);
+			}
+		
 			return set;
 		},
 

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -305,8 +305,9 @@ Crafty.DrawManager = (function () {
 	/** array of DOMs needed updating */
 		dom = [], 
 	
-	/** object for managing dirty rectangles */
+	/** recManager: an object for managing dirty rectangles. */
 	rectManager = {
+		/** Finds smallest rectangles that overlaps a and b, merges them into target */
 		merge: function(a, b, target){
 			if (target == null)
 				target={}
@@ -322,8 +323,8 @@ Crafty.DrawManager = (function () {
 			return target
 		},
 
+		/** cleans up current dirty state, stores stale state for future passes */
 		clean: function(){
-			// Cleanup; assign the now stale rectangles and clear the arrays
             for (var i=0, l=changed_objs.length; i<l; i++){
             	var obj = changed_objs[i];
             	if (obj.staleRect == null)
@@ -340,8 +341,8 @@ Crafty.DrawManager = (function () {
 
 		},
 
-		// Takes the current and previous position of an object, and pushes the dirty regions onto the stack
-		// If the entity has only moved/changed a little bit, the regions are squashed together
+		/** Takes the current and previous position of an object, and pushes the dirty regions onto the stack
+		* 	If the entity has only moved/changed a little bit, the regions are squashed together */
 		createDirty: function(obj){
 			if (obj.staleRect){
 				//If overlap, merge stale and current position together, then return
@@ -365,6 +366,7 @@ Crafty.DrawManager = (function () {
 			
 		},
 
+		/** Checks whether two rectangles overlap */
 		overlap: function(a, b){
 			return (a._x < b._x + b._w && a._y < b._y + b._h 
 					&& a._x + a._w > b._x && a._y + a._h > b._y)

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -543,7 +543,8 @@ Crafty.DrawManager = (function () {
 			//if the amount of changed objects is over 60% of the total objects
 			//do the naive method redrawing
 			// TODO: I'm not sure this condition really makes that much sense!
-			if (l / this.total2D > 0.6) {
+			console.log("numbers: " + l + "  | "  + this.total2D )
+			if (l / this.total2D > 0.6 && false) {
 				this.drawAll();
 				dirty_rects.length = 0;
 				return;
@@ -552,21 +553,29 @@ Crafty.DrawManager = (function () {
 			// Calculate dirty_rects from all changed objects
 			for  (i=0; i<l; i++){
 				obj = changed_objs[i];
-				if (obj.staleRect)
+				if (obj.staleRect){
 					dirty_rects.push(obj.staleRect)
-				else
+					//console.log("Stale")
+				} else{
 					obj.staleRect ={}
+					//console.log("Creation of stale")
+				}
 				// Assign current position to new rect, and also stale rect 
-				obj.staleRect._x = obj.newRect._x = obj._x;
-				obj.staleRect._y = obj.newRect._y = obj._y;
-				obj.staleRect._w = obj.newRect._w = obj._w;
-				obj.staleRect._h = obj.newRect._h = obj._h;
+				obj.newRect._x = obj._x;
+				obj.newRect._y = obj._y;
+				obj.newRect._w = obj._w;
+				obj.newRect._h = obj._h;
 				dirty_rects.push(obj.newRect)
+
+				//Clear for redrawing next time
+				obj._dirtyFlag = false
 
 
 
 
 			}
+			
+			
 
 
 			dirty_rects = this.merge(dirty_rects);
@@ -577,6 +586,8 @@ Crafty.DrawManager = (function () {
 				q = Crafty.map.search(rect, false); //search for ents under dirty rect
 
 				dupes = {};
+				//clear the rect from the main canvas
+				ctx.clearRect(rect._x, rect._y, rect._w, rect._h);
 
 				//loop over found objects removing dupes and adding to obj array
 				for (j = 0, len = q.length; j < len; ++j) {
@@ -589,8 +600,7 @@ Crafty.DrawManager = (function () {
 					objs.push({ obj: obj, rect: rect });
 				}
 
-				//clear the rect from the main canvas
-				ctx.clearRect(rect._x, rect._y, rect._w, rect._h);
+				
 
 			}
 
@@ -631,8 +641,24 @@ Crafty.DrawManager = (function () {
 				ent._changed = false;
 			}
 
+			/*ctx.strokeStyle = 'red';
+            for (i = 0, l=dirty_rects.length; i < l; ++i) { //loop over every dirty rect
+                rect = dirty_rects[i];
+                ctx.strokeRect(rect._x,rect._y,rect._w,rect._h)
+            }*/
+
+            // Cleanup; assign the now stale rectangles and clear the arrays
+            for (i=0, l=changed_objs.length; i<l; i++){
+            	obj = changed_objs[i];
+        		obj.staleRect._x = obj._x;
+				obj.staleRect._y = obj._y;
+				obj.staleRect._w = obj._w;
+				obj.staleRect._h = obj._h;
+            }
+
 			//empty dirty_rects
 			dirty_rects.length = 0;
+			changed_objs.length=0;
 			//all merged IDs are now invalid
 			merged = {};
 		}

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -318,6 +318,8 @@ Crafty.DrawManager = (function () {
 			target._w = Math.max(a._x + a._w, b._x + b._w);
 			target._x = ~~Math.min(a._x, b._x);
 			target._y = ~~Math.min(a._y, b._y);
+			target._w -= target._x;
+			target._h -= target._y
 			target._w = (target._w == ~~target._w) ? target._w : ~~target._w + 1 | 0;
 			target._h = (target._h == ~~target._h) ? target._h : ~~target._h + 1 | 0;
 			return target
@@ -641,16 +643,17 @@ Crafty.DrawManager = (function () {
 				ent._changed = false;
 			}
 
-			/*ctx.strokeStyle = 'red';
-            for (i = 0, l=dirty_rects.length; i < l; ++i) { //loop over every dirty rect
-                rect = dirty_rects[i];
-                ctx.strokeRect(rect._x,rect._y,rect._w,rect._h)
-            } */
-
+			// Draw dirty rectangles for debugging, if flag is set
+			if (Crafty.DrawManager.debugDirty === true){
+				ctx.strokeStyle = 'red';
+		        for (i = 0, l=dirty_rects.length; i < l; ++i) { 
+		            rect = dirty_rects[i];
+		            ctx.strokeRect(rect._x,rect._y,rect._w,rect._h)
+		        } 
+        	}
             //Clean up lists etc
             rectManager.clean()
-			//all merged IDs are now invalid
-			merged = {};
+
 		}
 	};
 })();

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -399,44 +399,33 @@ Crafty.DrawManager = (function () {
 		},
 
 		/**@
-		* #Crafty.DrawManager.merge
+		* #Crafty.DrawManager.mergeSet
 		* @comp Crafty.DrawManager
-		* @sign public Object Crafty.DrawManager.merge(Object set)
+		* @sign public Object Crafty.DrawManager.mergeSet(Object set)
 		* @param set - an array of rectangular regions
 		* 
-		* Merged into non overlapping rectangular region
+		* Merge any consecutive, overlapping rects into each other.
 		* Its an optimization for the redraw regions.
+		*
+		* The order of set isn't strictly meaningful, 
+		* but overlapping objects will often cause each other to change, 
+		* and will might be consecutive.
 		*/
-		merge: function (set) {
-			var newset = []
-			// 
+		mergeSet: function (set) {
+ 
 			do {
-				var didMerge = false, i = 0,
-					l = set.length, current, next;
-
-				while (i < l) {
-					current = set[i];
-					next = set[i + 1];
-
+				var didMerge = false, i = 0;
+				while (i < set.length-1) {
 					// If current and next overlap, merge them together, and skip the index forward
-					if (i < l - 1 && rectManager.overlap(current, next) ){
-						rectManager.merge(current, next, current);
-						i++;
+					if (rectManager.overlap(set[i], set[i+1]) ){
+						rectManager.merge(set[i], set[i+1], set[i]);
+						//Remove merged rect from array
+						set.splice(i+1, 1);
 						didMerge = true;
 					}
-					newset.push(current);
 					i++;
 				}
-
-				// Use current as a placeholder while we swap set and newset to iterate once through the list again
-				if (newset.length){
-					current = set;
-					set = newset;
-					newset = current;
-					newset.length=0;
-				}
 			} while (didMerge);
-
 			return set;
 		},
 
@@ -580,7 +569,7 @@ Crafty.DrawManager = (function () {
 			for  (i=0; i<l; i++){
 				rectManager.createDirty(changed_objs[i])
 			}
-			dirty_rects = this.merge(dirty_rects);
+			dirty_rects = this.mergeSet(dirty_rects);
 
 			// Find entities overlapping dirty screen areas
 			l = dirty_rects.length;

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -336,7 +336,7 @@ Crafty.DrawManager = (function () {
 				obj.staleRect._w = obj._w;
 				obj.staleRect._h = obj._h;
 
-				obj._dirtyFlag = false
+				obj._changed = false
             }
             changed_objs.length = 0;
             dirty_rects.length = 0
@@ -557,8 +557,6 @@ Crafty.DrawManager = (function () {
 			//do the naive method redrawing
 			// TODO: I'm not sure this condition really makes that much sense!
 			if (l / this.total2D > 0.6 ) {
-				console.log("numbers: " + l + "  | "  + this.total2D )
-
 				this.drawAll();
 				rectManager.clean()
 				return;


### PR DESCRIPTION
This is a rewrite of the general mechanism that Crafty uses to track dirty areas of the screen.  
1. Only which entities have changed are tracked.  The dirty regions are then calculated right before the scene is drawn.  (The old method was to calculate dirty regions as entities changed, which was inefficient.)
2. The algorithm for merging rectangular regions together was corrected and simplified.
3. This patch also changes the order in which entities are drawn; everything within a particular dirty rectangle is now drawn in one go.

There's an alternative patch for 2 that got merged to master; I'm going to go ahead and submit this pull request anyway.  If that one gets merged to develop, I'll do the work in making them compatible.  However, change 3 would actually _also_ fix the problem the other patch was targeting  ([demo](http://abstractvisitorfactory.com/~tim/AlphaProblems/alternateFix.html)) ; so ideally we'd want to measure how the two algorithms compare.  (As part of change 3, the dirty region is cleared directly before it is drawn to, instead of clearing all regions before drawing any entities.  This prevents the overlapping alpha issue that prompted the other patch)
