### PR TITLE
Add the ability for components to run a special function on removal/destruction

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -363,15 +363,19 @@
         * ~~~
         */
         removeComponent: function (id, soft) {
-            if (soft === false) {
-                var props = components[id], prop;
-                for (prop in props) {
+            var comp = components[id];
+            this.trigger("RemoveComponent", id);
+            if (comp && "remove" in comp){
+                comp.remove.call(this, false);
+            }
+            if (soft === false && comp) {
+                for (var prop in comp) {
                     delete this[prop];
                 }
             }
             delete this.__c[id];
 
-            this.trigger("RemoveComponent", id);
+            
             return this;
         },
 
@@ -729,7 +733,13 @@
         destroy: function () {
             //remove all event handlers, delete from entities
             this.each(function () {
+                var comp;
                 this.trigger("Remove");
+                for (var compName in this.__c){
+                    comp = components[compName];                    
+                    if (comp && "remove" in comp)
+                        comp.remove.call(this, true);                   
+                }
                 for (var e in handlers) {
                     this.unbind(e);
                 }
@@ -1043,11 +1053,14 @@
         * Creates a component where the first argument is the ID and the second
         * is the object that will be inherited by entities.
         *
-        * There is a convention for writing components. 
+        * A couple of methods are treated specially. They are invoked in partiular contexts, and (in those contexts) cannot be overridden by other components.
+        *
+        * - `init` will be called when the component is added to an entity
+        * - `remove` will be called just before a component is removed, or before an entity is destroyed. It is passed a single boolean parameter that is `true` if the entity is being destroyed.
+        * 
+        * In addition to these hardcoded special methods, there are some conventions for writing components. 
         *
         * - Properties or methods that start with an underscore are considered private.
-        * - A method called `init` will automatically be called as soon as the
-        * component is added to an entity.
         * - A method with the same name as the component is considered to be a constructor
         * and is generally used when you need to pass configuration data to the component on a per entity basis.
         *

--- a/tests/core.html
+++ b/tests/core.html
@@ -64,8 +64,34 @@ $(document).ready(function() {
 		strictEqual( first.added && !first.has("comp"), true, "soft-removed component (properties remain)" );
 		first.removeComponent("comp", false);
 		strictEqual( !first.added && !first.has("comp"), true, "hard-removed component (properties are gone)" );
+
 		// Clean up
 		Crafty("*").destroy();
+	});
+
+	test("remove", function() {
+		var removeRan = false, destroyFlag = false;
+
+		Crafty.c("comp", {
+			remove: function(destroyed){
+				removeRan = true;
+				destroyFlag = destroyed;
+			}
+		})
+		e = Crafty.e("comp, blank");
+		e.removeComponent("blank");
+		strictEqual( removeRan, false, "Remove doesn't run on other component removal");
+
+		removeRan = false;
+		e.removeComponent("comp");
+		strictEqual( removeRan, true, "Remove runs on correct component removal");
+		strictEqual( destroyFlag, false, "Destroy flag false on regular removal");
+		
+		removeRan = false;
+		e.addComponent("comp");
+		e.destroy()
+		strictEqual( removeRan, true, "Remove runs on component destrution");
+		strictEqual( destroyFlag, true, "Destroy flag true on destruction");
 	});
 	
 	test("attr", function() {


### PR DESCRIPTION
Allows components to define a `remove` method that work similarly to `init`.  It will be called when the entity is destroyed or the component is removed.  It's passed a boolean flag that is true on destruction, false on simple removal.

This patch also moves the trigger of "RemoveComponent" so that it occurs before the component is removed, instead of after.
