### PR TITLE
fix bug where particles can appear in wrong place

### DIFF
--- a/src/particles.js
+++ b/src/particles.js
@@ -66,6 +66,8 @@ Crafty.c("Particles", {
 		c.width = Crafty.viewport.width;
 		c.height = Crafty.viewport.height;
 		c.style.position = 'absolute';
+		c.style.left = "0px";
+		c.style.top = "0px";
 
 		Crafty.stage.elem.appendChild(c);
 


### PR DESCRIPTION
In firefox and chrome (at least), the canvases can wind up not aligned on the page. This fixes it in my tests. [Thanks Gizmoa.]

Example:
With old crafty: http://jsfiddle.net/4r6FX/11/
With fixed crafty: http://jsfiddle.net/4r6FX/17/
