### PR TITLE
Gravity collision detected only on top.

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -1045,6 +1045,7 @@ Crafty.c("Gravity", {
      */
     gravity: function (comp) {
         if (comp) this._anti = comp;
+        if(isNaN(this._jumpSpeed)) this._jumpSpeed = 0; //set to 0 if Twoway component is not present
 
         this.bind("EnterFrame", this._enterFrame);
 
@@ -1108,8 +1109,10 @@ Crafty.c("Gravity", {
             }
         }
 
-        if (hit) { //stop falling if found
-            if (this._falling) this.stopFalling(hit);
+        if (hit) { //stop falling if found and player is moving down
+            if (this._falling && ((this._gy > this._jumpSpeed) || !this._up)){
+              this.stopFalling(hit);
+            } 
         } else {
             this._falling = true; //keep falling otherwise
         }

--- a/src/controls.js
+++ b/src/controls.js
@@ -908,12 +908,16 @@ Crafty.c("Twoway", {
         });
 
         if (speed) this._speed = speed;
-        if (arguments.length < 2) jump = this._speed * 2;
+        if (arguments.length < 2){
+          this._jumpSpeed = this._speed * 2;
+        } else{
+          this._jumpSpeed = jump;
+        }
 
         this.bind("EnterFrame", function () {
             if (this.disableControls) return;
             if (this._up) {
-                this.y -= jump;
+                this.y -= this._jumpSpeed;
                 this._falling = true;
             }
         }).bind("KeyDown", function () {


### PR DESCRIPTION
I am working on a runner inspired by http://www.mylostgames.com/play/nyan_cat_lost_in_space . I need a mechanism for main character to jump on platforms from below (like in Icy Tower). I am using Twoway and Gravity components. 

Current implementation of gravity against 'anti' objects make character go immediately up at any contact: http://www.youtube.com/watch?v=kdhKF39-IKc . 

This pull request changes make character being stopped by platforms only when he is on top on them: http://www.youtube.com/watch?v=j6vOzTU3kaY. Treshold of 10 pixels was choosen as it avoids jumpy animation and  ensures good collision detection.

I would be grateful for a tip on how to detect if character is moving up or down, so that I can stop his movement only if he gets on platform from above.
