### PR TITLE
fix unit-tests to avoid false-positives in IE8

### DIFF
--- a/tests/core.html
+++ b/tests/core.html
@@ -111,6 +111,11 @@ $(document).ready(function() {
 	});
 
 	test("setter", function() {
+		if (!(Crafty.support.setter || Crafty.support.defineProperty)) {
+			// IE8 has a setter() function but it behaves differently. No test is currently written for IE8.
+			expect(0);
+			return;
+		}
 		var first = Crafty.e("test");
 		first.setter('p1', function(v) {this._p1 = v*2 });
 		first.p1 = 2;
@@ -234,25 +239,29 @@ $(document).ready(function() {
 	
 	module("2D");
 	
-	Crafty.init(500,500);
-	
 	test("position", function() {
+		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50}).color("red");
 		player.x += 50;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._x, 50, "X moved");
 		
 		player.y += 50;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._y, 50, "Y moved");
 		
 		player.w += 50;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._w, 100, "Width increase");
 		
 		player.h += 50;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._h, 100, "Height increase");
 		
 		strictEqual(player._globalZ, player[0], "Global Z, Before");
 		
 		player.z = 1;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._z, 1, "Z index");
 		
 		var global_z_guess;
@@ -267,12 +276,14 @@ $(document).ready(function() {
 	});
 	
 	test("intersect", function() {
+		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50}).color("red");
 		player.x = 0;
 		player.y = 0;
 		player.w = 50;
 		player.h = 50;
-		
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
+
 		strictEqual(player.intersect(0, 0, 100, 50), true, "Intersected");
 
 		strictEqual(player.intersect({x: 0, y: 0, w: 100, h: 50}), true, "Intersected Again");
@@ -283,11 +294,13 @@ $(document).ready(function() {
 	});
 
 	test("within", function() {
+		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50});
 		player.x = 0;
 		player.y = 0;
 		player.w = 50;
 		player.h = 50;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		
 		strictEqual(player.within(0, 0, 50, 50), true, "Within");
 
