### PR TITLE
Add jsvalidate to grunt build process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,6 @@ module.exports = function (grunt) {
                     ' * Copyright <%= grunt.template.today("yyyy") %>, <%= pkg.author.name %>\n' +
                     ' * Dual licensed under the MIT or GPL licenses.\n' +
                     ' */\n\n';
-    
 
     var getFiles = function (){
         return fileList
@@ -69,6 +68,10 @@ module.exports = function (grunt) {
             	'tests/math.html']
         }, 
 
+        jsvalidate: {
+            files: "crafty.js"
+        },
+
     });
 
     // Load the plugin that provides the "uglify" task.
@@ -76,16 +79,17 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-qunit');
+    grunt.loadNpmTasks('grunt-jsvalidate');
     
     // Defined tasks for Crafty
     grunt.registerTask('api', "Generate api documentation", docGen)
 
 
     // Default task.
-    grunt.registerTask('default', ['concat']);
+    grunt.registerTask('default', ['concat', 'jsvalidate']);
 
     // Task chains
-    grunt.registerTask('check', ['concat', 'qunit', 'jshint'])
+    grunt.registerTask('check', ['concat', 'jsvalidate', 'qunit', 'jshint'])
     grunt.registerTask('release', ['concat', 'uglify', 'api']);
 
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "grunt-contrib-concat": "0.3.0",
         "grunt-contrib-jshint": "0.5.2",
         "grunt-contrib-qunit":  "0.2.1",
+        "grunt-jsvalidate":     "0.2.1",
         "marked":               "0.2.9",
         "coffee-script":        "1.6.3"
     }


### PR DESCRIPTION
This adds the [jsvalidate](https://github.com/ariya/grunt-jsvalidate) package to our build process.  It's fast, so I set it to run by default.  It'll help catch any syntax errors in `crafty.js`.

I tried having it run on all the source files individually, but it was a bit kludgy.  ( `core.js` wouldn't be valid by itself.)  Maybe someone else can have better luck with that.
