### PR TITLE
Logic error in "DebugPolygon"

### DIFF
--- a/src/DebugLayer.js
+++ b/src/DebugLayer.js
@@ -230,10 +230,13 @@ Crafty.c("DebugPolygon", {
     },
 
     drawDebugPolygon: function () {
+        if (typeof this.polygon === "undefined")
+            return;
+
         ctx = Crafty.DebugCanvas.context;
         ctx.beginPath();
         for (var p in this.polygon.points) {
-            ctx.lineTo(this.map.points[p][0], this.map.points[p][1]);
+            ctx.lineTo(this.polygon.points[p][0], this.polygon.points[p][1]);
         }
         ctx.closePath();
 


### PR DESCRIPTION
Currently DebugPolygon iterates through the designated polygon, but uses the equivalent points in the hitmap for drawing.  This can cause errors when they're not the same length, in addition to just being wrong!

Also, test that the polygon exists before trying to draw it.
