### PR TITLE
Return early from _attr when there is no change in the value of the attribute.

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -747,6 +747,10 @@ Crafty.c("2D", {
 	* x, y, w, h, alpha, rotation and visible.
 	*/
 	_attr: function (name, value) {
+		// Return if there is no change
+		if (this[name] === value){
+			return
+		}
 		//keep a reference of the old positions
 		var pos = this.pos(),
 			old = this.mbr() || pos;


### PR DESCRIPTION
This prevents any unnecessary events from being triggered.  This _should_ fix #363.
