### PR TITLE
Get the version from the package.json and inject it into version.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,5 @@
 require("coffee-script");
+var fs = require('fs');
 
 module.exports = function (grunt) {
     var pkg = grunt.file.readJSON('package.json');
@@ -109,6 +110,10 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-jsvalidate');
     grunt.loadNpmTasks('grunt-browserify');
     grunt.loadNpmTasks('grunt-banner');
+
+    grunt.registerTask('version', 'Takes the version into src/version.js', function() {
+        fs.writeFileSync('src/version.js', 'module.exports = "' + version + '";');
+    });
     
     // Build development
     grunt.registerTask('build:dev', ['browserify:debug', 'usebanner']);
@@ -126,7 +131,7 @@ module.exports = function (grunt) {
     grunt.registerTask('check', ['build:dev', 'jsvalidate', 'qunit', 'jshint']);
 
     // Make crafty.js ready for release - minified version
-    grunt.registerTask('release', ['build:release', 'uglify', 'api']);
+    grunt.registerTask('release', ['version', 'build:release', 'uglify', 'api']);
 
     // Run only tests
     grunt.registerTask('validate', ['qunit']);

--- a/src/core.js
+++ b/src/core.js
@@ -1,3 +1,5 @@
+var version = require('./version');
+
 /**@
  * #Crafty
  * @category Core
@@ -863,8 +865,7 @@ Crafty.extend({
      * ~~~
      */
     getVersion: function () {
-        var pjson = require('../package.json');
-        return pjson.version;
+        return version;
     },
 
     /**@

--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,1 @@
+module.exports = "0.5.4";

--- a/tests/core.html
+++ b/tests/core.html
@@ -30,8 +30,8 @@ $(document).ready(function() {
 	module("CORE");
 
 	test("getVersion", function() {
-		var actualVersion = "0.5.4";
-		strictEqual(Crafty.getVersion(), actualVersion, "The actual library version");
+		
+		ok(Crafty.getVersion(), "The actual library version");
 	});
 		
 	test("selectors", function() {


### PR DESCRIPTION
This reads the version from the package.json and inject it into version.js

This solves that the whole package.json file is not included in the browserified crafty.js, when it is build. Saves kilobytes.

I also changes the test so it checks for a non empty string, so the test do not have to be changes every time the version is bumped.

---

I first create a more complex solution where the version.js file contained `module.exports = "dev";`, and only when you was building for release (`grunt release`), it would change the version and afterwards cleanup and put it back to what is was before. But that meant that when we was building for development, there would be no version in the crafty.js file, and i did not think that was a good idea.

---

This is the simple solution. Maybe it is best to Keep It Simple?
