### PR TITLE
Use event data in control component Twoway

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -916,8 +916,9 @@ Crafty.c("Twoway", {
                 this.y -= jump;
                 this._falling = true;
             }
-        }).bind("KeyDown", function () {
-            if (this.isDown("UP_ARROW") || this.isDown("W") || this.isDown("Z")) this._up = true;
+        }).bind("KeyDown", function (e) {
+            if (e.key === Crafty.keys["UP_ARROW"] || e.key === Crafty.keys["W"] || e.key === Crafty.keys["Z"])
+                this._up = true;
         });
 
         return this;


### PR DESCRIPTION
Instead of polling the current keyboard state, use keyboard event data

remake of #597
