### PR TITLE
IE8 viewport code: Use a global event instead of a listener entity

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -623,10 +623,18 @@ Crafty.extend({
                     }
                 });
             } else {
-                //create empty entity waiting for enterframe
+                // IE8 has no getter/setters -- Check for an update each frame.
                 this.x = this._x;
                 this.y = this._y;
-                Crafty.e("ViewportSetter");
+                Crafty.bind("EnterFrame", function () {
+                    if (Crafty.viewport._x !== Crafty.viewport.x) {
+                        Crafty.viewport.scroll('_x', Crafty.viewport.x);
+                    }
+
+                    if (Crafty.viewport._y !== Crafty.viewport.y) {
+                        Crafty.viewport.scroll('_y', Crafty.viewport.y);
+                    }
+                });
             }
         },
 
@@ -680,24 +688,5 @@ Crafty.extend({
             Crafty.viewport.mouselook('stop');
             Crafty.viewport.scale();
         }
-    }
-});
-
-
-/**
- * Entity fixes the lack of setter support
- */
-Crafty.c("ViewportSetter", {
-    init: function () {
-        this.bind("EnterFrame", function () {
-            if (Crafty.viewport._x !== Crafty.viewport.x) {
-                Crafty.viewport.scroll('_x', Crafty.viewport.x);
-            }
-
-            if (Crafty.viewport._y !== Crafty.viewport.y) {
-                Crafty.viewport.scroll('_y', Crafty.viewport.y);
-            }
-
-        });
     }
 });


### PR DESCRIPTION
The advantage of this approach is: IE8 code has the same number of
entities as other browsers, so Crafty('*') behaves predictably etc.
Also, this change removes a layer of unnecessary abstraction /
complexity.
