### PR TITLE
Fix debug polygon drawing

### DIFF
--- a/src/DebugLayer.js
+++ b/src/DebugLayer.js
@@ -232,7 +232,7 @@ Crafty.c("DebugPolygon", {
     drawDebugPolygon: function () {
         ctx = Crafty.DebugCanvas.context;
         ctx.beginPath();
-        for (var p in this.polygon.points) {
+        for (var p in this.map.points) {
             ctx.lineTo(this.map.points[p][0], this.map.points[p][1]);
         }
         ctx.closePath();


### PR DESCRIPTION
The polygon is always 4 points, where if someone passes in a custom hit area with less than 4 points or more than 4 points the polygon debug drawing will fail, or only draw 4 of N points.

This is not a breaking change, only a bug fix
