### PR TITLE
Add Crafty.viewport.absoluteScale()

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -724,6 +724,66 @@ Crafty.extend({
             }
         })(),
         /**@
+         * #Crafty.viewport.absoluteScale
+         * @comp Crafty.viewport
+         * @sign public void Crafty.viewport.absoluteScale(Number scaleFactor)
+         * @param Number scaleFactor - scale factor relative to original pixels (eg. 2, 4, 0.5)
+         *
+         * Scales the entire canvas by the given factor.
+         *   1.0 = entities render 1:1 between screen pixels and canvas coordinates
+         *   0.5 = entities render at half scale
+         *   2.0 = entities render at 2x scale
+         *
+         * Absolute scale is not cumulative. New scaleFactor will *replace* any previous scaling.
+         *
+         * @example
+         * ~~~
+         * Crafty.init();
+         * Crafty.canvas.init();
+         *
+         * var original = { w: Crafty.viewport.width, h: Crafty.viewport.height };
+         * var scaler = function() {
+         *   var current = { w: Crafty.viewport.width, h: Crafty.viewport.height };
+         *
+         *   // This will reset the scale when it adjusts the canvas element
+         *   // dimensions, so do it right before setting the scale we want.
+         *   Crafty.viewport.reload();
+         *
+         *   if ( current.w > current.h ) {
+         *     // Landscape, scale to fit height
+         *     Crafty.viewport.absoluteScale( current.h / original.h );
+         *   } else {
+         *     // Portrait, scale to fit width
+         *     Crafty.viewport.absoluteScale( current.w / original.w );
+         *   }
+         * };
+         *
+         * // Avoid drawing entities before we're ready to scale.
+         * Crafty.removeEvent( Crafty, window, 'resize', Crafty.viewport.reload );
+         *
+         * // Adjust scale to fit inside resized window.
+         * Crafty.addEvent( Crafty, window, 'resize', scaler );
+         *
+         * // Run the scaler after scene changes, since they reset the scale.
+         * Crafty.bind( 'SceneChange', scaler );
+         * ~~~
+         */
+        absoluteScale: function (scaleFactor) {
+            var ctx = Crafty.canvas.context;
+
+            // Clear entire canvas; scaling invalidates dirty rects and leaves artifacts behind.
+            ctx.save();
+            ctx.setTransform(1,0,0,1,0,0);
+            ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+            ctx.restore();
+
+            // Trick Crafty.viewport.scale into operating in absolute mode.
+            Crafty.stage.inner.style['transform'] =
+                Crafty.stage.inner.style[Crafty.support.prefix + "Transform"] = 'scale(1, 1)';
+            Crafty.viewport._zoom = 1;
+            Crafty.viewport.scale(scaleFactor);
+        },
+        /**@
          * #Crafty.viewport.mouselook
          * @comp Crafty.viewport
          * @sign public void Crafty.viewport.mouselook(Boolean active)


### PR DESCRIPTION
### Resolution independence: The problem

I need my games to scale to fit the browser window, or at least select something close from a list of known good resolutions. Unfortunately, Crafty's viewport system is working against me. Looking at other open issues, it seems like a common pain point.
### Crafty today

I can't figure out the use case for `Crafty.viewport.scale`. It doesn't work at all for my purposes. Where it applies a cumulative scale factor, I need to apply an absolute scale factor calculated from the window size. Additionally, Crafty resets the canvas transform all by itself when the scene changes or the browser is resized. I need to apply a scale factor that overrides everything else for the lifetime of the game.
### One solution

The existing `Crafty.viewport.scale` method applies the new scale as a multiplier against the old scale. This pull request adds a `Crafty.viewport.absoluteScale` method that sets the scale absolutely, regardless of the old scale. Calling `scale(0.5)` twice results in a scale of 0.25. Calling `absoluteScale(0.5)` twice results in a scale of 0.5. This is useful when scaling the stage in response to browser window resize events. 

Unfortunately, this doesn't fix Crafty's incompatibility between viewport scaling and panning in a mixed Canvas/DOM setting (see [fiddle](http://jsfiddle.net/JUxyE/3/)). It looks like setting `Crafty.viewport.x = 5` (or panning) moves DOM elements by 5 screen pixels and canvas elements by 5 scaled pixels, causing alignment problems. The viewport system may be due for rethinking.
### Sample resizing code

Here's some sample code for a Crafty app that can scale the viewport in response to the browser window size ([fiddle here](http://jsfiddle.net/JUxyE/4/)):

``` javascript
var Screen = { w: 800, h: 480 };

Crafty.init();
Crafty.canvas.init();

var scaler = function() {
  var current = { w: Crafty.viewport.width, 
                  h: Crafty.viewport.height };

  // This will reset the scale when it adjusts the canvas element
  // dimensions, so do it right before setting the scale we want.
  Crafty.viewport.reload();

  if ( current.w > current.h ) {
    // Landscape, scale to fit height
    Crafty.viewport.absoluteScale( current.h / Screen.h );
  } else {
    // Portrait, scale to fit width
    Crafty.viewport.absoluteScale( current.w / Screen.w )
  }
};

// Avoid drawing entities before we're ready to scale.
Crafty.removeEvent( Crafty, window, 'resize', Crafty.viewport.reload );

// Adjust scale to fit inside resized window.
Crafty.addEvent( Crafty, window, 'resize', scaler );

// Run the scaler after scene changes, since they reset the scale.
Crafty.bind( 'SceneChange', scaler );
```
### Discussion

Thoughts? Is there a better way to go about this? :dancer: 
