### PR TITLE
FIX : Make Color and Sprite component work together for DOM elements

### DIFF
--- a/src/drawing.js
+++ b/src/drawing.js
@@ -10,7 +10,7 @@ Crafty.c("Color", {
 	init: function () {
 		this.bind("Draw", function (e) {
 			if (e.type === "DOM") {
-				e.style.background = this._color;
+				e.style.backgroundColor = this._color;
 				e.style.lineHeight = 0;
 			} else if (e.type === "canvas") {
 				if (this._color) e.ctx.fillStyle = this._color;
@@ -30,7 +30,7 @@ Crafty.c("Color", {
 	*
 	* The argument must be a color readable depending on which browser you
 	* choose to support. IE 8 and below doesn't support the rgb() syntax.
-	* 
+	*
 	* @example
 	* ~~~
 	* Crafty.e("2D, DOM, Color")
@@ -76,9 +76,9 @@ Crafty.c("Tint", {
 	* @sign public this .tint(String color, Number strength)
 	* @param color - The color in hexadecimal
 	* @param strength - Level of opacity
-	* 
+	*
 	* Modify the color and level opacity to give a tint on the entity.
-	* 
+	*
 	* @example
 	* ~~~
 	* Crafty.e("2D, Canvas, Tint")
@@ -110,9 +110,9 @@ Crafty.c("Image", {
 				if (!this.ready || !this._pattern) return;
 
 				var context = e.ctx;
-				
+
 				context.fillStyle = this._pattern;
-				
+
 				context.save();
 				context.translate(e.pos._x, e.pos._y);
 				context.fillRect(0, 0, this._w, this._h);
@@ -135,7 +135,7 @@ Crafty.c("Image", {
 	* @sign public this .image(String url[, String repeat])
 	* @param url - URL of the image
 	* @param repeat - If the image should be repeated to fill the entity.
-	* 
+	*
 	* Draw specified image. Repeat follows CSS syntax (`"no-repeat", "repeat", "repeat-x", "repeat-y"`);
 	*
 	* *Note: Default repeat is `no-repeat` which is different to standard DOM (which is `repeat`)*
@@ -143,7 +143,7 @@ Crafty.c("Image", {
 	* If the width and height are `0` and repeat is set to `no-repeat` the width and
 	* height will automatically assume that of the image. This is an
 	* easy way to create an image without needing sprites.
-	* 
+	*
 	* @example
 	* Will default to no-repeat. Entity width and height will be set to the images width and height
 	* ~~~
@@ -155,7 +155,7 @@ Crafty.c("Image", {
 	*              .attr({w: Crafty.viewport.width, h: Crafty.viewport.height})
 	*              .image("bg.png", "repeat");
 	* ~~~
-	* 
+	*
 	* @see Crafty.sprite
 	*/
 	image: function (url, repeat) {
@@ -212,7 +212,7 @@ Crafty.extend({
 	* @param uninit - Function to execute before next scene is played, after entities with `2D` are destroyed
 	* @sign public void Crafty.scene(String sceneName)
 	* @param sceneName - Name of scene to play
-	* 
+	*
 	* Method to create scenes on the stage. Pass an ID and function to register a scene.
 	*
 	* To play a scene, just pass the ID. When a scene is played, all
@@ -258,7 +258,7 @@ Crafty.extend({
 		// this._scenes is an object like the following:
 		// {'Opening scene': {'initialize': fnA, 'uninitialize': fnB},
 		//  'Another scene': {'initialize': fnC, 'uninitialize': fnD}}
-		
+
 		// If there's one argument, play the scene
 		if (arguments.length === 1) {
 			Crafty.viewport.reset();
@@ -276,7 +276,7 @@ Crafty.extend({
 			Crafty.trigger("SceneChange", { oldScene: oldScene, newScene: name });
 			return;
 		}
-		
+
 		// If there is more than one argument, add the scene information to _scenes
 		this._scenes[name] = {};
 		this._scenes[name].initialize = intro;
@@ -292,16 +292,16 @@ Crafty.extend({
 	* @sign public String Crafty.scene(String hex[, Number alpha])
 	* @param hex - a 6 character hex number string representing RGB color
 	* @param alpha - The alpha value.
-	* 
+	*
 	* Get a rgb string or rgba string (if `alpha` presents).
-	* 
+	*
 	* @example
 	* ~~~
 	* Crafty.toRGB("ffffff"); // rgb(255,255,255)
 	* Crafty.toRGB("#ffffff"); // rgb(255,255,255)
 	* Crafty.toRGB("ffffff", .5); // rgba(255,255,255,0.5)
 	* ~~~
-	* 
+	*
 	* @see Text.textColor
 	*/
 	toRGB: function (hex, alpha) {
@@ -322,7 +322,7 @@ Crafty.extend({
 * #Crafty.DrawManager
 * @category Graphics
 * @sign Crafty.DrawManager
-* 
+*
 * An internal object manage objects to be drawn and implement
 * the best method of drawing in both DOM and canvas
 */
@@ -336,7 +336,7 @@ Crafty.DrawManager = (function () {
 		/**@
 		* #Crafty.DrawManager.total2D
 		* @comp Crafty.DrawManager
-		* 
+		*
 		* Total number of the entities that have the `2D` component.
 		*/
 		total2D: Crafty("2D").length,
@@ -346,7 +346,7 @@ Crafty.DrawManager = (function () {
 		* @comp Crafty.DrawManager
 		* @sign public Crafty.DrawManager.onScreen(Object rect)
 		* @param rect - A rectangle with field {_x: x_val, _y: y_val, _w: w_val, _h: h_val}
-		* 
+		*
 		* Test if a rectangle is completely in viewport
 		*/
 		onScreen: function (rect) {
@@ -359,7 +359,7 @@ Crafty.DrawManager = (function () {
 		* @comp Crafty.DrawManager
 		* @sign public Object Crafty.DrawManager.merge(Object set)
 		* @param set - an array of rectangular regions
-		* 
+		*
 		* Merged into non overlapping rectangular region
 		* Its an optimization for the redraw regions.
 		*/
@@ -408,7 +408,7 @@ Crafty.DrawManager = (function () {
 		* @sign public Crafty.DrawManager.add(old, current)
 		* @param old - Undocumented
 		* @param current - Undocumented
-		* 
+		*
 		* Calculate the bounding rect of dirty data and add to the register of dirty rectangles
 		*/
 		add: function add(old, current) {
@@ -531,7 +531,7 @@ Crafty.DrawManager = (function () {
 		*	do the naive method redrawing `Crafty.DrawManager.drawAll`
 		* - Otherwise, clear the dirty regions, and redraw entities overlapping the dirty regions.
 		* ~~~
-		* 
+		*
         * @see Canvas.draw, DOM.draw
 		*/
 		draw: function draw() {

--- a/src/sprite.js
+++ b/src/sprite.js
@@ -47,7 +47,8 @@ Crafty.c("Sprite", {
 								 pos._h //height on canvas
 				);
 			} else if (e.type === "DOM") {
-				this._element.style.background = "url('" + this.__image + "') no-repeat -" + co.x + "px -" + co.y + "px";
+				var style = this._element.style;
+				style.background = style.backgroundColor + "url('" + this.__image + "') no-repeat -" + co.x + "px -" + co.y + "px";
 			}
 		};
 
@@ -64,7 +65,7 @@ Crafty.c("Sprite", {
 	* @param y - Y cell position
 	* @param w - Width in cells
 	* @param h - Height in cells
-	* 
+	*
 	* Uses a new location on the sprite map as its sprite.
 	*
 	* Values should be in tiles or cells (not pixels).
@@ -100,7 +101,7 @@ Crafty.c("Sprite", {
 	* @param y - Offset y position
 	* @param w - New width
 	* @param h - New height
-	* 
+	*
 	* If the entity needs to be smaller than the tile size, use this method to crop it.
 	*
 	* The values should be in pixels rather than tiles.

--- a/src/sprite.js
+++ b/src/sprite.js
@@ -48,7 +48,7 @@ Crafty.c("Sprite", {
 				);
 			} else if (e.type === "DOM") {
 				var style = this._element.style;
-				style.background = style.backgroundColor + "url('" + this.__image + "') no-repeat -" + co.x + "px -" + co.y + "px";
+				style.background = style.backgroundColor + " url('" + this.__image + "') no-repeat -" + co.x + "px -" + co.y + "px";
 			}
 		};
 


### PR DESCRIPTION
When using DOM rendering on a sprite created from a spritesheet, the `color()` method was ineffective (but it works in Canvas mode).

A good test for this is the ['Sprites and Components' tutorial by craftyjstut](https://github.com/starmelt/craftyjstut/tree/master/firststeps/2_components_and_sprites) (change Canvas to DOM in the tutorial)

PS. _I'm really sorry for the dirty commit with the trailing spaces removed by my editor_, but hope you can follow it as it is simple enough.. I have another pull request following this one, so it'd be hard for me to redo it again from start..
