### PR TITLE
viewport for IE9/10, let it can init again.

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -629,7 +629,8 @@ Crafty.extend({
                     },
                     get: function () {
                         return this._x;
-                    }
+                    },
+                    configurable : true
                 });
                 Object.defineProperty(this, 'y', {
                     set: function (v) {
@@ -637,7 +638,8 @@ Crafty.extend({
                     },
                     get: function () {
                         return this._y;
-                    }
+                    },
+                    configurable : true
                 });
             } else {
                 // IE8 has no getter/setters -- Check for an update each frame.


### PR DESCRIPTION
  I need to use Crafty.stop(), and then use init to restart it, actually the point is to init() again. It seems strange, but I encounter a situation that the Crafty appears in one div, then it must appear in another div. When it is in IE10, I can't init for a second time just because configurable default to be false.
