### PR TITLE
fix unit-tests to avoid false-positives in IE8

### DIFF
--- a/tests/core.html
+++ b/tests/core.html
@@ -42,11 +42,15 @@ $(document).ready(function() {
 		strictEqual( Crafty("test test2").length, 2, "Two components ANDed" );
 		strictEqual( Crafty("test, test2").length, 7, "Two components ORed" );
 		
-		strictEqual( Crafty("*").length, 7, "All components - universal selector" );
+		if (Crafty("ViewportSetter").length === 0) {
+			strictEqual( Crafty("*").length, 7, "All components - universal selector" );
+		} else {
+			strictEqual( Crafty("*").length, 8, "All components - universal selector" );
+		}
 		
 		strictEqual( Crafty(first[0]), first, "Get by ID" );
 		// Clean up
-		Crafty("*").destroy();
+		Crafty("test, test2").destroy();
 	});
 	
 	test("addComponent and removeComponent", function() {
@@ -70,7 +74,7 @@ $(document).ready(function() {
 		strictEqual( !first.added && !first.has("comp"), true, "hard-removed component (properties are gone)" );
 
 		// Clean up
-		Crafty("*").destroy();
+		first.destroy();
 	});
 
 	test("remove", function() {
@@ -107,10 +111,15 @@ $(document).ready(function() {
 		strictEqual( first.prop, "test", "properties from object assigned" );
 		strictEqual( first.another, 56, "properties from object assigned" );
 		// Clean up
-		Crafty("*").destroy();
+		first.destroy();
 	});
 
 	test("setter", function() {
+		if (!(Crafty.support.setter || Crafty.support.defineProperty)) {
+			// IE8 has a setter() function but it behaves differently. No test is currently written for IE8.
+			expect(0);
+			return;
+		}
 		var first = Crafty.e("test");
 		first.setter('p1', function(v) {this._p1 = v*2 });
 		first.p1 = 2;
@@ -121,7 +130,7 @@ $(document).ready(function() {
 		first.p3 = 3;
 		strictEqual(first._p2 + first._p3, 10, "two property setters");
 		// Clean up
-		Crafty("*").destroy();
+		first.destroy();
 	});
 	
 	test("bind", function () {
@@ -133,7 +142,7 @@ $(document).ready(function() {
 		first.trigger("myevent");
 		strictEqual(triggered, true, "custom event triggered");
 		// Clean up
-		Crafty("*").destroy();
+		first.destroy();
 	});
 
 	test("unbind", function() {
@@ -157,7 +166,7 @@ $(document).ready(function() {
 		first.unbind("myevent", callback);
 		first.trigger("myevent");
 		// Clean up
-		Crafty("*").destroy();
+		first.destroy();
 	});
 	
 	test("globalBindAndUnbind", function () {
@@ -197,9 +206,9 @@ $(document).ready(function() {
 		Crafty("*").each(function() {
 			count++;
 		});
-		strictEqual(count, 7, "Iterated all elements");
+		strictEqual(count, Crafty("*").length, "Iterated all elements");
 		// Clean up
-		Crafty("*").destroy();
+		Crafty("test, test2").destroy();
 	});
 	
 	test("requires", function() {
@@ -220,7 +229,7 @@ $(document).ready(function() {
 		strictEqual(first.notyet, true, "Assigned if didn't have");
 		ok(first.has("already") && first.has("notyet"), "Both added");
 		// Clean up
-		Crafty("*").destroy();
+		first.destroy();
 	});
 	
 	test("destroy", function() {
@@ -228,31 +237,33 @@ $(document).ready(function() {
 			id = first[0]; //id
 		first.destroy();
 		strictEqual(Crafty(id).length, 0, "Not listed");
-		// Clean up
-		Crafty("*").destroy();
 	});
 	
 	module("2D");
-	
-	Crafty.init(500,500);
-	
+		
 	test("position", function() {
+		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50}).color("red");
 		player.x += 50;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._x, 50, "X moved");
 		
 		player.y += 50;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._y, 50, "Y moved");
 		
 		player.w += 50;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._w, 100, "Width increase");
 		
 		player.h += 50;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._h, 100, "Height increase");
 		
 		strictEqual(player._globalZ, player[0], "Global Z, Before");
 		
 		player.z = 1;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._z, 1, "Z index");
 		
 		var global_z_guess;
@@ -263,31 +274,35 @@ $(document).ready(function() {
 		}
 		strictEqual(player._globalZ, global_z_guess, "Global Z, After");
 		// Clean up
-		Crafty("*").destroy();
+		player.destroy();
 	});
 	
 	test("intersect", function() {
+		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50}).color("red");
 		player.x = 0;
 		player.y = 0;
 		player.w = 50;
 		player.h = 50;
-		
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
+
 		strictEqual(player.intersect(0, 0, 100, 50), true, "Intersected");
 
 		strictEqual(player.intersect({x: 0, y: 0, w: 100, h: 50}), true, "Intersected Again");
 
 		strictEqual(player.intersect(100, 100, 100, 50), false, "Didn't intersect");
 		// Clean up
-		Crafty("*").destroy();
+		player.destroy();
 	});
 
 	test("within", function() {
+		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50});
 		player.x = 0;
 		player.y = 0;
 		player.w = 50;
 		player.h = 50;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		
 		strictEqual(player.within(0, 0, 50, 50), true, "Within");
 
@@ -299,22 +314,22 @@ $(document).ready(function() {
 		strictEqual(player.within(0, 0, 40, 50), false, "Wasn't within");
 
 		player.rotation = 90;	// Once rotated, the entity should no longer be within the rectangle
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
 		strictEqual(player.within(0, 0, 50, 50), false, "Rotated, Not within");
 		strictEqual(player.within(-50, 0, 50, 50), true, "Rotated, within rotated area");
 
-
-		
-		// Clean up
-		Crafty("*").destroy();
+		player.destroy();
 	});
 
 	test("contains", function() {
+		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50});
 		player.x = 0;
 		player.y = 0;
 		player.w = 50;
 		player.h = 50;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		
 
 		strictEqual(player.contains(0, 0, 50, 50), true, "Contains");
@@ -326,34 +341,38 @@ $(document).ready(function() {
 		strictEqual(player.contains(1, 1, 51, 51), false, "Doesn't contain");
 
 		player.rotation = 90;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
 		strictEqual(player.contains(0, 0, 50, 50), false, "Rotated, no longer contains");
 		strictEqual(player.within(-50, 0, 50, 50), true, "Rotated, contains rotated area");
-
 		
 		// Clean up
-		Crafty("*").destroy();
+		player.destroy();
 	});
 
 
 	
 	test("circle", function() {
+		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50}).color("red");
 		var circle = new Crafty.circle(0, 0, 10);
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		
 		strictEqual(circle.containsPoint(1, 2), true, "Contained the point");
 		strictEqual(circle.containsPoint(8, 9), false, "Didn't contain the point");
 		
 		circle.shift(1, 0);
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		
 		strictEqual(circle.x, 1, "Shifted of one pixel on the x axis");
 		strictEqual(circle.y, 0, "circle.y didn't change");
 		strictEqual(circle.radius, 10, "circle.radius didn't change");
 		// Clean up
-		Crafty("*").destroy();
+		player.destroy();
 	});
 
 	test("child", function () {
+		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var parent0 = Crafty.e("2D, DOM, Color").attr({x:0, y:0, w:50, h:50}).color("red");
 		var child0 = Crafty.e("2D, DOM, Color").attr({x:1, y:1, w:50, h:50}).color("red");
 		var child1 = Crafty.e("2D, DOM, Color").attr({x:2, y:2, w:50, h:50}).color("red");
@@ -368,10 +387,12 @@ $(document).ready(function() {
 		parent0.attach(child2);
 		parent0.attach(child3);
 		parent0.x += 50;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(child0._x, 51, 'child0 shifted when parent did');
 		strictEqual(child1._x, 52, 'child1 shifted when parent did');
 		child0.x += 1;
 		child1.x += 1;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(parent0._x, 50, 'child shifts do not move the parent');
 		child1.destroy();
 		deepEqual(parent0._children, [child0,child2,child3], 'child1 cleared itself from parent0._children when destroyed');
@@ -379,11 +400,10 @@ $(document).ready(function() {
 		strictEqual(Crafty(child0_ID).length, 0, 'destruction of parent killed child0');
 		strictEqual(Crafty(child2_ID).length, 0, 'destruction of parent killed child2');
 		strictEqual(Crafty(child3_ID).length, 0, 'destruction of parent killed child3');
-		// Clean up
-		Crafty("*").destroy();
 	});
 
 	test("child_rotate", function () {
+		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var parent = Crafty.e("2D, DOM, Color")
 			.attr({x:0, y:0, w:50, h:50, rotation:10})
 			.color("red");
@@ -392,13 +412,15 @@ $(document).ready(function() {
 			.color("red");
 		parent.attach(child);
 		parent.rotation += 20;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(parent.rotation, 30, 'parent rotates normally');
 		strictEqual(child.rotation, 35, 'child follows parent rotation');
 		child.rotation += 22;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(parent.rotation, 30, 'parent ignores child rotation');
 		strictEqual(child.rotation, 57, 'child rotates normally');
 		// Clean up
-		Crafty("*").destroy();
+		parent.destroy();
 	});
 
 	// This test assumes that the "circles" are really octagons, as per Crafty.circle.
@@ -408,14 +430,16 @@ $(document).ready(function() {
 		var c2 = new Crafty.circle(100, 105, 10);
 		strictEqual((e._SAT(c1, c2).overlap < -13.8 && e._SAT(c1, c2).overlap > -13.9), true, "Expected overlap to be about -13.86 ( or 15 cos[pi/8])")
 		// Clean up
-		Crafty("*").destroy();
+		e.destroy();
 	});
 
 
         test("disableControl and enableControl", function () {
+            var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
             var e = Crafty.e("2D, Twoway")
                 .attr({ x: 0 })
                 .twoway(1);
+            if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
             equal(e._movement.x, 0);
             equal(e._x, 0);
@@ -454,8 +478,10 @@ $(document).ready(function() {
 
 
 		test("Resizing 2D objects & hitboxes", function(){
+			var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 			var e = Crafty.e("2D, Collision");
 			e.attr({x:0, y:0, w:40, h:50})	
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			
 			equal(e.map.points[0][0], 0, "Before rotation: x_0 is 0")
 			equal(e.map.points[0][1], 0, "y_0 is 0")
@@ -463,6 +489,7 @@ $(document).ready(function() {
 			equal(e.map.points[2][1], 50, "y_2 is 50")
 
 			e.rotation = 90;
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
 			equal( Math.round(e.map.points[0][0]), 0, "After rotation by 90 deg: x_0 is 0")
 			equal( Math.round(e.map.points[0][1]), 0, "y_0 is 0")
@@ -486,6 +513,7 @@ $(document).ready(function() {
 			// Check that changing the width when rotated resizes correctly for both hitbox and MBR
 			// Rotated by 90 degrees, changing the width of the entity should change the height of the hitbox/mbr
 			e.w = 100;
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
 			equal( Math.round(e.map.points[0][0]), 0, "After rotation and increase in width: x_0 is 0")
 			equal( Math.round(e.map.points[0][1]), 0, "y_0 is 0")
@@ -497,11 +525,16 @@ $(document).ready(function() {
 			equal( Math.round(e._mbr._h), 100, "_mbr._h is  100" );
 			equal( Math.round(e._mbr._x), -50, "_mbr._x is -50");
 			equal( Math.round(e._mbr._y), 0, "_mbr._y is 0");
-
+			
+			e.destroy();
 		});
 
 	module("DebugLayer");
 		test("DebugCanvas", function(){
+			if (!(Crafty.support.canvas)) {
+				expect(0);
+				return;
+			}
 			var e = Crafty.e("2D, DebugCanvas");
 			var ctx = Crafty.DebugCanvas.context;
 
@@ -527,13 +560,18 @@ $(document).ready(function() {
 		});
 
 		test("VisibleMBR and DebugRect", function(){
+			var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 			var e = Crafty.e("2D, VisibleMBR").attr({x:10, y:10, w:10, h:20});
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e._assignRect();
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.debugRect._x, 10, "debugRect has correct x coord");
 			equal(e.debugRect._h, 20, "debugRect has correct height");
 
 			e.rotation = 90;
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e._assignRect();
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.debugRect._h, 10, "debugRect has correct height of MBR after rotation");
 
 			e.destroy();
@@ -541,8 +579,11 @@ $(document).ready(function() {
 		});
 
 		test("Hitbox debugging", function(){
+			var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 			var e = Crafty.e("2D, Collision, WiredHitBox").attr({x:10, y:10, w:10, h:20}).collision();
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e.matchHitBox(); // only necessary until collision works properly!
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.polygon.points[0][0], 10, "WiredHitBox -- correct x coord for upper right corner");
 			equal(e.polygon.points[2][1], 30, "correct y coord for lower right corner");
 			notEqual(typeof e._debug.strokeStyle, "undefined" , "stroke style is assigned");
@@ -551,14 +592,18 @@ $(document).ready(function() {
 			e.destroy();
 
 			var e = Crafty.e("2D, Collision, SolidHitBox").attr({x:10, y:10, w:10, h:20}).collision();
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e.matchHitBox(); // only necessary until collision works properly!
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.polygon.points[0][0], 10, "SolidHitBox -- correct x coord for upper right corner");
 			equal(e.polygon.points[2][1], 30, "correct y coord for lower right corner");
 			equal(typeof e._debug.strokeStyle, "undefined" , "stroke style is undefined");
 			notEqual(typeof e._debug.fillStyle, "undefined", "fill style is assigned");
 
 			e.collision( new Crafty.polygon([0, 0], [15, 0], [0, 15]) );
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e.matchHitBox();
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.polygon.points[2][1], 25, "After change -- correct y coord for third point");
 
 			e.destroy();


### PR DESCRIPTION
As discussed at https://github.com/craftyjs/Crafty/issues/456 , this pull-request fixes the core.html unit tests to reduce false-positives in IE8 (and also one in IE10). Some of the unit tests still fail in IE8, but I think the remaining ones are actual problems in the crafty code, not just bad tests. I ran the tests and they all pass in IE10, IE9 mode (in IE10), chromium, firefox, and grunt (phantomjs).
