### PR TITLE
Make 2d comparison functions consistently use _x style properties

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -444,7 +444,7 @@ Crafty.c("2D", {
 	* @param w - Width of the rect
 	* @param h - Height of the rect
 	* @sign public Boolean .within(Object rect)
-	* @param rect - An object that must have the `x, y, w, h` values as properties
+	* @param rect - An object that must have the `_x, _y, _w, _h` values as properties
 	* Determines if this current entity is within another rectangle.
 	*/
 	within: function (x, y, w, h) {
@@ -452,11 +452,11 @@ Crafty.c("2D", {
 		if (typeof x === "object") {
 			rect = x;
 		} else {
-			rect = { x: x, y: y, w: w, h: h };
+			rect = { _x: x, _y: y, _w: w, _h: h };
 		}
 
-		return rect.x <= mbr.x && rect.x + rect.w >= mbr.x + mbr.w &&
-				rect.y <= mbr.y && rect.y + rect.h >= mbr.y + mbr.h;
+		return rect._x <= mbr._x && rect._x + rect._w >= mbr._x + mbr._w &&
+				rect._y <= mbr._y && rect._y + rect._h >= mbr._y + mbr._h;
 	},
 
 	/**@
@@ -468,7 +468,7 @@ Crafty.c("2D", {
 	* @param w - Width of the rect
 	* @param h - Height of the rect
 	* @sign public Boolean .contains(Object rect)
-	* @param rect - An object that must have the `x, y, w, h` values as properties
+	* @param rect - An object that must have the `_x, _y, _w, _h` values as properties.  
 	* Determines if the rectangle is within the current entity.  If the entity is rotated, its MBR is used for the test.
 	*/
 	contains: function (x, y, w, h) {
@@ -476,11 +476,11 @@ Crafty.c("2D", {
 		if (typeof x === "object") {
 			rect = x;
 		} else {
-			rect = { x: x, y: y, w: w, h: h };
+			rect = { _x: x, _y: y, _w: w, _h: h };
 		}
 
-		return rect.x >= mbr.x && rect.x + rect.w <= mbr.x + mbr.w &&
-				rect.y >= mbr.y && rect.y + rect.h <= mbr.y + mbr.h;
+		return rect._x >= mbr._x && rect._x + rect._w <= mbr._x + mbr._w &&
+				rect._y >= mbr._y && rect._y + rect._h <= mbr._y + mbr._h;
 	},
 
 	/**@
@@ -537,8 +537,8 @@ Crafty.c("2D", {
 			return this.map.containsPoint(x, y);
 		}
 		var mbr = this._mbr || this;
-		return mbr.x <= x && mbr.x + mbr.w >= x &&
-			   mbr.y <= y && mbr.y + mbr.h >= y;
+		return mbr._x <= x && mbr._x + mbr._w >= x &&
+			   mbr._y <= y && mbr._y + mbr._h >= y;
 	},
 
 	/**@

--- a/tests/core.html
+++ b/tests/core.html
@@ -264,13 +264,15 @@ $(document).ready(function() {
 		strictEqual(player.within(-1, -1, 51, 51), true, "Within");
 
 
-		strictEqual(player.within({x: 0, y: 0, w: 50, h: 50}), true, "Within Again");
+		strictEqual(player.within({_x: 0, _y: 0, _w: 50, _h: 50}), true, "Within Again");
 
 		strictEqual(player.within(0, 0, 40, 50), false, "Wasn't within");
 
 		player.rotation = 90;	// Once rotated, the entity should no longer be within the rectangle
 
 		strictEqual(player.within(0, 0, 50, 50), false, "Rotated, Not within");
+		strictEqual(player.within(-50, 0, 50, 50), true, "Rotated, within rotated area");
+
 
 		
 		// Clean up
@@ -289,13 +291,14 @@ $(document).ready(function() {
 
 		strictEqual(player.contains(1, 1, 49, 49), true, "Contains");
 
-		strictEqual(player.contains({x: 0, y: 0, w: 50, h: 50}), true, "Contains");
+		strictEqual(player.contains({_x: 0, _y: 0, _w: 50, _h: 50}), true, "Contains");
 
 		strictEqual(player.contains(1, 1, 51, 51), false, "Doesn't contain");
 
 		player.rotation = 90;
 
 		strictEqual(player.contains(0, 0, 50, 50), false, "Rotated, no longer contains");
+		strictEqual(player.within(-50, 0, 50, 50), true, "Rotated, contains rotated area");
 
 		
 		// Clean up


### PR DESCRIPTION
Modifies `isAt`, `contains`, and `within` to accept objects with `_x` style properties, such as MBRs.  (Fixes #504).  Would break code that passed manually constructed objects with old-style properties.

Adds a couple tests to better catch issues with MBRs and within/contains.
