### PR TITLE
extend functionality of Crafty.debug()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1444,7 +1444,9 @@
             return comp in components;
         },
 
-        debug: function () {
+        debug: function (str) {
+            // access internal variables - handlers or entities
+            if (str === 'handlers') { return handlers; }
             return entities;
         },
 


### PR DESCRIPTION
add an undocumented debugging feature to be able to view the handlers object.
