### PR TITLE
Hashmap revision

### DIFF
--- a/src/HashMap.js
+++ b/src/HashMap.js
@@ -49,7 +49,7 @@
 			for (i = keys.x1; i <= keys.x2; i++) {
 				//insert into all y buckets
 				for (j = keys.y1; j <= keys.y2; j++) {
-					hash = i + SPACE + j;
+					hash = (i << 16)^j;
 					if (!this.map[hash]) this.map[hash] = [];
 					this.map[hash].push(obj);
 				}
@@ -81,13 +81,11 @@
 			for (i = keys.x1; i <= keys.x2; i++) {
 				//insert into all y buckets
 				for (j = keys.y1; j <= keys.y2; j++) {
-					hash = i + SPACE + j;
-
-					if (this.map[hash]) {
-                        for (k = 0; k<this.map[hash].length; k++)
-                            results.push(this.map[hash][k]);
-						//results = results.concat(this.map[hash]);
-					}
+					cell = this.map[(i << 16)^j];
+					if (cell) {
+                        for (k = 0; k<cell.length; k++)
+                            results.push(cell[k]);
+					}	
 				}
 			}
 
@@ -141,7 +139,7 @@
 			for (i = keys.x1; i <= keys.x2; i++) {
 				//insert into all y buckets
 				for (j = keys.y1; j <= keys.y2; j++) {
-					hash = i + SPACE + j;
+					hash = (i << 16)^j;
 
 					if (this.map[hash]) {
 						var cell = this.map[hash],
@@ -191,9 +189,9 @@
 				if (!this.map[h].length) continue;
 
         //broad phase coordinate
-				var map_coord = h.split(SPACE),
-					i=map_coord[0],
-					j=map_coord[0];
+				var i= h>>16,
+					j=(h<<16)>>16;
+				if (j<0) { i = i^-1 }
 				if (i >= hash.max.x) {
 					hash.max.x = i;
 					for (k in this.map[h]) {

--- a/src/HashMap.js
+++ b/src/HashMap.js
@@ -22,7 +22,8 @@
 		this.map = {};
 	},
 
-	SPACE = " ";
+	SPACE = " ",
+	keyHolder ={};
 
 	HashMap.prototype = {
 	/**@
@@ -69,10 +70,10 @@
     * - If `filter` is `true`, filter the above results by checking that they actually overlap `rect`.
     * The easier usage is with `filter`=`true`. For performance reason, you may use `filter`=`false`, and filter the result yourself. See examples in drawing.js and collision.js
 	*/
+
 		search: function (rect, filter) {
-			var keys = HashMap.key(rect),
+			var keys = HashMap.key(rect, keyHolder ),
 			i, j,k,
-			hash,
 			results = [];
 
 			if (filter === undefined) filter = true; //default filter to true
@@ -84,7 +85,7 @@
 					cell = this.map[(i << 16)^j];
 					if (cell) {
                         for (k = 0; k<cell.length; k++)
-                            results.push(cell[k]);
+                            results.push(cell[k])
 					}	
 				}
 			}
@@ -132,7 +133,7 @@
 
 			if (arguments.length == 1) {
 				obj = keys;
-				keys = HashMap.key(obj);
+				keys = HashMap.key(obj, keyHolder);
 			}
 
 			//search in all x buckets
@@ -143,8 +144,7 @@
 
 					if (this.map[hash]) {
 						var cell = this.map[hash],
-						m,
-						n = cell.length;
+						 m, n = cell.length;
 						//loop over objs in cell and delete
 						for (m = 0; m < n; m++)
 							if (cell[m] && cell[m][0] === obj[0])
@@ -257,15 +257,19 @@
     * 
     * @see Crafty.HashMap.constructor
 	*/
-	HashMap.key = function (obj) {
+	HashMap.key = function (obj, keys) {
 		if (obj.hasOwnProperty('mbr')) {
 			obj = obj.mbr();
 		}
-		var x1 = Math.floor(obj._x / cellsize),
-		y1 = Math.floor(obj._y / cellsize),
-		x2 = Math.floor((obj._w + obj._x) / cellsize),
-		y2 = Math.floor((obj._h + obj._y) / cellsize);
-		return { x1: x1, y1: y1, x2: x2, y2: y2 };
+		if (!keys){
+			keys = {}
+		}
+
+		keys.x1 = Math.floor(obj._x / cellsize);
+		keys.y1 = Math.floor(obj._y / cellsize);
+		keys.x2 = Math.floor((obj._w + obj._x) / cellsize);
+		keys.y2 = Math.floor((obj._h + obj._y) / cellsize);
+		return keys;
 	};
 
 	HashMap.hash = function (keys) {
@@ -281,7 +285,7 @@
 	Entry.prototype = {
 		update: function (rect) {
 			//check if buckets change
-			if (HashMap.hash(HashMap.key(rect)) != HashMap.hash(this.keys)) {
+			if (HashMap.hash(HashMap.key(rect, keyHolder)) != HashMap.hash(this.keys)) {
 				this.map.remove(this.keys, this.obj);
 				var e = this.map.insert(this.obj);
 				this.keys = e.keys;

--- a/src/HashMap.js
+++ b/src/HashMap.js
@@ -155,6 +155,62 @@
 		},
 
 	/**@
+	* #Crafty.map.refresh
+	* @comp Crafty.map
+	* @sign public void Crafty.map.remove(Entry entry)
+	* @param entry - An entry to update
+	* 
+	* Refresh an entry's keys, and its position in the broad phrase map.
+	*
+	* @example 
+	* ~~~
+	* Crafty.map.refresh(e);
+	* ~~~
+	*/
+		refresh: function(entry) {
+				var keys = entry.keys;
+				var obj = entry.obj;
+				var cell, i, j, m, n;
+
+				//First delete current contents
+				for (i = keys.x1; i <= keys.x2; i++) {
+				//insert into all y buckets
+					for (j = keys.y1; j <= keys.y2; j++) {
+						cell = this.map[(i << 16)^j];
+						if (cell) {
+							n = cell.length;
+							//loop over objs in cell and delete
+							for (m = 0; m < n; m++)
+								if (cell[m] && cell[m][0] === obj[0])
+									cell.splice(m, 1);
+						}
+					}
+				}
+
+				//update keys
+				HashMap.key(obj, keys);
+
+
+
+				//insert into all x buckets
+				for (i = keys.x1; i <= keys.x2; i++) {
+					//insert into all y buckets
+					for (j = keys.y1; j <= keys.y2; j++) {
+						cell = this.map[(i << 16)^j];
+						if (!cell) cell=this.map[(i << 16)^j] = [];
+						cell.push(obj);
+					}
+				}
+
+			return entry;
+		},
+
+
+
+
+		
+
+	/**@
 	* #Crafty.map.boundaries
 	* @comp Crafty.map
 	* @sign public Object Crafty.map.boundaries()
@@ -280,15 +336,13 @@
 		this.keys = keys;
 		this.map = map;
 		this.obj = obj;
-	}
+	};
 
 	Entry.prototype = {
 		update: function (rect) {
 			//check if buckets change
 			if (HashMap.hash(HashMap.key(rect, keyHolder)) != HashMap.hash(this.keys)) {
-				this.map.remove(this.keys, this.obj);
-				var e = this.map.insert(this.obj);
-				this.keys = e.keys;
+					this.map.refresh(this)
 			}
 		}
 	};

--- a/src/HashMap.js
+++ b/src/HashMap.js
@@ -71,7 +71,7 @@
 	*/
 		search: function (rect, filter) {
 			var keys = HashMap.key(rect),
-			i, j,
+			i, j,k,
 			hash,
 			results = [];
 
@@ -84,7 +84,9 @@
 					hash = i + SPACE + j;
 
 					if (this.map[hash]) {
-						results = results.concat(this.map[hash]);
+                        for (k = 0; k<this.map[hash].length; k++)
+                            results.push(this.map[hash][k]);
+						//results = results.concat(this.map[hash]);
 					}
 				}
 			}

--- a/src/HashMap.js
+++ b/src/HashMap.js
@@ -172,9 +172,8 @@
 				var obj = entry.obj;
 				var cell, i, j, m, n;
 
-				//First delete current contents
+				//First delete current object from appropriate cells
 				for (i = keys.x1; i <= keys.x2; i++) {
-				//insert into all y buckets
 					for (j = keys.y1; j <= keys.y2; j++) {
 						cell = this.map[(i << 16)^j];
 						if (cell) {
@@ -190,11 +189,8 @@
 				//update keys
 				HashMap.key(obj, keys);
 
-
-
-				//insert into all x buckets
+				//insert into all rows and columns
 				for (i = keys.x1; i <= keys.x2; i++) {
-					//insert into all y buckets
 					for (j = keys.y1; j <= keys.y2; j++) {
 						cell = this.map[(i << 16)^j];
 						if (!cell) cell=this.map[(i << 16)^j] = [];
@@ -314,8 +310,8 @@
     * @see Crafty.HashMap.constructor
 	*/
 	HashMap.key = function (obj, keys) {
-		if (obj.hasOwnProperty('mbr')) {
-			obj = obj.mbr();
+		if (obj._mbr) {
+			obj = obj._mbr
 		}
 		if (!keys){
 			keys = {}


### PR DESCRIPTION
These patches rewrite portions of Crafty's Hashmap.  Changes:
- Uses the bit pattern `(i << 16)^j`as a coordinate key instead of the string `i + SPACE + j`.  This is faster and creates less garbage, but would break a scene that involved more than 65k cells.  (With the default settings, that would be 2 million pixels.)  I don't this is a real concern, but enlighten me if I'm wrong!  :)
- Add a function to refresh an objects position in the hashmap, rather than removing it and then adding it back.  The old way created a lot of garbage.  (I imagine the refresh function could be further optimized.)
- Where possible, avoid creating objects by reusing existing ones.  Every use of mbr() makes Firefox's GC cry, and we don't want that.

I've used these changes for a long time in a game I wrote, so they seem fairly bug free.  My own benchmarking showed a general performance improvement.   I ran some jsperf tests on [encoding](http://jsperf.com/string-vs-bit-hash/2) and [decoding](http://jsperf.com/hash-reversal-for-bits-and-strings) the hash, and the bitwise version won out with both, but the most noticeable gain was the reduction in GC pauses in Firefox.
