### PR TITLE
Remove .setVersion on IndexedDB as it has been deprecated.

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -295,7 +295,7 @@ Crafty.storage = (function () {
                     stores.push('cache');
                 }
                 if (db === null) {
-                    var request = indexedDB.open(gameName);
+                    var request = indexedDB.open(gameName, 1);
                     request.onsuccess = function (e) {
                         db = e.target.result;
                         getTimestamps();
@@ -329,16 +329,13 @@ Crafty.storage = (function () {
                 }
 
                 function createStores() {
-                    var request = db.setVersion("1.0");
-                    request.onsuccess = function (e) {
-                        for (var i = 0; i < stores.length; i++) {
-                            var st = stores[i];
-                            if (db.objectStoreNames.contains(st)) continue;
-                            var store = db.createObjectStore(st, {
-                                keyPath: "key"
-                            });
-                        }
-                    };
+                    for (var i = 0; i < stores.length; i++) {
+                        var st = stores[i];
+                        if (db.objectStoreNames.contains(st)) continue;
+                        var store = db.createObjectStore(st, {
+                            keyPath: "key"
+                        });
+                    }
                 }
             },
 


### PR DESCRIPTION
Based on #518 by @chadams.  Removes a deprecated method of opening an IndexedDB datastore.

I have no idea if this actually works, just wanted to update the PR so it was in a state that could be tested.
