### PR TITLE
fix -- .each documentation was not copied to website

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -620,6 +620,7 @@
 
         /**@
         * #.each
+        * @comp Crafty Core
         * @sign public this .each(Function method)
         * @param method - Method to call on each iteration
         * Iterates over found entities, calling a function for every entity.


### PR DESCRIPTION
I don't know exactly how the documentation-generation works, but based
on the model of other similar functions, I bet that the problem is the
missing @comp line.
