### PR TITLE
Add note about tileh to docs

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -144,8 +144,9 @@ Crafty.extend({
     /**@
     * #Crafty.sprite
     * @category Graphics
-    * @sign public this Crafty.sprite([Number tile], String url, Object map[, Number paddingX[, Number paddingY]])
+    * @sign public this Crafty.sprite([Number tile, [Number tileh]], String url, Object map[, Number paddingX[, Number paddingY]])
     * @param tile - Tile size of the sprite map, defaults to 1
+    * @param tileh - Height of the tile; if provided, tile is interpreted as the width
     * @param url - URL of the sprite image
     * @param map - Object where the key is what becomes a new component and the value points to a position on the sprite map
     * @param paddingX - Horizontal space in between tiles. Defaults to 0.


### PR DESCRIPTION
The documentation was missing `tileh` in the function signature
