### PR TITLE
Remove browserify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "grunt-jsvalidate": "0.2.1",
     "marked": "0.2.9",
     "coffee-script": "1.6.3",
-    "browserify": "~2.34.3",
     "grunt-browserify": "~1.2.9",
     "grunt-banner": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3"


### PR DESCRIPTION
It's not used anywhere besides in grunt-browserify, which already defines it as a peer dependency. It will still be installed to `node_modules` upon `npm install` anyways.
