### PR TITLE
Extension of Gravity component - moving platforms

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -1019,7 +1019,7 @@ Crafty.c("Gravity", {
     _gy: 0,
     _falling: true,
     _anti: null,
-	_attachedToEntity: null,
+    _attachedToEntity: null,
 
     init: function () {
         this.requires("2D");
@@ -1031,12 +1031,12 @@ Crafty.c("Gravity", {
      * @sign public this .gravity([comp], [shouldAttach])
      * @param comp - The name of a component that will stop this entity from falling
      * @param shouldAttach - The truth value if the entity should attach upon landing on platform.
-	 *
+     *
      * Enable gravity for this entity no matter whether comp parameter is not specified,
      * If comp parameter is specified all entities with that component will stop this entity from falling.
      * For a player entity in a platform game this would be a component that is added to all entities
      * that the player should be able to walk on.
-	 * If you have moving platforms set shouldAttach to true.
+     * If you have moving platforms set shouldAttach to true.
      *
      * @example
      * ~~~
@@ -1048,11 +1048,10 @@ Crafty.c("Gravity", {
      */
     gravity: function (comp, shouldAttach) {
         if (comp) this._anti = comp;
-		this._shouldAttach = !!shouldAttach;
+        this._shouldAttach = !!shouldAttach;
 
         this.bind("EnterFrame", this._enterFrame);
 
-		
         return this;
     },
 
@@ -1115,25 +1114,25 @@ Crafty.c("Gravity", {
 
         if (hit) { //stop falling if found
             if (this._falling) this.stopFalling(hit);
-			
-			if (this._shouldAttach) {
-				//detach from old entity, attach to new one
-				if (this._attachedToEntity !== hit) {
-					if (this._attachedToEntity)
-						this._attachedToEntity.detach(this);
-					this._attachedToEntity = hit;
-					this._attachedToEntity.attach(this);
-				}
-			}
+            
+            if (this._shouldAttach) {
+                //detach from old entity, attach to new one
+                if (this._attachedToEntity !== hit) {
+                    if (this._attachedToEntity)
+                        this._attachedToEntity.detach(this);
+                    this._attachedToEntity = hit;
+                    this._attachedToEntity.attach(this);
+                }
+            }
         } else {
             this._falling = true; //keep falling otherwise
-			
-			if (this._shouldAttach) {
-				//detach from old entity
-				if (this._attachedToEntity)
-					this._attachedToEntity.detach(this);
-				this._attachedToEntity = null;
-			}
+            
+            if (this._shouldAttach) {
+                //detach from old entity
+                if (this._attachedToEntity)
+                    this._attachedToEntity.detach(this);
+                this._attachedToEntity = null;
+            }
         }
     },
 

--- a/src/2D.js
+++ b/src/2D.js
@@ -1019,6 +1019,7 @@ Crafty.c("Gravity", {
     _gy: 0,
     _falling: true,
     _anti: null,
+	_attachedToEntity: null,
 
     init: function () {
         this.requires("2D");
@@ -1027,13 +1028,15 @@ Crafty.c("Gravity", {
     /**@
      * #.gravity
      * @comp Gravity
-     * @sign public this .gravity([comp])
+     * @sign public this .gravity([comp], [shouldAttach])
      * @param comp - The name of a component that will stop this entity from falling
-     *
+     * @param shouldAttach - The truth value if the entity should attach upon landing on platform.
+	 *
      * Enable gravity for this entity no matter whether comp parameter is not specified,
      * If comp parameter is specified all entities with that component will stop this entity from falling.
      * For a player entity in a platform game this would be a component that is added to all entities
      * that the player should be able to walk on.
+	 * If you have moving platforms set shouldAttach to true.
      *
      * @example
      * ~~~
@@ -1043,11 +1046,13 @@ Crafty.c("Gravity", {
      *   .gravity("platform");
      * ~~~
      */
-    gravity: function (comp) {
+    gravity: function (comp, shouldAttach) {
         if (comp) this._anti = comp;
+		this._shouldAttach = !!shouldAttach;
 
         this.bind("EnterFrame", this._enterFrame);
 
+		
         return this;
     },
 
@@ -1110,8 +1115,25 @@ Crafty.c("Gravity", {
 
         if (hit) { //stop falling if found
             if (this._falling) this.stopFalling(hit);
+			
+			if (this._shouldAttach) {
+				//detach from old entity, attach to new one
+				if (this._attachedToEntity !== hit) {
+					if (this._attachedToEntity)
+						this._attachedToEntity.detach(this);
+					this._attachedToEntity = hit;
+					this._attachedToEntity.attach(this);
+				}
+			}
         } else {
             this._falling = true; //keep falling otherwise
+			
+			if (this._shouldAttach) {
+				//detach from old entity
+				if (this._attachedToEntity)
+					this._attachedToEntity.detach(this);
+				this._attachedToEntity = null;
+			}
         }
     },
 

--- a/tests/core.html
+++ b/tests/core.html
@@ -452,47 +452,47 @@ $(document).ready(function() {
 	});
 
 
-        test("disableControl and enableControl", function () {
-            var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
-            var e = Crafty.e("2D, Twoway")
-                .attr({ x: 0 })
-                .twoway(1);
-            if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
+		test("disableControl and enableControl", function () {
+			var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
+			var e = Crafty.e("2D, Twoway")
+				.attr({ x: 0 })
+				.twoway(1);
+			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
-            equal(e._movement.x, 0);
-            equal(e._x, 0);
-            Crafty.trigger('KeyDown', { key: Crafty.keys.D });
-            Crafty.trigger('EnterFrame');
-            equal(e._movement.x, 1);
-            equal(e._x, 1);
+			equal(e._movement.x, 0);
+			equal(e._x, 0);
+			Crafty.trigger('KeyDown', { key: Crafty.keys.D });
+			Crafty.trigger('EnterFrame');
+			equal(e._movement.x, 1);
+			equal(e._x, 1);
 
-            e.disableControl();
-            Crafty.trigger('EnterFrame');
-            equal(e._movement.x, 1);
-            equal(e._x, 1);
+			e.disableControl();
+			Crafty.trigger('EnterFrame');
+			equal(e._movement.x, 1);
+			equal(e._x, 1);
 
-            Crafty.trigger('KeyUp',   { key: Crafty.keys.D });
-            Crafty.trigger('EnterFrame');
-            equal(e._movement.x, 0);
-            equal(e._x, 1);
+			Crafty.trigger('KeyUp',   { key: Crafty.keys.D });
+			Crafty.trigger('EnterFrame');
+			equal(e._movement.x, 0);
+			equal(e._x, 1);
 
-            e.enableControl();
-            Crafty.trigger('EnterFrame');
-            equal(e._movement.x, 0);
-            equal(e._x, 1);
+			e.enableControl();
+			Crafty.trigger('EnterFrame');
+			equal(e._movement.x, 0);
+			equal(e._x, 1);
 
-            Crafty.trigger('KeyDown', { key: Crafty.keys.D });
-            Crafty.trigger('EnterFrame');
-            equal(e._movement.x, 1);
-            equal(e._x, 2);
+			Crafty.trigger('KeyDown', { key: Crafty.keys.D });
+			Crafty.trigger('EnterFrame');
+			equal(e._movement.x, 1);
+			equal(e._x, 2);
 
-            Crafty.trigger('KeyUp',   { key: Crafty.keys.D });
-            Crafty.trigger('EnterFrame');
-            equal(e._movement.x, 0);
-            equal(e._x, 2);
+			Crafty.trigger('KeyUp',   { key: Crafty.keys.D });
+			Crafty.trigger('EnterFrame');
+			equal(e._movement.x, 0);
+			equal(e._x, 2);
 
-            e.destroy();
-        });
+			e.destroy();
+		});
 
 
 		test("Resizing 2D objects & hitboxes", function(){

--- a/tests/core.html
+++ b/tests/core.html
@@ -548,59 +548,73 @@ $(document).ready(function() {
 		});
 
 		asyncTest("gravity - player falls through platform", 2, function() {
+			var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 			var player = Crafty.e("2D, Gravity")
 				.attr({ x:0, y: 0, w: 10, h: 10 })
 				.gravity();
 			var platform = Crafty.e("2D, platform")
 				.attr({ x:0, y: 50, w: 10, h: 10 });
+			if (no_getter_setters) Crafty.trigger("EnterFrame");
+
 			
 			setTimeout(function() {
 				notStrictEqual(player.y, 0, "Player changed y after enabling gravity" );
 				notStrictEqual(player.y, platform.y, "Player fell through platform" );
+				
 				start();
+				player.destroy();
+				platform.destroy();
 			}, 2000);
 		});
 		
 		asyncTest("gravity - player lands on platform", 1, function() {
+			var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 			var player = Crafty.e("2D, Gravity")
 				.attr({ x:0, y: 0, w: 10, h: 10 })
 				.gravity("platform");
 			var platform = Crafty.e("2D, platform")
 				.attr({ x:0, y: 50, w: 10, h: 10 });
+			if (no_getter_setters) Crafty.trigger("EnterFrame");
 			
 			setTimeout(function() {
 				strictEqual(player.y + player.h, platform.y, "Player lands on platform" );
+				
 				start();
+				player.destroy();
+				platform.destroy();
 			}, 2000);
 		});
 		
 		asyncTest("gravity - player moves with platform", 5, function() {
-			var player = Crafty.e("2D, Collision, Gravity")
-				.attr({ x:0, y: 0, w: 10, h: 10 })
-				.gravity("platform", true);
-			var platform = Crafty.e("2D, Collision, platform")
+			var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
+			var platform = Crafty.e("2D, platform")
 				.attr({ x:0, y: 50, w: 10, h: 10 });
+			if (no_getter_setters) Crafty.trigger("EnterFrame");
+			var player = Crafty.e("2D, Gravity")
+				.attr({ x:0, y: 35, w: 10, h: 10 })
+				.gravity("platform", true);
+			if (no_getter_setters) Crafty.trigger("EnterFrame");
 			
 			setTimeout(function() {
 				platform.x += 50;
-				setTimeout(function() {
-					strictEqual(player.x, platform.x, "Player moved horizontally with platform" );
-					platform.y += 200;
-					setTimeout(function() {
-						strictEqual(player.y + player.h, platform.y, "Player moved vertically downwards with platform" );
-						platform.y -= 100;
-						setTimeout(function() {
-							strictEqual(player.y + player.h, platform.y, "Player moved vertically upwards with platform" );
-							platform.attr({ x:5, y: 55});
-							setTimeout(function() {
-								strictEqual(player.x, platform.x, "Player x matches platform x after diagonal move" );
-								strictEqual(player.y + player.h, platform.y, "Players y matches platform y after diagonal move" );
-								start(); //count assertions
-							}, 1000);
-						}, 1000);
-					}, 1000);
-				}, 1000);
+				if (no_getter_setters) Crafty.trigger("EnterFrame");
+				strictEqual(player.x, platform.x, "Player moved horizontally with platform" );
+				platform.y += 200;
+				if (no_getter_setters) Crafty.trigger("EnterFrame");
+				strictEqual(player.y + player.h, platform.y, "Player moved vertically downwards with platform" );
+				platform.y -= 100;
+				if (no_getter_setters) Crafty.trigger("EnterFrame");
+				strictEqual(player.y + player.h, platform.y, "Player moved vertically upwards with platform" );
+				platform.attr({ x:5, y: 55});
+				if (no_getter_setters) Crafty.trigger("EnterFrame");
+				strictEqual(player.x, platform.x, "Player x matches platform x after diagonal move" );
+				strictEqual(player.y + player.h, platform.y, "Players y matches platform y after diagonal move" );
+				
+				start();
+				player.destroy();
+				platform.destroy();
 			}, 2000);
+
 		});
 
 	module("DebugLayer");

--- a/tests/core.html
+++ b/tests/core.html
@@ -547,6 +547,62 @@ $(document).ready(function() {
 			e.destroy();
 		});
 
+		asyncTest("gravity - player falls through platform", 2, function() {
+			var player = Crafty.e("2D, Gravity")
+				.attr({ x:0, y: 0, w: 10, h: 10 })
+				.gravity();
+			var platform = Crafty.e("2D, platform")
+				.attr({ x:0, y: 50, w: 10, h: 10 });
+			
+			setTimeout(function() {
+				notStrictEqual(player.y, 0, "Player changed y after enabling gravity" );
+				notStrictEqual(player.y, platform.y, "Player fell through platform" );
+				start();
+			}, 2000);
+		});
+		
+		asyncTest("gravity - player lands on platform", 1, function() {
+			var player = Crafty.e("2D, Gravity")
+				.attr({ x:0, y: 0, w: 10, h: 10 })
+				.gravity("platform");
+			var platform = Crafty.e("2D, platform")
+				.attr({ x:0, y: 50, w: 10, h: 10 });
+			
+			setTimeout(function() {
+				strictEqual(player.y + player.h, platform.y, "Player lands on platform" );
+				start();
+			}, 2000);
+		});
+		
+		asyncTest("gravity - player moves with platform", 5, function() {
+			var player = Crafty.e("2D, Collision, Gravity")
+				.attr({ x:0, y: 0, w: 10, h: 10 })
+				.gravity("platform", true);
+			var platform = Crafty.e("2D, Collision, platform")
+				.attr({ x:0, y: 50, w: 10, h: 10 });
+			
+			setTimeout(function() {
+				platform.x += 50;
+				setTimeout(function() {
+					strictEqual(player.x, platform.x, "Player moved horizontally with platform" );
+					platform.y += 200;
+					setTimeout(function() {
+						strictEqual(player.y + player.h, platform.y, "Player moved vertically downwards with platform" );
+						platform.y -= 100;
+						setTimeout(function() {
+							strictEqual(player.y + player.h, platform.y, "Player moved vertically upwards with platform" );
+							platform.attr({ x:5, y: 55});
+							setTimeout(function() {
+								strictEqual(player.x, platform.x, "Player x matches platform x after diagonal move" );
+								strictEqual(player.y + player.h, platform.y, "Players y matches platform y after diagonal move" );
+								start(); //count assertions
+							}, 1000);
+						}, 1000);
+					}, 1000);
+				}, 1000);
+			}, 2000);
+		});
+
 	module("DebugLayer");
 		test("DebugCanvas", function(){
 			if (!(Crafty.support.canvas)) {


### PR DESCRIPTION
In a platformer you sometimes have moving platforms. 
If you do not attach the player to the platform, he just falls off it when the platform moves away.
Therefor I added an optional argument `shouldAttach` to the `gravity` constructor.

Example usage can be seen in the qunit tests.
