### PR TITLE
Use floor/ceiling instead of round when calculating MBR. 

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -355,10 +355,10 @@ Crafty.c("2D", {
 			y2 = o.y - (this._x + this._w - o.x) * st + (this._y + this._h - o.y) * ct,
 			x3 = o.x + (this._x - o.x) * ct + (this._y + this._h - o.y) * st,
 			y3 = o.y - (this._x - o.x) * st + (this._y + this._h - o.y) * ct,
-			minx = Math.round(Math.min(x0, x1, x2, x3)),
-			miny = Math.round(Math.min(y0, y1, y2, y3)),
-			maxx = Math.round(Math.max(x0, x1, x2, x3)),
-			maxy = Math.round(Math.max(y0, y1, y2, y3));
+			minx = Math.floor(Math.min(x0, x1, x2, x3)),
+			miny = Math.floor(Math.min(y0, y1, y2, y3)),
+			maxx = Math.ceil(Math.max(x0, x1, x2, x3)),
+			maxy = Math.ceil(Math.max(y0, y1, y2, y3));
 
 		this._mbr = { _x: minx, _y: miny, _w: maxx - minx, _h: maxy - miny };
 


### PR DESCRIPTION
To ensure that the rendered entity lies within the MBR, we need to take the floor of the minimum coords, and the ceiling of the maximum.  Consider: if minx = 0.7, and maxx=9.3, then with rounding the calculated width will be 8, which is not large enough to contain the true width of 8.6.
