### PR TITLE
Fixing reference to removed "Drawmanager.draw()" function

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1072,7 +1072,7 @@
                 while (frames-- > 0) {
                     Crafty.trigger("EnterFrame", { frame: frame++ });
                 }
-                Crafty.DrawManager.draw();
+                Crafty.trigger("RenderScene");
             }
 
         },


### PR DESCRIPTION
The DrawManager.draw() function was removed some time ago, but the
SimulateFrames() function was still referencing it. This was causing
tests in stage.html to fail.
