### PR TITLE
Remove grunt-cli dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     ],
     "dependencies": {
         "grunt":                "0.4.0",
-        "grunt-cli":            "0.1.8",
         "grunt-contrib-uglify": "0.2.0",
         "grunt-contrib-concat": "0.3.0",
         "grunt-contrib-jshint": "0.5.2",


### PR DESCRIPTION
grunt-cli should be installed globally using `npm install -g grunt-cli`.

From grunt-cli README:

> If you don't have administrator rights, you may need to install
> grunt-cli locally to your project using
> `npm install grunt-cli --save-dev`. Unfortunately, this will not put the
> grunt executable in your PATH. You'll need to specify its explicit
> location when executing it, eg: `./node_modules/.bin/grunt`.
> 
> Note: Using grunt-cli in this way is unsupported.

Source: https://github.com/gruntjs/grunt-cli#installing-grunt-cli-locally

See also https://github.com/craftyjs/Crafty/commit/44eb78836dc074f3e33f669fe7a7ce150e10daaa#commitcomment-4263105
