### PR TITLE
fix for building in linux/unix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "name": "crafty",
     "version": "0.5.4",
     "title": "Crafty game framework",


### PR DESCRIPTION
An extra dos character is included which causes npm install to fail.

ERR! Couldn't read dependencies.
ERR! Failed to parse json
ERR! Unexpected token ﻿

I simply ran dos2unix which removed this character.
