### PR TITLE
Fix, for applying a flat array to a rotated model

### DIFF
--- a/src/collision.js
+++ b/src/collision.js
@@ -59,6 +59,11 @@ Crafty.c("Collision", {
             this.bind("Resize", this._resizeMap);
         }
 
+        if (arguments.length > 1) {
+            //convert args to array to create polygon
+            var args = Array.prototype.slice.call(arguments, 0);
+            poly = new Crafty.polygon(args);
+        }
 
         if (this.rotation) {
             poly.rotate({
@@ -69,12 +74,6 @@ Crafty.c("Collision", {
                     y: this._origin.y
                 }
             });
-        }
-
-        if (arguments.length > 1) {
-            //convert args to array to create polygon
-            var args = Array.prototype.slice.call(arguments, 0);
-            poly = new Crafty.polygon(args);
         }
 
         this.map = poly;


### PR DESCRIPTION
The evaluation order was incorrect if you passed in a flat array for the collision area if the model was already rotated.
