### PR TITLE
Changes to how _attr passes change information

### DIFF
--- a/src/DebugLayer.js
+++ b/src/DebugLayer.js
@@ -288,7 +288,7 @@ Crafty.DebugCanvas  = {
 		},
 
 		remove: function(ent){
-			list = this.entities;
+			var list = this.entities;
 			for (var i = list.length-1; i>=0; i--)
 				if(list[i]==ent)
 						list.splice(i, 1)


### PR DESCRIPTION
The changes are that it:
- Uses the actual object position instead of the MBR.  If you want to know how an object has moved, you want to compare its _actual_ position, not its MBR.
- Create a rectPool to improve performance by recycling rectangle objects.  Previously, a new object was created every time you set an object's position, which hurts performance.  I didn't want to simply store the info in an object attached to the entity, because it's conceivable a call to `_attr` could trigger a _second_ such call on the same entity.  So the `Crafty.rectPool` object creates a little pool of objects to recycle. 

I did a fair amount of benchmarking the rectPool optimization to make sure that it (a) didn't hurt average performance, and (b) really did reduce stutter.  I found the best metric was to look at the number of "EnterFrame" events per call to `step()`.  With a lot of objects moving around, it reduced this number across the board.

(This PR also has a commit to remove an accidental global in DeubgLayer.js.)
