### PR TITLE
Make the stage element (#cr-stage) more modular

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -753,8 +753,8 @@
         * Uses `requestAnimationFrame` to sync the drawing with the browser but will default to `setInterval` if the browser does not support it.
         * @see Crafty.stop,  Crafty.viewport
         */
-        init: function (w, h) {
-            Crafty.viewport.init(w, h);
+        init: function (w, h, stage_elem) {
+            Crafty.viewport.init(w, h, stage_elem);
 
             //call all arbitrary functions attached to onload
             this.trigger("Load");
@@ -795,7 +795,7 @@
         	if (clearState) {
         		if (Crafty.stage && Crafty.stage.elem.parentNode) {
         			var newCrStage = document.createElement('div');
-        			newCrStage.id = "cr-stage";
+        			newCrStage.id = Crafty.stage.elem.id;
         			Crafty.stage.elem.parentNode.replaceChild(newCrStage, Crafty.stage.elem);
         		}
         		initState();

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -789,7 +789,7 @@ Crafty.extend({
          *
          * @see Crafty.device, Crafty.DOM, Crafty.stage
          */
-        init: function (w, h) {
+        init: function (w, h, stage_elem) {
             Crafty.DOM.window.init();
 
             //fullscreen if mobile or not specified
@@ -797,7 +797,16 @@ Crafty.extend({
             this.height = (!h || Crafty.mobile) ? Crafty.DOM.window.height : h;
 
             //check if stage exists
-            var crstage = document.getElementById("cr-stage");
+            if(typeof stage_elem === 'undefined')
+                stage_elem = "cr-stage";
+
+            var crstage;
+            if(typeof stage_elem === 'string')
+                crstage = document.getElementById(stage_elem);
+            else if(typeof HTMLElement !== "undefined" ? stage_elem instanceof HTMLElement : stage_elem instanceof Element)
+                crstage = stage_elem;
+            else
+                throw new TypeError("stage_elem must be a string or an HTMLElement");
 
             /**@
              * #Crafty.stage
@@ -872,7 +881,7 @@ Crafty.extend({
             //add to the body and give it an ID if not exists
             if (!crstage) {
                 document.body.appendChild(Crafty.stage.elem);
-                Crafty.stage.elem.id = "cr-stage";
+                Crafty.stage.elem.id = stage_elem;
             }
 
             var elem = Crafty.stage.elem.style,


### PR DESCRIPTION
I needed to have Crafty use an element other than a div with id 'cr-stage', and I noticed that the support for a modular stage element was already there with Crafty.stage.elem, but there were a couple references to 'cr-stage' still in the code. I updated Crafty.init(w, h) and Crafty.viewport.init(w, h) to take an optional stage_elem parameter that could be either a string or an HTMLElement (known as just an Element in IE8). If no parameter is given, it defaults to the original behavior of finding an element with id cr-stage and, if none exists, creating it under 'body'. In addition to this, I updated the stop function to set the id of the replacement div for stage with the id from the original stage element. Please look it over and let me know what you think.
