### PR TITLE
Fixes rounding of dirty rects and MBRs

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -475,6 +475,9 @@ Crafty.c("2D", {
 
         var ct = Math.cos(rad),
             st = Math.sin(rad);
+        // Special case 90 degree rotations to prevent rounding problems
+        ct = (ct < 1e-10 && ct > -1e-10) ? 0 : ct;
+        st = (st < 1e-10 && st > -1e-10) ? 0 : st;
         var x0 = ox + (this._x - ox) * ct + (this._y - oy) * st,
             y0 = oy - (this._x - ox) * st + (this._y - oy) * ct,
             x1 = ox + (this._x + this._w - ox) * ct + (this._y - oy) * st,
@@ -483,18 +486,18 @@ Crafty.c("2D", {
             y2 = oy - (this._x + this._w - ox) * st + (this._y + this._h - oy) * ct,
             x3 = ox + (this._x - ox) * ct + (this._y + this._h - oy) * st,
             y3 = oy - (this._x - ox) * st + (this._y + this._h - oy) * ct,
-            minx = Math.round(Math.min(x0, x1, x2, x3)),
-            miny = Math.round(Math.min(y0, y1, y2, y3)),
-            maxx = Math.round(Math.max(x0, x1, x2, x3)),
-            maxy = Math.round(Math.max(y0, y1, y2, y3));
-        if (!this._mbr)
+            minx = Math.floor(Math.min(x0, x1, x2, x3)),
+            miny = Math.floor(Math.min(y0, y1, y2, y3)),
+            maxx = Math.ceil(Math.max(x0, x1, x2, x3)),
+            maxy = Math.ceil(Math.max(y0, y1, y2, y3));
+        if (!this._mbr) {
             this._mbr = {
                 _x: minx,
                 _y: miny,
                 _w: maxx - minx,
                 _h: maxy - miny
             };
-        else {
+        } else {
             this._mbr._x = minx;
             this._mbr._y = miny;
             this._mbr._w = maxx - minx;

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -358,17 +358,14 @@ Crafty.DrawManager = (function () {
             merge: function (a, b, target) {
                 if (target == null)
                     target = {};
-                    // Doing it in this order means we can use either a or b as the target, with no conflict
-                    // Round resulting values to integers; down for xy, up for wh
-                    // Would be slightly off if negative w, h were allowed
+                // Doing it in this order means we can use either a or b as the target, with no conflict
                 target._h = Math.max(a._y + a._h, b._y + b._h);
                 target._w = Math.max(a._x + a._w, b._x + b._w);
-                target._x = ~~Math.min(a._x, b._x);
-                target._y = ~~Math.min(a._y, b._y);
+                target._x = Math.min(a._x, b._x);
+                target._y = Math.min(a._y, b._y);
                 target._w -= target._x;
                 target._h -= target._y;
-                target._w = (target._w == ~~target._w) ? target._w : ~~target._w + 1 | 0;
-                target._h = (target._h == ~~target._h) ? target._h : ~~target._h + 1 | 0;
+                
                 return target;
             },
 
@@ -638,12 +635,22 @@ Crafty.DrawManager = (function () {
             l = dirty_rects.length;
             var dupes = [],
                 objs = [];
-                // For each dirty rectangle, find entities near it, and draw the overlapping ones
+            // For each dirty rectangle, find entities near it, and draw the overlapping ones
             for (i = 0; i < l; ++i) { //loop over every dirty rect
                 rect = dirty_rects[i];
                 dupes.length = 0;
                 objs.length = 0;
                 if (!rect) continue;
+
+                // Find the smallest rectangle with integer coordinates that encloses rect
+                rect._w = rect._x + rect._w;
+                rect._h = rect._y + rect._h;
+                rect._x = (rect._x > 0) ? (rect._x|0) : (rect._x|0) - 1;
+                rect._y = (rect._y > 0) ? (rect._y|0) : (rect._y|0) - 1;
+                rect._w -= rect._x;
+                rect._h -= rect._y;
+                rect._w = (rect._w === (rect._w|0)) ? rect._w : (rect._w|0) + 1;
+                rect._h = (rect._h === (rect._h|0)) ? rect._h : (rect._h|0) + 1;
 
                 //search for ents under dirty rect
                 q = Crafty.map.search(rect, false);
@@ -678,7 +685,6 @@ Crafty.DrawManager = (function () {
                         obj.draw();
                     obj._changed = false;
                 }
-
 
                 // Close rectangle clipping
                 ctx.closePath();


### PR DESCRIPTION
We want the areas of the screen that we clear and clip to have integer coordinates.  Prior to this patch there were some cases that were not caught.   The solution is to do this "rounding up" of regions directly before we use them, rather than as they are created.

Similarly, the MBRs used should have integer coordinates.  This fixes a regression that caused them to be "rounded down" in some cases, and also special cases rotations of 90 degrees.   Previously, taking (say) the cosine of PI/2 resulted in a very small nonzero value, which due to rounding caused some deviations of the MBR from an ideal 90 degree rotation.

This seems worth special-casing due to the privileged nature of 90 degree rotations.
