### PR TITLE
switch from getter to attribute-lookup

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -854,7 +854,7 @@ Crafty.c("2D", {
 			var oldValue = this[name];		
 			this[name] = value;
 			if (mbr){
-				this._calculateMBR(this._origin.x + this.x, this._origin.y + this.y, -this.rotation*DEG_TO_RAD);
+				this._calculateMBR(this._origin.x + this._x, this._origin.y + this._y, -this._rotation*DEG_TO_RAD);
 			}
 			if (name === '_w'){
 				this.trigger("Resize", {axis:'w', amount:value-oldValue})


### PR DESCRIPTION
attribute-lookups are faster than getters. We use attribute-lookups when possible everywhere in the code. This is a rare exception, presumably an accidental oversight.

I tested in a game with some rotating elements - it still works. The qunit tests also pass.
