### PR TITLE
Allow an alternate stage element to be provided

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -770,8 +770,8 @@
         * Uses `requestAnimationFrame` to sync the drawing with the browser but will default to `setInterval` if the browser does not support it.
         * @see Crafty.stop,  Crafty.viewport
         */
-        init: function (w, h) {
-            Crafty.viewport.init(w, h);
+        init: function (w, h, stage_elem) {
+            Crafty.viewport.init(w, h, stage_elem);
 
             //call all arbitrary functions attached to onload
             this.trigger("Load");
@@ -813,7 +813,7 @@
         	    Crafty.audio.remove();
         		if (Crafty.stage && Crafty.stage.elem.parentNode) {
         			var newCrStage = document.createElement('div');
-        			newCrStage.id = "cr-stage";
+        			newCrStage.id = Crafty.stage.elem.id;
         			Crafty.stage.elem.parentNode.replaceChild(newCrStage, Crafty.stage.elem);
         		}
         		initState();

--- a/src/core.js
+++ b/src/core.js
@@ -755,11 +755,13 @@
         * @category Core
         * @trigger EnterFrame - on each frame - { frame: Number }
         * @trigger Load - Just after the viewport is initialised. Before the EnterFrame loops is started
-        * @sign public this Crafty.init([Number width, Number height])
-        * @param width - Width of the stage
-        * @param height - Height of the stage
-        * 
-        * Create a div with id `cr-stage`, if there is not already an HTMLElement with id `cr-stage` (by `Crafty.viewport.init`).
+        * @sign public this Crafty.init([Number width, Number height, String stage_elem])
+        * @sign public this Crafty.init([Number width, Number height, HTMLElement stage_elem])
+        * @param Number width - Width of the stage
+        * @param Number height - Height of the stage
+        * @param String or HTMLElement stage_elem - the element to use for the stage    
+        *
+        * Sets the element to use as the stage, creating it if necessary.  By default a div with id 'cr-stage' is used, but if the 'stage_elem' argument is provided that will be used instead.  (see `Crafty.viewport.init`)     
         *
         * Starts the `EnterFrame` interval. This will call the `EnterFrame` event for every frame.
         *

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -823,7 +823,7 @@ Crafty.extend({
          *
          * @see Crafty.device, Crafty.DOM, Crafty.stage
          */
-        init: function (w, h) {
+        init: function (w, h, stage_elem) {
             Crafty.DOM.window.init();
 
             //fullscreen if mobile or not specified
@@ -831,7 +831,16 @@ Crafty.extend({
             this.height = (!h || Crafty.mobile) ? Crafty.DOM.window.height : h;
 
             //check if stage exists
-            var crstage = document.getElementById("cr-stage");
+            if(typeof stage_elem === 'undefined')
+                stage_elem = "cr-stage";
+
+            var crstage;
+            if(typeof stage_elem === 'string')
+                crstage = document.getElementById(stage_elem);
+            else if(typeof HTMLElement !== "undefined" ? stage_elem instanceof HTMLElement : stage_elem instanceof Element)
+                crstage = stage_elem;
+            else
+                throw new TypeError("stage_elem must be a string or an HTMLElement");
 
             /**@
              * #Crafty.stage
@@ -906,7 +915,7 @@ Crafty.extend({
             //add to the body and give it an ID if not exists
             if (!crstage) {
                 document.body.appendChild(Crafty.stage.elem);
-                Crafty.stage.elem.id = "cr-stage";
+                Crafty.stage.elem.id = stage_elem;
             }
 
             var elem = Crafty.stage.elem.style,

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -814,12 +814,15 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.init
          * @comp Crafty.viewport
-         * @sign public void Crafty.viewport.init([Number width, Number height])
-         * @param width - Width of the viewport
-         * @param height - Height of the viewport
+         * @sign public void Crafty.viewport.init([Number width, Number height, String stage_elem])
+         * @sign public void Crafty.viewport.init([Number width, Number height, HTMLElement stage_elem])
+         * @param Number width - Width of the viewport
+         * @param Number height - Height of the viewport
+         * @param String or HTMLElement stage_elem - the element to use as the stage (either its id or the actual element).
          *
          * Initialize the viewport. If the arguments 'width' or 'height' are missing, or Crafty.mobile is true, use Crafty.DOM.window.width and Crafty.DOM.window.height (full screen model).
-         * Create a div with id `cr-stage`, if there is not already an HTMLElement with id `cr-stage` (by `Crafty.viewport.init`).
+         *
+         * The argument 'stage_elem' is used to specify a stage element other than the default, and can be either a string or an HTMLElement.  If a string is provided, it will look for an element with that id and, if none exists, create a div.  If an HTMLElement is provided, that is used directly.  Omitting this argument is the same as passing an id of 'cr-stage'.
          *
          * @see Crafty.device, Crafty.DOM, Crafty.stage
          */


### PR DESCRIPTION
This is just #442 but with documentation added.  Copying the original message  by @smartboyathome below:

> I needed to have Crafty use an element other than a div with id 'cr-stage', and I noticed that the support for a modular stage element was already there with Crafty.stage.elem, but there were a couple references to 'cr-stage' still in the code. I updated Crafty.init(w, h) and Crafty.viewport.init(w, h) to take an optional stage_elem parameter that could be either a string or an HTMLElement (known as just an Element in IE8). If no parameter is given, it defaults to the original behavior of finding an element with id cr-stage and, if none exists, creating it under 'body'. In addition to this, I updated the stop function to set the id of the replacement div for stage with the id from the original stage element. Please look it over and let me know what you think.

I'll merge this soon unless someone spots something wrong with the docs, or the actual patch.  The code doesn't allow you to provide the stage element if you don't provide the width or height; does that matter?
