### PR TITLE
FIX : Make Color and Sprite components work together for DOM elements (resubmission)

### DIFF
--- a/src/drawing.js
+++ b/src/drawing.js
@@ -10,7 +10,7 @@ Crafty.c("Color", {
 	init: function () {
 		this.bind("Draw", function (e) {
 			if (e.type === "DOM") {
-				e.style.background = this._color;
+				e.style.backgroundColor = this._color;
 				e.style.lineHeight = 0;
 			} else if (e.type === "canvas") {
 				if (this._color) e.ctx.fillStyle = this._color;

--- a/src/sprite.js
+++ b/src/sprite.js
@@ -47,14 +47,15 @@ Crafty.c("Sprite", {
 								 pos._h //height on canvas
 				);
 			} else if (e.type === "DOM") {
-				//Get scale (ratio of entity dimensions to sprite's dimensions)
+				// Get scale (ratio of entity dimensions to sprite's dimensions)
 				// If needed, we will scale up the entire sprite sheet, and then modify the position accordingly
-				var vscale = this._h/co.h, hscale =this._w/co.w;
+				var vscale = this._h/co.h, hscale = this._w/co.w,
+				    style = this._element.style;
 
-				this._element.style.background = "url('" + this.__image + "') no-repeat -" + co.x*hscale + "px -" + co.y*vscale + "px";
+				style.background = style.backgroundColor + " url('" + this.__image + "') no-repeat -" + co.x*hscale + "px -" + co.y*vscale + "px";
 				// style.backgroundSize must be set AFTER style.background!
-				if (vscale != 1 || hscale != 1){
-					this._element.style.backgroundSize = (this.img.width * hscale) + "px" + " " + (this.img.height * vscale) + "px";
+				if (vscale != 1 || hscale != 1) {
+					style.backgroundSize = (this.img.width * hscale) + "px" + " " + (this.img.height * vscale) + "px";
 				}
 			}
 		};


### PR DESCRIPTION
Cancel and replace PUSH REQUEST #466

When using DOM rendering on a sprite created from a spritesheet, the color() method was ineffective (but it works in Canvas mode).

A good test for this is the ['Sprites and Components'](https://github.com/starmelt/craftyjstut/tree/master/firststeps/2_components_and_sprites) tutorial by craftyjstut (change Canvas to DOM in the tutorial)
