### PR TITLE
Fix rotation cascading

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -363,7 +363,7 @@ Crafty.c("2D", {
 		this._mbr = { _x: minx, _y: miny, _w: maxx - minx, _h: maxy - miny };
 
 		//trigger rotation event
-		var difference = this._rotation - v,
+		var difference = v - this._rotation,
 			drad = difference * DEG_TO_RAD;
 
 		this.trigger("Rotate", {
@@ -737,7 +737,7 @@ Crafty.c("2D", {
 		this._origin.y = e.o.y - this._y;
 
 		//modify through the setter method
-		this._attr('_rotation', e.theta);
+		this._attr('_rotation', this._rotation + e.deg);
 	},
 
 	/**@

--- a/src/2D.js
+++ b/src/2D.js
@@ -1000,8 +1000,8 @@ Crafty.polygon.prototype = {
 		for (; i < l; i++) {
 			current = this.points[i];
 
-			x = e.o.x + (current[0] - e.o.x) * e.cos + (current[1] - e.o.y) * e.sin;
-			y = e.o.y - (current[0] - e.o.x) * e.sin + (current[1] - e.o.y) * e.cos;
+			x = e.o.x + (current[0] - e.o.x) * e.cos - (current[1] - e.o.y) * e.sin;
+			y = e.o.y + (current[0] - e.o.x) * e.sin + (current[1] - e.o.y) * e.cos;
 
 			current[0] = x;
 			current[1] = y;

--- a/src/2D.js
+++ b/src/2D.js
@@ -1000,8 +1000,8 @@ Crafty.polygon.prototype = {
 		for (; i < l; i++) {
 			current = this.points[i];
 
-			x = e.o.x + (current[0] - e.o.x) * e.cos - (current[1] - e.o.y) * e.sin;
-			y = e.o.y + (current[0] - e.o.x) * e.sin + (current[1] - e.o.y) * e.cos;
+			x = e.o.x + (current[0] - e.o.x) * e.cos + (current[1] - e.o.y) * e.sin;
+			y = e.o.y - (current[0] - e.o.x) * e.sin + (current[1] - e.o.y) * e.cos;
 
 			current[0] = x;
 			current[1] = y;

--- a/tests/core.html
+++ b/tests/core.html
@@ -298,6 +298,24 @@ $(document).ready(function() {
 		Crafty("*").destroy();
 	});
 
+	test("child_rotate", function () {
+		var parent = Crafty.e("2D, DOM, Color")
+			.attr({x:0, y:0, w:50, h:50, rotation:10})
+			.color("red");
+		var child = Crafty.e("2D, DOM, Color")
+			.attr({x:1, y:1, w:50, h:50, rotation:15})
+			.color("red");
+		parent.attach(child);
+		parent.rotation += 20;
+		strictEqual(parent.rotation, 30, 'parent rotates normally');
+		strictEqual(child.rotation, 35, 'child follows parent rotation');
+		child.rotation += 22;
+		strictEqual(parent.rotation, 30, 'parent ignores child rotation');
+		strictEqual(child.rotation, 57, 'child rotates normally');
+		// Clean up
+		Crafty("*").destroy();
+	});
+
 	test("SAT", function () {
 		var e = Crafty.e("2D, Collision");
 		var c1 = new Crafty.circle(100, 100, 10);


### PR DESCRIPTION
As discussed in issue #378, rotating a parent does not rotate the child, but instead sets the child's rotation to undefined. (It calls e.theta, which was never defined.) This change seems to fix it, and I added a unit test to confirm.

In #378, @benbarefield also suggests that collision polygons are rotating the wrong way, and proposes a code change to fix it. So I made that change, but I have NOT checked it.
