### PR TITLE
Fix or suppress warnings produced by jshint

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -220,6 +220,11 @@ Crafty.extend({
         paddingX = parseInt(paddingX || 0, 10); //just incase
         paddingY = parseInt(paddingY || 0, 10);
 
+        var markSpritesReady = function() {
+            this.ready = true;
+            this.trigger("Change");
+        };
+
         img = Crafty.asset(url);
         if (!img) {
             img = new Image();
@@ -228,13 +233,31 @@ Crafty.extend({
             img.onload = function () {
                 //all components with this img are now ready
                 for (var spriteName in map) {
-                    Crafty(spriteName).each(function () {
-                        this.ready = true;
-                        this.trigger("Change");
-                    });
+                    Crafty(spriteName).each(markSpritesReady);
                 }
             };
         }
+
+        var sharedSpriteInit = function() {
+            this.requires("2D, Sprite");
+            this.__trim = [0, 0, 0, 0];
+            this.__image = url;
+            this.__coord = [this.__coord[0], this.__coord[1], this.__coord[2], this.__coord[3]];
+            this.__tile = tile;
+            this.__tileh = tileh;
+            this.__padding = [paddingX, paddingY];
+            this.img = img;
+
+            //draw now
+            if (this.img.complete && this.img.width > 0) {
+                this.ready = true;
+                this.trigger("Change");
+            }
+
+            //set the width and height to the sprite size
+            this.w = this.__coord[2];
+            this.h = this.__coord[3];
+        };
 
         for (spriteName in map) {
             if (!map.hasOwnProperty(spriteName)) continue;
@@ -250,26 +273,7 @@ Crafty.extend({
                 ready: false,
                 __coord: [x, y, w, h],
 
-                init: function () {
-                    this.requires("2D, Sprite");
-                    this.__trim = [0, 0, 0, 0];
-                    this.__image = url;
-                    this.__coord = [this.__coord[0], this.__coord[1], this.__coord[2], this.__coord[3]];
-                    this.__tile = tile;
-                    this.__tileh = tileh;
-                    this.__padding = [paddingX, paddingY];
-                    this.img = img;
-
-                    //draw now
-                    if (this.img.complete && this.img.width > 0) {
-                        this.ready = true;
-                        this.trigger("Change");
-                    }
-
-                    //set the width and height to the sprite size
-                    this.w = this.__coord[2];
-                    this.h = this.__coord[3];
-                }
+                init: sharedSpriteInit
             });
         }
 

--- a/src/loader.js
+++ b/src/loader.js
@@ -380,6 +380,8 @@ Crafty.extend({
             $script.path = function (p) {
                 scriptpath = p;
             };
+            // This function is a tangled mess of conciseness, so suppress warnings here
+            /* jshint -W030 */
             $script.ready = function (deps, ready, req) {
                 deps = deps[push] ? deps : [deps];
                 var missing = [];
@@ -395,7 +397,7 @@ Crafty.extend({
                 }(deps.join('|'));
                 return $script;
             };
-
+            /* jshint +W030 */
             $script.noConflict = function () {
                 win.$script = old;
                 return this;

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,6 +1,10 @@
 var Crafty = require('./core.js'),
     document = window.document;
 
+// Directive for jshint to ignore evals
+// eval is used to support IE8, so this can be removed if we decide to drop that
+/* jshint evil:true */
+
 /**@
  * #Storage
  * @category Utilities


### PR DESCRIPTION
This patch makes it so we pass jshint without any issues.
- Moves some function creation outside of loops.  One of those might have actually generated a lot of unnecessary garbage, the other probably doesn't make a difference.
- Jshint complained about our use of eval in `storage.js`; since we need that for IE8, I suppressed the warning for that file.
- It also didn't like the tricky uses of `&&` and `||` to make a bit of code more concise in `loader.js`.   That code is actually so unreadable I just suppressed those warnings for now.  If someone wants to patch that up, go for it!

This would fix #539.
