### PR TITLE
some improvements to text

### DIFF
--- a/demos/asteroids/game.js
+++ b/demos/asteroids/game.js
@@ -26,7 +26,7 @@ $(document).ready(function() {
 		var score = Crafty.e("2D, DOM, Text")
 			.text("Score: 0")
 			.attr({x: Crafty.viewport.width - 300, y: Crafty.viewport.height - 50, w: 200, h:50})
-			.css({color: "#fff"});
+			.textColor("#FFFFFF");
 			
 		//player entity
 		var player = Crafty.e("2D, Canvas, ship, Controls, Collision")

--- a/demos/connect4/connect4.js
+++ b/demos/connect4/connect4.js
@@ -73,9 +73,9 @@ window.onload = function () {
 	
 	Crafty.scene("win", function() {
 		var bg = Crafty.e("2D, DOM, Image").image("images/win.png", "no-repeat").attr({w: 600, h: 500, z: -1});
-		Crafty.e("2D, DOM, Text").attr({x: 220, y: 200}).text(turn ? "RED" : "YELLOW").css({
-        "font-family": "Arial"
-        , "font-size": "30pt"
+		Crafty.e("2D, DOM, Text").attr({x: 220, y: 200}).text(turn ? "RED" : "YELLOW").textFont({
+        "family": "Arial"
+        , "size": "30pt"
       });
 	});
 

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -239,8 +239,8 @@ Crafty.c("DOM", {
 	*
 	* To return a value, pass the property.
 	* 
-	* Note: For text elements, some css properties are controlled by separate functions
-    * `.textFont()` and `.textColor()`, and ignore `.css()` settings. See Text component for details.
+	* Note: For entities with "Text" component, some css properties are controlled by separate functions
+	* `.textFont()` and `.textColor()`, and ignore `.css()` settings. See Text component for details.
 	* 
 	* @example
 	* ~~~

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -239,9 +239,12 @@ Crafty.c("DOM", {
 	*
 	* To return a value, pass the property.
 	* 
+	* Note: For text elements, some css properties are controlled by separate functions
+    * `.textFont()` and `.textColor()`, and ignore `.css()` settings. See Text component for details.
+	* 
 	* @example
 	* ~~~
-	* this.css({'text-align', 'center', font: 'Arial'});
+	* this.css({'text-align', 'center', 'text-decoration': 'line-through'});
 	* this.css("textAlign", "center");
 	* this.css("text-align"); //returns center
 	* ~~~

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -229,7 +229,8 @@ Crafty.extend({
 	*     Crafty.e("2D, DOM, Text")
 	*           .attr({ w: 100, h: 20, x: 150, y: 120 })
 	*           .text("Loading")
-	*           .css({ "text-align": "center", "color": "#FFF" });
+	*           .css({ "text-align": "center"})
+    *           .textColor("#FFFFFF");
 	* });
 	*
 	* Crafty.scene("UFO_dance",

--- a/src/text.js
+++ b/src/text.js
@@ -7,12 +7,17 @@
 *
 * By default, text will have the style "10px sans-serif".
 * 
-* Note: An entity with the text component is just text! If you want to write text
+* Note 1: An entity with the text component is just text! If you want to write text
 * inside an image, you need one entity for the text and another entity for the image.
 * More tips for writing text inside an image: (1) Use the z-index (from 2D component)
 * to ensure that the text is on top of the image, not the other way around; (2)
 * use .attach() (from 2D component) to glue the text to the image so they move and
 * rotate together.
+* 
+* Note 2: For DOM (but not canvas) text entities, various font settings (like
+* text-decoration and text-align) can be set using `.css()` (see DOM component). But
+* you cannot use `.css()` to set the properties which are controlled by `.textFont()`
+* or `.textColor()` -- the settings will be ignored.
 */
 Crafty.c("Text", {
 	_text: "",
@@ -69,7 +74,6 @@ Crafty.c("Text", {
     * @param text - String of text that will be inserted into the DOM or Canvas element.
     * 
     * This method will update the text inside the entity.
-    * If you use DOM, to modify the font, use the `.css` method inherited from the DOM component.
     *
     * If you need to reference attributes on the entity itself you can pass a function instead of a string.
     * 
@@ -162,5 +166,34 @@ Crafty.c("Text", {
 
 		this.trigger("Change");
 		return this;
+	},
+	/**@
+    * #.unselectable
+    * @comp Text
+    * @triggers Change
+    * @sign public this .unselectable()
+    *
+    * This method sets the text so that it cannot be selected (highlighted) by dragging.
+    * (Canvas text can never be highlighted, so this only matters for DOM text.)
+    * Works by changing the css property "user-select" and its variants.
+    * 
+    * @example
+    * ~~~
+    * Crafty.e("2D, DOM, Text").text('This text cannot be highlighted!').unselectable();
+    * ~~~
+    */
+	unselectable: function () {
+		// http://stackoverflow.com/questions/826782/css-rule-to-disable-text-selection-highlighting
+		if (this.has("DOM")) {
+			this.css({'-webkit-touch-callout': 'none',
+				'-webkit-user-select': 'none',
+				'-khtml-user-select': 'none',
+				'-moz-user-select': 'none',
+				'-ms-user-select': 'none',
+				'user-select': 'none'});
+			this.trigger("Change");
+		}
+		return this;
 	}
+
 });


### PR DESCRIPTION
Where possible, avoid styling text using css, as it makes it harder to
switch DOM <--> canvas (see complaint at
http://buildnewgames.com/game-engine-comparison/), and doesn't always
work anyway. Also, add .unselectable() method