@@ -299,6 +312,7 @@ $(document).ready(function() {
 		strictEqual(player.within(0, 0, 40, 50), false, "Wasn't within");
 
 		player.rotation = 90;	// Once rotated, the entity should no longer be within the rectangle
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
 		strictEqual(player.within(0, 0, 50, 50), false, "Rotated, Not within");
 		strictEqual(player.within(-50, 0, 50, 50), true, "Rotated, within rotated area");
@@ -310,11 +324,13 @@ $(document).ready(function() {
 	});
 
 	test("contains", function() {
+		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50});
 		player.x = 0;
 		player.y = 0;
 		player.w = 50;
 		player.h = 50;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		
 
 		strictEqual(player.contains(0, 0, 50, 50), true, "Contains");
@@ -326,10 +342,10 @@ $(document).ready(function() {
 		strictEqual(player.contains(1, 1, 51, 51), false, "Doesn't contain");
 
 		player.rotation = 90;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
 		strictEqual(player.contains(0, 0, 50, 50), false, "Rotated, no longer contains");
 		strictEqual(player.within(-50, 0, 50, 50), true, "Rotated, contains rotated area");
-
 		
 		// Clean up
 		Crafty("*").destroy();
@@ -338,13 +354,16 @@ $(document).ready(function() {
 
 	
 	test("circle", function() {
+		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50}).color("red");
 		var circle = new Crafty.circle(0, 0, 10);
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		
 		strictEqual(circle.containsPoint(1, 2), true, "Contained the point");
 		strictEqual(circle.containsPoint(8, 9), false, "Didn't contain the point");
 		
 		circle.shift(1, 0);
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		
 		strictEqual(circle.x, 1, "Shifted of one pixel on the x axis");
 		strictEqual(circle.y, 0, "circle.y didn't change");
@@ -354,6 +373,7 @@ $(document).ready(function() {
 	});
 
 	test("child", function () {
+		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var parent0 = Crafty.e("2D, DOM, Color").attr({x:0, y:0, w:50, h:50}).color("red");
 		var child0 = Crafty.e("2D, DOM, Color").attr({x:1, y:1, w:50, h:50}).color("red");
 		var child1 = Crafty.e("2D, DOM, Color").attr({x:2, y:2, w:50, h:50}).color("red");
@@ -368,10 +388,12 @@ $(document).ready(function() {
 		parent0.attach(child2);
 		parent0.attach(child3);
 		parent0.x += 50;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(child0._x, 51, 'child0 shifted when parent did');
 		strictEqual(child1._x, 52, 'child1 shifted when parent did');
 		child0.x += 1;
 		child1.x += 1;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(parent0._x, 50, 'child shifts do not move the parent');
 		child1.destroy();
 		deepEqual(parent0._children, [child0,child2,child3], 'child1 cleared itself from parent0._children when destroyed');
@@ -384,6 +406,7 @@ $(document).ready(function() {
 	});
 
 	test("child_rotate", function () {
+		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var parent = Crafty.e("2D, DOM, Color")
 			.attr({x:0, y:0, w:50, h:50, rotation:10})
 			.color("red");
@@ -392,9 +415,11 @@ $(document).ready(function() {
 			.color("red");
 		parent.attach(child);
 		parent.rotation += 20;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(parent.rotation, 30, 'parent rotates normally');
 		strictEqual(child.rotation, 35, 'child follows parent rotation');
 		child.rotation += 22;
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(parent.rotation, 30, 'parent ignores child rotation');
 		strictEqual(child.rotation, 57, 'child rotates normally');
 		// Clean up
@@ -413,9 +438,11 @@ $(document).ready(function() {
 
 
         test("disableControl and enableControl", function () {
+            var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
             var e = Crafty.e("2D, Twoway")
                 .attr({ x: 0 })
                 .twoway(1);
+            if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
             equal(e._movement.x, 0);
             equal(e._x, 0);
@@ -454,8 +481,10 @@ $(document).ready(function() {
 
 
 		test("Resizing 2D objects & hitboxes", function(){
+			var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 			var e = Crafty.e("2D, Collision");
 			e.attr({x:0, y:0, w:40, h:50})	
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			
 			equal(e.map.points[0][0], 0, "Before rotation: x_0 is 0")
 			equal(e.map.points[0][1], 0, "y_0 is 0")
@@ -463,6 +492,7 @@ $(document).ready(function() {
 			equal(e.map.points[2][1], 50, "y_2 is 50")
 
 			e.rotation = 90;
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
 			equal( Math.round(e.map.points[0][0]), 0, "After rotation by 90 deg: x_0 is 0")
 			equal( Math.round(e.map.points[0][1]), 0, "y_0 is 0")
@@ -486,6 +516,7 @@ $(document).ready(function() {
 			// Check that changing the width when rotated resizes correctly for both hitbox and MBR
 			// Rotated by 90 degrees, changing the width of the entity should change the height of the hitbox/mbr
 			e.w = 100;
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
 			equal( Math.round(e.map.points[0][0]), 0, "After rotation and increase in width: x_0 is 0")
 			equal( Math.round(e.map.points[0][1]), 0, "y_0 is 0")
@@ -497,11 +528,16 @@ $(document).ready(function() {
 			equal( Math.round(e._mbr._h), 100, "_mbr._h is  100" );
 			equal( Math.round(e._mbr._x), -50, "_mbr._x is -50");
 			equal( Math.round(e._mbr._y), 0, "_mbr._y is 0");
-
+			
+			e.destroy();
 		});
 
 	module("DebugLayer");
 		test("DebugCanvas", function(){
+			if (!(Crafty.support.canvas)) {
+				expect(0);
+				return;
+			}
 			var e = Crafty.e("2D, DebugCanvas");
 			var ctx = Crafty.DebugCanvas.context;
 
@@ -527,13 +563,18 @@ $(document).ready(function() {
 		});
 
 		test("VisibleMBR and DebugRect", function(){
+			var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 			var e = Crafty.e("2D, VisibleMBR").attr({x:10, y:10, w:10, h:20});
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e._assignRect();
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.debugRect._x, 10, "debugRect has correct x coord");
 			equal(e.debugRect._h, 20, "debugRect has correct height");
 
 			e.rotation = 90;
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e._assignRect();
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.debugRect._h, 10, "debugRect has correct height of MBR after rotation");
 
 			e.destroy();
@@ -541,8 +582,11 @@ $(document).ready(function() {
 		});
 
 		test("Hitbox debugging", function(){
+			var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 			var e = Crafty.e("2D, Collision, WiredHitBox").attr({x:10, y:10, w:10, h:20}).collision();
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e.matchHitBox(); // only necessary until collision works properly!
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.polygon.points[0][0], 10, "WiredHitBox -- correct x coord for upper right corner");
 			equal(e.polygon.points[2][1], 30, "correct y coord for lower right corner");
 			notEqual(typeof e._debug.strokeStyle, "undefined" , "stroke style is assigned");
@@ -551,14 +595,18 @@ $(document).ready(function() {
 			e.destroy();
 
 			var e = Crafty.e("2D, Collision, SolidHitBox").attr({x:10, y:10, w:10, h:20}).collision();
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e.matchHitBox(); // only necessary until collision works properly!
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.polygon.points[0][0], 10, "SolidHitBox -- correct x coord for upper right corner");
 			equal(e.polygon.points[2][1], 30, "correct y coord for lower right corner");
 			equal(typeof e._debug.strokeStyle, "undefined" , "stroke style is undefined");
 			notEqual(typeof e._debug.fillStyle, "undefined", "fill style is assigned");
 
 			e.collision( new Crafty.polygon([0, 0], [15, 0], [0, 15]) );
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e.matchHitBox();
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.polygon.points[2][1], 25, "After change -- correct y coord for third point");
 
 			e.destroy();


### PR DESCRIPTION
As discussed at #456 , this pull-request fixes the core.html unit tests to reduce false-positives in IE8 (and also one in IE10). Some of the unit tests still fail in IE8, but I think the remaining ones are actual problems in the crafty code, not just bad tests. I ran the tests and they all pass in IE10, IE9 mode (in IE10), chromium, firefox, and grunt (phantomjs).

(This is a re-do of https://github.com/craftyjs/Crafty/pull/553 after incorporating the suggestions.)
