### PR TITLE
Adds support for using Crafty as a CommonJS module such as in browserify

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1348,10 +1348,12 @@
 
     initComponents(Crafty, window, window.document);
 
-    //make Crafty global
-    window.Crafty = Crafty;
-
-    if (typeof define === 'function') {
+    // export Crafty
+    if (typeof define === 'function') { // AMD
         define('crafty', [], function() { return Crafty; });
+    } else if (typeof exports === 'object') { // CommonJS
+        module.exports = Crafty;
+    } else { // browser global
+        window.Crafty = Crafty;
     }
 })(window,


### PR DESCRIPTION
There was already support for use as an AMD module, and adding CommonJS support isn't a particularly big addition, so why not?
