### PR TITLE
corrected formula for calculating x and y in sprite function

### DIFF
--- a/src/sprite.js
+++ b/src/sprite.js
@@ -93,8 +93,8 @@ Crafty.c("Sprite", {
      * The coordinate of the slide within the sprite in the format of [x, y, w, h].
      */
     sprite: function (x, y, w, h) {
-        this.__coord = [x * this.__tile + this.__padding[0] + this.__trim[0],
-            y * this.__tileh + this.__padding[1] + this.__trim[1],
+        this.__coord = [x * (this.__tile + this.__padding[0]) + this.__trim[0],
+            y * (this.__tileh + this.__padding[1]) + this.__trim[1],
             this.__trim[2] || w * this.__tile || this.__tile,
             this.__trim[3] || h * this.__tileh || this.__tileh
         ];


### PR DESCRIPTION
As I understand it we need to include the padding for each cell when computing the x and y coordinates in a sprite. This is also what is done in the [sprite function in extensions.js](https://github.com/craftyjs/Crafty/blob/develop/src/extensions.js#L240) , but there are missing parenthesis in the sprite.js sprite() function

I Hope I'm not missing something here.
