### PR TITLE
Add `avoidCss3dTransform` flag

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -92,7 +92,8 @@ module.exports = function (grunt) {
                 'tests/math.html',
                 'tests/isometric.html',
                 'tests/loader.html',
-                'tests/text.html'
+                'tests/text.html',
+                'tests/dom.html'
             ]
         }, 
 

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -16,6 +16,13 @@ Crafty.c("DOM", {
     //holds current styles, so we can check if there are changes to be written to the DOM
     _cssStyles: null,
 
+    /**@
+     * #.avoidCss3dTransforms
+     * @comp DOM
+     * Avoids using of CSS 3D Transform for positioning when true. Default value is false.
+     */
+    avoidCss3dTransforms: false,
+
     init: function () {
         this._cssStyles = {
             visibility: '',
@@ -133,7 +140,7 @@ Crafty.c("DOM", {
         }
 
         //utilize CSS3 if supported
-        if (Crafty.support.css3dtransform) {
+        if (Crafty.support.css3dtransform && !this.avoidCss3dTransforms) {
             trans.push("translate3d(" + (~~this._x) + "px," + (~~this._y) + "px,0)");
         } else {
             if (this._cssStyles.left !== this._x) {

--- a/tests/dom.html
+++ b/tests/dom.html
@@ -1,0 +1,65 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" 
+                    "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+
+<!-- Note to developers: Run the "grunt check" task to run these tests in the
+    PhantomJS browser. (PhantomJS is based on webkit, so it should behave similar
+    to safari or chrome.) To run in other browsers, run "grunt" (the default task)
+    to compile crafty.js, then open this HTML file to run the tests. However,
+    you may need to change browser security settings:
+       * To run the tests in firefox: First you need to go to about:config in firefox, and
+             switch "security.fileuri.strict_origin_policy" to false. [This only changes the
+             security settings when firefox opens an HTML file saved on your computer; it does
+             not affect your security when you are browsing the internet.]
+       * To run the tests in chrome: You need to pass a flag when opening chrome.
+             For example, in Linux, you would run this command in a Linux terminal:      
+             chromium-browser /path/to/core.html --allow-file-access-from-files
+-->
+
+<head>
+  <script src="./lib/jquery.min.js"></script>
+  <link rel="stylesheet" href="./lib/qunit.css" type="text/css" media="screen" />
+  <script type="text/javascript" src="./lib/qunit.js"></script>
+  <script type="text/javascript" src="../crafty.js"></script>
+
+<script>
+
+$(document).ready(function() {
+  Crafty.init(500,500);
+  
+  module("DOM");
+  
+  test("avoidCss3dTransforms", function() {
+    var useCss3dTransforms = Crafty.e("2D, DOM")
+      .attr({x: 10, y: 10})
+      .draw();
+    
+    strictEqual(useCss3dTransforms.avoidCss3dTransforms, false);
+    strictEqual(useCss3dTransforms._cssStyles.transform, "translate3d(10px,10px,0)");
+    strictEqual(useCss3dTransforms._cssStyles.top, "");
+    strictEqual(useCss3dTransforms._cssStyles.left, "");
+
+    var avoidCss3dTransforms = Crafty.e("2D, DOM")
+      .attr({x: 10, y: 10, avoidCss3dTransforms: true})
+      .draw();
+
+    strictEqual(avoidCss3dTransforms.avoidCss3dTransforms, true);
+    strictEqual(avoidCss3dTransforms._cssStyles.transform, "");
+    strictEqual(avoidCss3dTransforms._cssStyles.top, 10);
+    strictEqual(avoidCss3dTransforms._cssStyles.left, 10);
+    // Clean up
+    Crafty("*").destroy();
+  });
+});
+</script>
+  
+</head>
+<body>
+<h1 id="qunit-header">Crafty: Core</h1>
+<h2 id="qunit-banner"></h2>
+<div id="qunit-testrunner-toolbar"></div>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests"></ol>
+<div id="qunit-fixture">test markup, will be hidden</div>
+</body>
+</html>


### PR DESCRIPTION
CSS 3D Transforms are used to set DOM entities position, this should increase performances as these operations are hardware-accelerated but using them for positioning makes CSS effects unavailable.

Setting this flag to true you can force DOM entities positioning using left and top CSS properties.
