### PR TITLE
Make default tint color transparent

### DIFF
--- a/src/drawing.js
+++ b/src/drawing.js
@@ -60,7 +60,7 @@ Crafty.c("Tint", {
 		var draw = function d(e) {
 			var context = e.ctx || Crafty.canvas.context;
 
-			context.fillStyle = this._color || "rgb(0,0,0)";
+			context.fillStyle = this._color || "rgba(0,0,0, 0)";
 			context.fillRect(e.pos._x, e.pos._y, e.pos._w, e.pos._h);
 		};
 


### PR DESCRIPTION
This'll make the initial tint color transparent instead of black until `tint()` is called.  Fixes #335
