### PR TITLE
Fixing some odd behaviour in isometric, and adding iso tests.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,7 +66,8 @@ module.exports = function (grunt) {
             	'tests/animation/animation.html',
             	'tests/stage.html',
             	'tests/events.html',
-            	'tests/math.html']
+            	'tests/math.html',
+            	'tests/isometric.html']
         }, 
 
         jsvalidate: {

--- a/src/isometric.js
+++ b/src/isometric.js
@@ -101,13 +101,13 @@ Crafty.extend({
          * ~~~
          * var iso = Crafty.isometric.size(128,96);
          * var px = iso.pos2px(12800,4800);
-         * console.log(px); //Object { x=-100, y=-100}
+         * console.log(px); //Object { x=100, y=100}
          * ~~~
          */
         px2pos:function(left,top){
             return {
-                x:Math.ceil(-left / this._tile.width - (top & 1)*0.5),
-                y:-top / this._tile.height * 2
+                x:-Math.ceil(-left / this._tile.width - (top & 1)*0.5),
+                y:top / this._tile.height * 2
             }; 
         },
         /**@

--- a/tests/isometric.html
+++ b/tests/isometric.html
@@ -1,0 +1,116 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" 
+                    "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+
+<!-- Note to developers: Grunt will run these tests in a webkit-based browser
+    (like safari or chrome). If you don't have grunt, and/or want to test in other
+    browsers, here is the easiest way:
+       (1) Change "../crafty.js" to "../crafty-local.js" (in the HTML head below).
+       (2) Open this file in a browser to run the tests.
+             ...However, browser security settings may keep it from working.
+       -- To run the tests in firefox: First you need to go to about:config in firefox, and
+             switch "security.fileuri.strict_origin_policy" to false. [This only changes the
+             security settings when firefox opens an HTML file saved on your computer; it does
+             not affect your security when you are browsing the internet.]
+       -- To run the tests in chrome: You need to pass a flag when opening chrome.
+             For example, in Linux, you would run this command in a Linux terminal:      
+             chromium-browser /path/to/core.html --allow-file-access-from-files
+ -->
+
+<head>
+	<script src="./lib/jquery.min.js"></script>
+	<link rel="stylesheet" href="./lib/qunit.css" type="text/css" media="screen" />
+	<script type="text/javascript" src="./lib/qunit.js"></script>
+	<script type="text/javascript" src="../crafty.js"></script>
+
+<script>
+
+$(document).ready(function() {
+	Crafty.init(500,500);
+	
+	module("ISOMETRIC");
+
+	test("place tile", function () {
+		var iso = Crafty.isometric.size(64,16);
+		
+		var tile1 = Crafty.e("2D, DOM, Color").attr({x:0, y:0, w:64, h:16}).color("red");
+		var tile2 = Crafty.e("2D, DOM, Color").attr({x:100, y:100, z:3, w:64, h:16}).color("blue");
+		
+		iso.place(0,0,0,tile1);
+		iso.place(1,2,5,tile2);
+		
+		equal(tile1.attr('x'), 0, "First tile should default to origin");
+		equal(tile1.attr('y'), 0, "First tile should default to origin");
+		equal(tile1.attr('z'), 0, "z-index should be transferred unchanged");
+		
+		equal(tile2.attr('x'), 64 + Crafty.viewport._x, "Each tile should be offset by the sum of the width of those before it");
+		equal(tile2.attr('y'), -24 + Crafty.viewport._y, "The row should be offset by one and a half times the height");
+		equal(tile2.attr('z'), 8, "z-index should be added to existing value");
+		
+		// Clean up
+		Crafty("*").destroy();
+	});
+	
+	test("pos2px", function () {
+		var iso = Crafty.isometric.size(64,16);
+		
+		var origin = iso.pos2px(0,0);
+		equal(origin.left, 0, "First tile should default to origin");
+		equal(origin.top, 0, "First tile should default to origin");
+		
+		var oddNumberedRow = iso.pos2px(0,1);
+		equal(oddNumberedRow.left, 32, "Odd numbered rows should be be inset by half the width");
+		equal(oddNumberedRow.top, 8, "Each row should move down by half the height");
+		
+		var evenNumberedRow = iso.pos2px(0,2);
+		equal(evenNumberedRow.left, 0, "Even numbered rows should not be be inset");
+		equal(evenNumberedRow.top, 16, "Each row should move down by half the height");
+		
+		var numberedColumn = iso.pos2px(3,0);
+		equal(numberedColumn.left, 64 * 3, "Should be inset by the width times the x position");
+	});
+	
+	test("px2pos", function () {
+		var iso = Crafty.isometric.size(64,16);
+		
+		var origin = iso.px2pos(0,0);
+		equal(origin.x, 0, "Origin should be the corner of the lowest numbered tile");
+		equal(origin.y, 0, "Origin should be the corner of the lowest numbered tile");
+		
+		var oddNumberedRow = iso.px2pos(32, 8);
+		equal(oddNumberedRow.x, 0, "Odd numbered rows should be be inset by half the width");
+		equal(oddNumberedRow.y, 1, "Each row should move down by half the height");
+		
+		var evenNumberedRow = iso.px2pos(0,16);
+		equal(evenNumberedRow.x, 0, "Even numbered rows should not be be inset");
+		equal(evenNumberedRow.y, 2, "Each row should move down by half the height");
+		
+		var numberedColumn = iso.px2pos(128,0);
+		equal(numberedColumn.x, 2, "Should be inset by the width times the x position");
+	});
+	
+	test("round trip conversions", function () {
+		var iso = Crafty.isometric.size(64,16);
+		
+		var startX = 14;
+		var startY = 21;
+		
+		var startingPoint = iso.pos2px(startX,startY);
+		var end = iso.px2pos(startingPoint.left, startingPoint.top);
+		
+		equal(end.x, startX, "x position should match");
+		equal(end.y, startY, "y position should match");
+	});
+});
+</script>
+  
+</head>
+<body>
+<h1 id="qunit-header">Crafty: Core</h1>
+<h2 id="qunit-banner"></h2>
+<div id="qunit-testrunner-toolbar"></div>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests"></ol>
+<div id="qunit-fixture">test markup, will be hidden</div>
+</body>
+</html>


### PR DESCRIPTION
When I was writing some tests for isometric, I noticed that px2pos and pos2px were not actually reversing each others' actions. I've adjusted that behaviour (such that px2pos(pos2px(a,b)) == (a,b)  now).
