### PR TITLE
Add unique and onetime binds

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -553,6 +553,46 @@
         },
 
         /**@
+        * #.uniqueBind
+        * @category Crafty Core
+        * @sign public Number ..uniqueBind(String eventName, Function callback)
+        * @param eventName - Name of the event to bind to
+        * @param callback - Method to execute upon event triggered
+        * @returns ID of the current callback used to unbind
+        * 
+        * Works like Crafty.bind, but prevents a callback from being bound multiple times.
+        * 
+        * @see .bind
+        */
+        uniqueBind: function (event, callback){
+            this.unbind(event, callback)
+            this.bind(event, callback)
+
+        },
+
+        /**@
+        * #.one
+        * @category Crafty Core
+        * @sign public Number one(String eventName, Function callback)
+        * @param eventName - Name of the event to bind to
+        * @param callback - Method to execute upon event triggered
+        * @returns ID of the current callback used to unbind
+        * 
+        * Works like Crafty.bind, but will be unbound once the event triggers.
+        * 
+        * @see .bind
+        */
+        one: function (event, callback){
+            var self = this;
+            var oneHandler = function(){
+                callback();
+                self.unbind(event, oneHandler);
+            }
+            return self.bind(event, oneHandler);
+
+        },
+
+        /**@
         * #.unbind
         * @comp Crafty Core
         * @sign public this .unbind(String eventName[, Function callback])
@@ -1156,6 +1196,47 @@
 
             if (!hdl.global) hdl.global = [];
             return hdl.global.push(callback) - 1;
+        },
+
+
+        /**@
+        * #Crafty.uniqueBind
+        * @category Core, Events
+        * @sign public Number uniqueBind(String eventName, Function callback)
+        * @param eventName - Name of the event to bind to
+        * @param callback - Method to execute upon event triggered
+        * @returns ID of the current callback used to unbind
+        * 
+        * Works like Crafty.bind, but prevents a callback from being bound multiple times.
+        * 
+        * @see Crafty.bind
+        */
+        uniqueBind: function (event, callback){
+            this.unbind(event, callback)
+            this.bind(event, callback)
+
+        },
+
+        /**@
+        * #Crafty.one
+        * @category Core, Events
+        * @sign public Number one(String eventName, Function callback)
+        * @param eventName - Name of the event to bind to
+        * @param callback - Method to execute upon event triggered
+        * @returns ID of the current callback used to unbind
+        * 
+        * Works like Crafty.bind, but will be unbound once the event triggers.
+        * 
+        * @see Crafty.bind
+        */
+        one: function (event, callback){
+            var self = this;
+            var oneHandler = function(){
+                callback();
+                self.unbind(event, oneHandler);
+            }
+            return self.bind(event, oneHandler);
+
         },
 
         /**@

--- a/tests/events.html
+++ b/tests/events.html
@@ -1,0 +1,111 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" 
+                    "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+
+<!-- Note to developers: To run these tests without regenerating crafty.js or
+     setting up a local server:
+       (1) Copy this file into the Crafty parent folder [because firefox security
+             blocks local files from seeing parent folders];
+       (2) Change "../crafty.js" to "./crafty-local.js" (in the HTML head below).
+       (3) Now you can open the HTML file in Firefox.
+       (4) Chrome has more restrictive security, you can pass a flag to loosen
+             the security. Run this command in a Linux terminal:
+             chromium-browser /path/to/core.html --allow-file-access-from-files
+ -->
+
+<head>
+	<script src="http://code.jquery.com/jquery-latest.js"></script>
+	<link rel="stylesheet" href="http://code.jquery.com/qunit/git/qunit.css" type="text/css" media="screen" />
+	<script type="text/javascript" src="http://code.jquery.com/qunit/git/qunit.js"></script>
+	<script type="text/javascript" src="../crafty.js"></script>
+
+<script>
+
+$(document).ready(function() {
+	Crafty.init(500,500);
+	
+	module("EVENTS");
+		
+	test("Global binding events", function() {
+		var x = 0;
+		function add(){x++}
+
+		Crafty.bind("Increment", add)
+		Crafty.trigger("Increment")
+		strictEqual(x, 1, "Crafty.bind fired once");
+		
+
+		x = 0;
+		Crafty.unbind("Increment", add)
+		Crafty.trigger("Increment")
+		strictEqual(x, 0, "Crafty.bind does not fire once unbound");
+
+		x = 0;
+		Crafty.one("Increment", add)
+		Crafty.trigger("Increment")
+		Crafty.trigger("Increment")
+		strictEqual(x, 1, "Event bound by Crafty.one fires exactly once");
+
+		x = 0;
+		Crafty.uniqueBind("Increment", add);
+		Crafty.uniqueBind("Increment", add);
+		Crafty.trigger("Increment");
+		strictEqual(x, 1, "Event bound twice by Crafty.uniqueBound fires only once");
+		
+		x = 0;
+		Crafty.unbind("Increment", add);
+		Crafty.trigger("Increment")
+		strictEqual(x, 0, "uniqueBound does not fire once unbound");
+
+	});
+
+	test("Entity binding events", function() {
+		
+		var x = 0;
+		function add(){x++}
+		var e = Crafty.e("Triggerable")
+
+		e.bind("Increment", add)
+		e.trigger("Increment")
+		strictEqual(x, 1, ".bind fired once");
+		
+
+		x = 0;
+		e.unbind("Increment", add)
+		e.trigger("Increment")
+		strictEqual(x, 0, ".bind does not fire once unbound");
+
+		x = 0;
+		e.one("Increment", add)
+		e.trigger("Increment")
+		e.trigger("Increment")
+		strictEqual(x, 1, "Event bound by .one fires exactly once");
+
+		x = 0;
+		e.uniqueBind("Increment", add);
+		e.uniqueBind("Increment", add);
+		e.trigger("Increment");
+		strictEqual(x, 1, "Event bound twice by .uniqueBound fires only once");
+		
+		x = 0;
+		e.unbind("Increment", add);
+		e.trigger("Increment")
+		strictEqual(x, 0, "uniqueBound does not fire once unbound");
+
+		e.destroy();
+	});
+	
+
+});
+</script>
+  
+</head>
+<body>
+<h1 id="qunit-header">Crafty: Events</h1>
+<h2 id="qunit-banner"></h2>
+<div id="qunit-testrunner-toolbar"></div>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests"></ol>
+<div id="qunit-fixture">test markup, will be hidden</div>
+</body>
+</html>

--- a/tests/events.html
+++ b/tests/events.html
@@ -94,8 +94,92 @@ $(document).ready(function() {
 
 		e.destroy();
 	});
-	
 
+	test("Multiple bound events", function(){
+
+		//Test with entity trigger
+		var temp = Crafty.e('Triggerable');
+		temp.xyz = 0;
+		temp.abc = 0;
+		temp.def = 0;
+		temp.one('Event A', function () {this.xyz++; });
+		temp.bind('Event A', function () {this.abc++; });
+		temp.one('Event A', function () {this.def++; });
+		temp.trigger('Event A');
+		temp.trigger('Event A');
+		strictEqual(temp.xyz, 1, "ENTITY -- first one() should trigger once");
+		strictEqual(temp.abc, 2, "regular event should trigger twice");
+		strictEqual(temp.def, 1, "second one() should trigger once");
+		temp.destroy();
+
+		//Test with global trigger on entity
+		temp = Crafty.e('Triggerable');
+		temp.xyz = 0;
+		temp.abc = 0;
+		temp.def = 0;
+		temp.one('Event A', function () {this.xyz++; });
+		temp.bind('Event A', function () {this.abc++; });
+		temp.one('Event A', function () {this.def++; });
+		Crafty.trigger('Event A');
+		Crafty.trigger('Event A');
+		strictEqual(temp.xyz, 1, "GLOBAL TRIGGER -- first one() should trigger once");
+		strictEqual(temp.abc, 2, "regular event should trigger twice");
+		strictEqual(temp.def, 1, "second one() should trigger once");
+		temp.destroy();
+
+		//Test with global trigger, events bound on global
+		temp=Crafty;
+		temp.xyz = 0;
+		temp.abc = 0;
+		temp.def = 0;
+		temp.one('Event A', function () {this.xyz++; });
+		temp.bind('Event A', function () {this.abc++; });
+		temp.one('Event A', function () {this.def++; });
+		Crafty.trigger('Event A');
+		Crafty.trigger('Event A');
+		strictEqual(temp.xyz, 1, "GLOBAL BIND -- first one() should trigger once");
+		strictEqual(temp.abc, 2, "regular event should trigger twice");
+		strictEqual(temp.def, 1, "second one() should trigger once");
+
+		Crafty.unbind("Event A")
+		
+	});
+
+	test("Data passing", function(){
+		var x = 0, e;
+		function add(data){x+=data.amount}
+		
+		x = 0;
+		e = Crafty.e("Triggerable")
+		e.bind("Increment", add)
+		e.trigger("Increment", {amount:2})
+		strictEqual(x, 2, "data passed correctly with .bind");
+		e.destroy();
+
+		x = 0;
+		e = Crafty.e("Triggerable")
+		e.one("Increment", add)
+		e.trigger("Increment", {amount:2})
+		strictEqual(x, 2, "data passed correctly with .one");
+		e.destroy();
+
+		x = 0;
+		Crafty.bind("Increment", add)
+		Crafty.trigger("Increment", {amount:2})
+		strictEqual(x, 2, "data passed correctly with Crafty.bind");
+		Crafty.unbind("Increment")
+
+		x = 0;
+		Crafty.one("Increment", add)
+		Crafty.trigger("Increment", {amount:3})
+		strictEqual(x, 3, "data passed correctly with Crafty.one");
+		Crafty.unbind("Increment")
+
+
+
+
+	});
+			
 });
 </script>
   


### PR DESCRIPTION
This adds two types of special binding methods.  I don't like the current names, though!  :)
- `. uniqueBind()` prevents the same event from being bound more than once
- `.one()` binds an event, and removes it once triggered.

Just as we have `Crafty.bind()` and `entity.bind()`, there are two versions of these.  I also added some basic qunit tests for binding/triggering them.

TODO: The current implementation is very straightforward (just exactly what I found myself doing in my own code) but could certainly be optimized.   Also, there are probably places in the base code where we should switch to using these.  I just wanted to get the basic functionality landed.

**_About the names**_
- `.one()` is what jQuery uses for the same functionality, so I copied them.  It's short, but I don't think it's a very intuitive name.
- `uniqueBind()` is ungainly, but at least describes what it does.

If you can come up with some better names, please let me know.  :)
