### PR TITLE
Fix `multiway`'s behavior when dealing with zero-valued axis of `speed`.

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -726,7 +726,7 @@ Crafty.c("Multiway", {
 		this._speed = { x: 3, y: 3 };
 
 		if (keys) {
-			if (speed.x && speed.y) {
+			if (speed.x !== undefined && speed.y !== undefined) {
 				this._speed.x = speed.x;
 				this._speed.y = speed.y;
 			} else {


### PR DESCRIPTION
This fixes the behavior of `multiway` when `speed` is as an object
with 0 value for either axis. Passing `{x: 0, y: 0}`, or variations
of, is now safe.
