### PR TITLE
Change how rotation cascades for 2D entities

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -935,12 +935,12 @@ Crafty.c("2D", {
      * Method for rotation rather than through a setter
      */
     rotate: function (e) {
-        //assume event data origin
-        this._origin.x = e.o.x - this._x;
-        this._origin.y = e.o.y - this._y;
-
-        //modify through the setter method
+        var x2, y2;
+        x2 =  (this._x + this._origin.x - e.o.x) * e.cos + (this._y + this._origin.y - e.o.y) * e.sin + (e.o.x - this._origin.x)
+        y2 =  (this._y + this._origin.y - e.o.y) * e.cos - (this._x + this._origin.x - e.o.x) * e.sin + (e.o.y - this._origin.y);
         this._attr('_rotation', this._rotation - e.deg);
+        this._attr('_x', x2 );
+        this._attr('_y', y2 );        
     },
 
     /**@

--- a/tests/core.html
+++ b/tests/core.html
@@ -410,25 +410,36 @@ $(document).ready(function() {
 	});
 
 	test("child_rotate", function () {
+		var Round = function(x){ return Math.round(x*100)/100 };
 		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var parent = Crafty.e("2D, DOM, Color")
 			.attr({x:0, y:0, w:50, h:50, rotation:10})
 			.color("red");
 		var child = Crafty.e("2D, DOM, Color")
-			.attr({x:1, y:1, w:50, h:50, rotation:15})
+			.attr({x:10, y:10, w:50, h:50, rotation:15})
 			.color("red");
 		parent.attach(child);
+
 		parent.rotation += 20;
 		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(parent.rotation, 30, 'parent rotates normally');
 		strictEqual(child.rotation, 35, 'child follows parent rotation');
+
 		child.rotation += 22;
 		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(parent.rotation, 30, 'parent ignores child rotation');
 		strictEqual(child.rotation, 57, 'child rotates normally');
+
+		parent.rotation = 100;	// Rotation by 90 degrees from initial position
+		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
+		strictEqual( Round(child.x), -10, "Child moved around parent upon rotation (x).")
+		strictEqual( Round(child.y), 10, "Child moved around parent upon rotation (y).")
+
 		// Clean up
 		Crafty("*").destroy();
 	});
+
+
 
 	// This test assumes that the "circles" are really octagons, as per Crafty.circle.
 	test("SAT", function () {


### PR DESCRIPTION
Previously when a parent rotated, it changed the origin and rotation of children directly.  This prevented independent rotation of children.

After this patch, children are rotated about their own origin, and shifted to the correct position relative to the parent.

This fixes #593.
