### PR TITLE
small grunt fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "title": "Crafty game framework",
     "author": {
         "name": "Louis Stowasser",
-        "url": "http://craftyengine.com/"
+        "url": "http://craftyjs.com/"
     },
     "branches" : { "develop" : true },
     "licenses": [
@@ -25,7 +25,6 @@
     "jsfiddle" : "disable",
     "homepage": "https://github.com/craftyjs/Crafty",
     "files": [
-        "src/license.txt",
         "src/core.js",
         "src/intro.js",
         "src/HashMap.js",


### PR DESCRIPTION
The grunt-generated banner makes it unnecessary to include license.txt.

(Before this change, the non-minified file has essentially the same banner twice.)

Also, changed craftyengine.com to craftyjs.com, which seems to be the canonical address.

(license.txt could be deleted altogether, but only after the PHP build process is officially deprecated.)
