### PR TITLE
Fixing timing test based on game loop refactor.

### DIFF
--- a/tests/stage.html
+++ b/tests/stage.html
@@ -112,9 +112,18 @@
 
 	module("Crafty.timer")
 	test("curTime", 1, function () {
-		var startTime = Crafty.timer.currentTime;
+		var startTime, lastKnownTime;
+		Crafty.e("").bind("EnterFrame", function(params){
+			if(!startTime){
+				startTime = params.gameTime;
+			}
+			else{
+				lastKnownTime = params.gameTime;
+			}
+		});
+		
 		setTimeout(function () {
-			var endTime = Crafty.timer.currentTime;
+			var endTime = lastKnownTime;
 			ok(endTime > startTime, "EndTime " + endTime + " must be larger than StartTime " + startTime);
 			start();
 		}, 100);


### PR DESCRIPTION
This test was failing because the game loop refactor removed access to the timer's "currentTime" variable.
The current time can be accessed from the enterframe event though, so the test now uses these values and asserts that multiple frames have been entered in the duration.
