### PR TITLE
Text property family should have singlequotes around the string

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -90,7 +90,8 @@ module.exports = function (grunt) {
                 'tests/events.html',
                 'tests/math.html',
                 'tests/isometric.html',
-                'tests/loader.html'
+                'tests/loader.html',
+                'tests/text.html'
             ]
         }, 
 

--- a/src/text.js
+++ b/src/text.js
@@ -158,7 +158,11 @@ Crafty.c("Text", {
 
             if (typeof key === "object") {
                 for (var propertyKey in key) {
-                    this._textFont[propertyKey] = key[propertyKey];
+                    if(propertyKey == 'family'){
+                        this._textFont[propertyKey] = "'" + key[propertyKey] + "'";
+                    } else {
+                        this._textFont[propertyKey] = key[propertyKey]; 
+                    }
                 }
             }
         } else {

--- a/tests/text.html
+++ b/tests/text.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" 
+                    "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+  <script src="./lib/jquery.min.js"></script>
+  <link rel="stylesheet" href="./lib/qunit.css" type="text/css" media="screen" />
+  <script type="text/javascript" src="./lib/qunit.js"></script>
+  <script type="text/javascript" src="../crafty.js"></script>
+
+<script>
+$(document).ready(function() {
+  module("Text");
+  Crafty.init();
+
+  test("fontFamily", function() {
+    var text = Crafty.e('DOM, Text').textFont({ family : 'Times New Roman 400', size : '30px' }).text('Test');
+    equal(text.attr('_textFont')['family'], "'Times New Roman 400'", 'Expect to have singlequotes arount the family property.');
+  });
+
+
+});
+</script>
+  
+</head>
+<body>
+<h1 id="qunit-header">Crafty: Core</h1>
+<h2 id="qunit-banner"></h2>
+<div id="qunit-testrunner-toolbar"></div>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests"></ol>
+<div id="qunit-fixture">test markup, will be hidden</div>
+</body>
+</html>


### PR DESCRIPTION
Fixes bug reported in #569

Also made a test for it, which checks that the family has singlequotes around the text.
