### PR TITLE
Provide default family and size for text

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -20,14 +20,17 @@ Crafty.c("Text", {
 		"size": "",
 		"family": ""
 	},
+	defaultSize: "10px",
+	defaultFamily: "sans-serif",
 	ready: true,
 
 	init: function () {
 		this.requires("2D");
 
 		this.bind("Draw", function (e) {
-			var font = this._textFont["type"] + ' ' + this._textFont["weight"] + ' ' +
-				this._textFont["size"] + ' ' + this._textFont["family"];
+			var font = this._textFont["type"] + ' ' + this._textFont["weight"] + ' '
+			 	+ (this._textFont["size"] || this.defaultSize) + ' ' 
+				+ (this._textFont["family"] || this.defaultFamily);
 
 			if (e.type === "DOM") {
 				var el = this._element,

--- a/src/text.js
+++ b/src/text.js
@@ -4,6 +4,8 @@
 * @trigger Change - when the text is changed
 * @requires Canvas or DOM
 * Component to make a text entity.
+*
+* By default, text will have the style "10px sans-serif".
 * 
 * Note: An entity with the text component is just text! If you want to write text
 * inside an image, you need one entity for the text and another entity for the image.


### PR DESCRIPTION
According to the CSS spec, you can't set the font family and size independently.  That means we need to provide defaults.  I chose "10px sans-serif" as the default, since that is apparently what the [canvas uses](https://developer.mozilla.org/en-US/docs/Drawing_text_using_a_canvas).

This mostly fixes #337.  @attonnnn is probably right that being able to set a global default would make sense; any suggestions on the best approach there?  Something as straightforward as just having a `Crafty.defaultTextSize` property?  Or should it be a property of the component somehow?
