### PR TITLE
Make "Text" work better with canvas

### DIFF
--- a/tests/text.html
+++ b/tests/text.html
@@ -15,8 +15,41 @@ $(document).ready(function() {
   test("fontFamily", function() {
     var text = Crafty.e('DOM, Text').textFont({ family : 'Times New Roman 400', size : '30px' }).text('Test');
     equal(text.attr('_textFont')['family'], "'Times New Roman 400'", 'Expect to have singlequotes arount the family property.');
+
+    Crafty("*").destroy();
   });
 
+  test("_getFontHeight", function(){
+    var e = Crafty.e("Text");
+    var h = e._getFontHeight("10px");
+    equal(h, 10, "Font height is 10 pixels");
+    h = e._getFontHeight("10in");
+    equal(h, 960, "Font height is 960 pixels");
+    Crafty("*").destroy();
+  })
+
+  test("Width of canvas element", function(){
+    var e = Crafty.e("2D, Canvas, Text");
+    e.text("a");
+    var w1 = e.w;
+    e.text("abc");
+    var w2 = e.w;
+    ok(w2>w1, "Entity increases in width when text is changed.")
+    Crafty("*").destroy();
+  })
+
+  test("Height of canvas element", function(){
+    var e = Crafty.e("2D, Canvas, Text");
+    e.text("a");
+    e.textFont("size", "10");
+    var h1 = e.h;
+    ok( h1 > 10, "Font height set correctly.")
+    e.textFont("size", "20");
+    var h2 = e.h;
+    ok( h2 > 20, "Font height set correctly.")
+    ok(h2 > h1, "Entity increases in height when font size is increased.")
+    Crafty("*").destroy();
+  })
 
 });
 </script>


### PR DESCRIPTION
This is based on @kcaze's patch #499.  Thanks for the original PR!

The major change is that a "Canvas, Text" entity will automatically resize when either its font or text are changed.
This is accomplished by using measureText() to get the width, and estimating the font size in pixels for the height.
Currently the width is adjusted _after_ drawing, and the height not at all.  This often caused the text to be rendered with portions cut-off.

Text is now also drawn at the (x,y) coordinate of the entity, with the baseline set to "top".  Previously text was translated to the bottom left corner of the entity, resulting in descenders getting cut-off.

Tests were added for the new resizing feature.
