### PR TITLE
fix - rotating parent should rotate child

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -737,7 +737,7 @@ Crafty.c("2D", {
 		this._origin.y = e.o.y - this._y;
 
 		//modify through the setter method
-		this._attr('_rotation', e.theta);
+		this._attr('_rotation', this._rotation - e.deg);
 	},
 
 	/**@

--- a/tests/core.html
+++ b/tests/core.html
@@ -298,6 +298,24 @@ $(document).ready(function() {
 		Crafty("*").destroy();
 	});
 
+	test("child_rotate", function () {
+		var parent = Crafty.e("2D, DOM, Color")
+			.attr({x:0, y:0, w:50, h:50, rotation:10})
+			.color("red");
+		var child = Crafty.e("2D, DOM, Color")
+			.attr({x:1, y:1, w:50, h:50, rotation:15})
+			.color("red");
+		parent.attach(child);
+		parent.rotation += 20;
+		strictEqual(parent.rotation, 30, 'parent rotates normally');
+		strictEqual(child.rotation, 35, 'child follows parent rotation');
+		child.rotation += 22;
+		strictEqual(parent.rotation, 30, 'parent ignores child rotation');
+		strictEqual(child.rotation, 57, 'child rotates normally');
+		// Clean up
+		Crafty("*").destroy();
+	});
+
 	test("SAT", function () {
 		var e = Crafty.e("2D, Collision");
 		var c1 = new Crafty.circle(100, 100, 10);


### PR DESCRIPTION
Previous behavior: Rotating parent caused child rotation to be undefined
Now: Rotating parent rotates the child as expected.

Added unit test that failed before, but passes now.

See issue #378.

Unlike the proposal in #378, this change does not have a side-effect
that messes up collision polygon rotation. (I checked that collision
polygon rotation was correct both before and after this change.)
