### PR TITLE
Refactor Crafty.audio

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -173,27 +173,18 @@ Crafty.extend({
            
             obj = Crafty.asset(current) || null;   
           
-            if (Crafty.support.audio && Crafty.audio.supported[ext]) {   
-                //Create new object if not exists
+            if (Crafty.audio.supports(ext)) {   
+                //Create a new asset if necessary, using the file name as an id
                 if(!obj){
                     var name = current.substr(current.lastIndexOf('/') + 1).toLowerCase();
-                    obj = Crafty.audio.audioElement();
-                    obj.id = name;
-                    obj.src = current;
-                    obj.preload = "auto";
-                    obj.volume = Crafty.audio.volume;
-                    Crafty.asset(current, obj);
-                    Crafty.audio.sounds[name] = {
-                        obj:obj,
-                        played:0
-                    } 
-                }
+                    obj = Crafty.audio.create(name, current).obj;
+            	}
         
-                //addEventListener is supported on IE9 , Audio as well
-                if (obj.addEventListener) {  
-                    obj.addEventListener('canplaythrough', pro, false);     
-                }
-                   
+	            //addEventListener is supported on IE9 , Audio as well
+	            if (obj.addEventListener) {  
+	                obj.addEventListener('canplaythrough', pro, false);     
+	            }
+               
                  
             } else if (Crafty.image_whitelist.indexOf(ext) >= 0) { 
                 if(!obj) {

--- a/src/loader.js
+++ b/src/loader.js
@@ -202,6 +202,9 @@ Crafty.extend({
             obj.onerror = err;
         }
        
+       	// If we aren't trying to handle *any* of the files, that's as complete as it gets!
+       	if (total === 0 )
+       		oncomplete();
        
     },
 	/**@


### PR DESCRIPTION
This PR
- Refactors Crafty.audio to remove duplicated code, and allows checking of audio file support with a function instead of checking against an object.
- Changes how we play audio files, so that the same file can be played multiple times at once
- As a consequence, there is now a maximum number of sounds that can be played at once -- this can be set by `Crafty.audio.setChannels(n)`.
- Fixes a couple of bugs with the loading of audio files  (Including #348), and in using Crafty.load when no file types are supported.

Other than the max number of channels, there are no breaking changes to the audio API.  I set the default to 7, but we could raise that if more simultaneous sounds are common.

I didn't add any unit tests to this set of changes, but did make a little "audio playground" and verified that the various play, pause, stop, and mute functions worked correctly.

_e:_ Rebased to fix an off-by-one error in setChannels when reducing the number.
