### PR TITLE
Fix within and contains methods

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -421,18 +421,18 @@ Crafty.c("2D", {
 	* @param h - Height of the rect
 	* @sign public Boolean .intersect(Object rect)
 	* @param rect - An object that must have the `x, y, w, h` values as properties
-	* Determines if this entity intersects a rectangle.
+	* Determines if this entity intersects a rectangle.  If the entity is rotated, its MBR is used for the test.
 	*/
 	intersect: function (x, y, w, h) {
-		var rect, obj = this._mbr || this;
+		var rect, mbr = this._mbr || this;
 		if (typeof x === "object") {
 			rect = x;
 		} else {
 			rect = { x: x, y: y, w: w, h: h };
 		}
 
-		return obj._x < rect.x + rect.w && obj._x + obj._w > rect.x &&
-			   obj._y < rect.y + rect.h && obj._h + obj._y > rect.y;
+		return mbr._x < rect.x + rect.w && mbr._x + mbr._w > rect.x &&
+			   mbr._y < rect.y + rect.h && mbr._h + mbr._y > rect.y;
 	},
 
 	/**@
@@ -448,15 +448,15 @@ Crafty.c("2D", {
 	* Determines if this current entity is within another rectangle.
 	*/
 	within: function (x, y, w, h) {
-		var rect;
+		var rect, mbr = this._mbr || this;
 		if (typeof x === "object") {
 			rect = x;
 		} else {
 			rect = { x: x, y: y, w: w, h: h };
 		}
 
-		return rect.x <= this.x && rect.x + rect.w >= this.x + this.w &&
-				rect.y <= this.y && rect.y + rect.h >= this.y + this.h;
+		return rect.x <= mbr.x && rect.x + rect.w >= mbr.x + mbr.w &&
+				rect.y <= mbr.y && rect.y + rect.h >= mbr.y + mbr.h;
 	},
 
 	/**@
@@ -469,18 +469,18 @@ Crafty.c("2D", {
 	* @param h - Height of the rect
 	* @sign public Boolean .contains(Object rect)
 	* @param rect - An object that must have the `x, y, w, h` values as properties
-	* Determines if the rectangle is within the current entity.
+	* Determines if the rectangle is within the current entity.  If the entity is rotated, its MBR is used for the test.
 	*/
 	contains: function (x, y, w, h) {
-		var rect;
+		var rect, mbr = this._mbr || this;
 		if (typeof x === "object") {
 			rect = x;
 		} else {
 			rect = { x: x, y: y, w: w, h: h };
 		}
 
-		return rect.x >= this.x && rect.x + rect.w <= this.x + this.w &&
-				rect.y >= this.y && rect.y + rect.h <= this.y + this.h;
+		return rect.x >= mbr.x && rect.x + rect.w <= mbr.x + mbr.w &&
+				rect.y >= mbr.y && rect.y + rect.h <= mbr.y + mbr.h;
 	},
 
 	/**@

--- a/tests/core.html
+++ b/tests/core.html
@@ -251,6 +251,58 @@ $(document).ready(function() {
 		// Clean up
 		Crafty("*").destroy();
 	});
+
+	test("within", function() {
+		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50});
+		player.x = 0;
+		player.y = 0;
+		player.w = 50;
+		player.h = 50;
+		
+		strictEqual(player.within(0, 0, 50, 50), true, "Within");
+
+		strictEqual(player.within(-1, -1, 51, 51), true, "Within");
+
+
+		strictEqual(player.within({x: 0, y: 0, w: 50, h: 50}), true, "Within Again");
+
+		strictEqual(player.within(0, 0, 40, 50), false, "Wasn't within");
+
+		player.rotation = 90;	// Once rotated, the entity should no longer be within the rectangle
+
+		strictEqual(player.within(0, 0, 50, 50), false, "Rotated, Not within");
+
+		
+		// Clean up
+		Crafty("*").destroy();
+	});
+
+	test("contains", function() {
+		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50});
+		player.x = 0;
+		player.y = 0;
+		player.w = 50;
+		player.h = 50;
+		
+
+		strictEqual(player.contains(0, 0, 50, 50), true, "Contains");
+
+		strictEqual(player.contains(1, 1, 49, 49), true, "Contains");
+
+		strictEqual(player.contains({x: 0, y: 0, w: 50, h: 50}), true, "Contains");
+
+		strictEqual(player.contains(1, 1, 51, 51), false, "Doesn't contain");
+
+		player.rotation = 90;
+
+		strictEqual(player.contains(0, 0, 50, 50), false, "Rotated, no longer contains");
+
+		
+		// Clean up
+		Crafty("*").destroy();
+	});
+
+
 	
 	test("circle", function() {
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50}).color("red");
@@ -413,7 +465,7 @@ $(document).ready(function() {
 			equal( Math.round(e._mbr._x), -50, "_mbr._x is -50");
 			equal( Math.round(e._mbr._y), 0, "_mbr._y is 0");
 
-
+		});
 
 	module("DebugLayer");
 		test("DebugCanvas", function(){


### PR DESCRIPTION
These methods test whether the entity is within or contains an entity.  For a rotated entity, we should test against the MBR.  I mentioned this in the docs, and added some tests.

intersect was considering the MBR already; I tweaked the variable names to match within/contains and added to the docs.

The problem with within was mentioned on the forums: https://groups.google.com/forum/?fromgroups#!topic/craftyjs/8m0NKKRjZ6Q
