### PR TITLE
If necessary, scale canvas on creation

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -172,7 +172,7 @@ Crafty.extend({
 				return;
 			}
 
-			//create 3 empty canvas elements
+			//create an empty canvas element
 			var c;
 			c = document.createElement("canvas");
 			c.width = Crafty.viewport.width;
@@ -184,6 +184,11 @@ Crafty.extend({
 			Crafty.stage.elem.appendChild(c);
 			Crafty.canvas.context = c.getContext('2d');
 			Crafty.canvas._canvas = c;
+
+			//Set any existing transformations
+			var zoom = Crafty.viewport._zoom
+			if (zoom != 1)
+				Crafty.canvas.context.scale(zoom, zoom);
 		}
 	}
 });


### PR DESCRIPTION
If you call `viewport.scale` before a canvas is created, any future "Canvas" elements will be unaware of this scaling.    This patch checks `Crafty.viewport._zoom` when the canvas is created, and scales the context if necessary.

This should fix #390

(I also fixed an odd comment that claimed three canvas elements were created.)
