### PR TITLE
Add a bit of functionality to Crafty.audio

### DIFF
--- a/src/sound.js
+++ b/src/sound.js
@@ -189,10 +189,11 @@ Crafty.extend({
          * @comp Crafty.audio
          * @sign public this Crafty.audio.play(String id)
          * @sign public this Crafty.audio.play(String id, Number repeatCount)
-         * @sign public this Crafty.audio.play(String id, Number repeatCount,Number volume)
+         * @sign public this Crafty.audio.play(String id, Number repeatCount, Number volume)
          * @param id - A string to refer to sounds
          * @param repeatCount - Repeat count for the file, where -1 stands for repeat forever.
          * @param volume - volume can be a number between 0.0 and 1.0
+         * @returns The audio element used to play the sound.  Null if the call failed due to a lack of open channels.
          *
          * Will play a sound previously added by using the ID that was used in `Crafty.audio.add`.
          * Has a default maximum of 5 channels so that the same sound can play simultaneously unless all of the channels are playing.
@@ -214,7 +215,7 @@ Crafty.extend({
             var s = this.sounds[id];
             var c = this.getOpenChannel();
             if (!c)
-                return;
+                return null;
             c.id = id;
             var a = c.obj;
 
@@ -246,6 +247,8 @@ Crafty.extend({
 
             };
             a.addEventListener("ended", c.onEnd, true);
+
+            return a;
         },
 
 

--- a/src/sound.js
+++ b/src/sound.js
@@ -347,24 +347,14 @@ Crafty.extend({
         stop: function (id) {
             if (!Crafty.support.audio)
                 return;
-            var s;
-            if (!id) {
-                for (var i in this.channels) {
-
-                    c = this.channels[i];
-                    if (c.active) {
-                        c.active = false;
-                        c.obj.pause();
-                    }
+            for (var i in this.channels) {
+                c = this.channels[i];
+                if ( (!id && c.active) || c._is(id) ) {
+                    c.active = false;
+                    c.obj.pause();
                 }
-                return;
             }
-
-            s = this.sounds[id];
-            if (!s)
-                return;
-            if (!s.obj.paused)
-                s.obj.pause();
+            return;
         },
         /**
          * #Crafty.audio._mute


### PR DESCRIPTION
This makes it so that `Crafty.audio.play` returns the actual audio element used to play the sound.

I also fixed a bug in how `audio.stop()` works; it wasn't properly updated when we switched to the channels approach.

There are probably some other, simple things we could do to make the audio stuff easier to use; since we might switch to using the web audio API in the future, it would be ideal if you never _needed_ to manipulate the audio elements directly.

So anyone have any specific ideas for small improvements?
