### PR TITLE
Remove entity-factory functionality

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -45,7 +45,6 @@
 
     	components = {}; //map of components and their functions
     	entities = {}; //map of entities and their data
-        entityFactories = {}; //templates of entities
     	handlers = {}; //global event handlers
     	onloads = []; //temporary storage of onload handlers
     	tick;
@@ -968,69 +967,6 @@
                 Crafty.DrawManager.draw();
             }
 
-        },
-
-        /**@
-        * #Crafty.addEntityFactory
-        * @category Core
-        * @param name - Name of the entity factory.
-        * @param callback - Function containing the entity creation procedure.
-        * 
-        * Registers an Entity Factory.  An Entity Factory allows for the repeatable creation of an Entity.
-        *
-        * @example
-        * ~~~
-        * Crafty.addEntityFactory('Projectile', function() {
-        *   var entity = Crafty.e('2D, Canvas, Color, Physics, Collision')
-        *   .color("red")
-        *   .attr({
-        *     w: 3,
-        *     h: 3,
-        *     x: this.x,
-        *     y: this.y
-        *   })
-        *   .addComponent('Gravity').gravity("Floor");
-        *   
-        *   return entity;
-        * });
-        * ~~~
-        * 
-        * @see Crafty.e
-        */
-        addEntityFactory: function(name, callback) {
-            this.entityFactories[name] = callback;
-        },
-
-        /**@
-        * #Crafty.newFactoryEntity
-        * @category Core
-        * @param name - Name of the entity factory.
-        * 
-        * Creates a new entity based on a specific Entity Factory.
-        *
-        * @example
-        * ~~~
-        * Crafty.addEntityFactory('Projectile', function() {
-        *   var entity = Crafty.e('2D, Canvas, Color, Physics, Collision')
-        *   .color("red")
-        *   .attr({
-        *     w: 3,
-        *     h: 3,
-        *     x: this.x,
-        *     y: this.y
-        *   })
-        *   .addComponent('Gravity').gravity("Floor");
-        *   
-        *   return entity;
-        * });
-        *
-        * Crafty.newFactoryEntity('Projectile'); // This returns a new Projectile Entity.
-        * ~~~
-        * 
-        * @see Crafty.e
-        */
-        newFactoryEntity: function(name) {
-            return this.entityTemplates[name]();
         },
 
         /**@


### PR DESCRIPTION
The entity-factory functionality is currently broken, and there is
no point in having it in the first place. (Every javascript programmer
already knows how to create reusable code: Create a function!)

Deleting the functionality was discussed and endorsed here:

https://groups.google.com/d/topic/craftyjs/1ESEbI09S7s/discussion
