### PR TITLE
Fix bugs in stage.html centerOn

### DIFF
--- a/tests/stage.html
+++ b/tests/stage.html
@@ -97,15 +97,16 @@
 		Crafty.timer.simulateFrames(10);
 		equal(Crafty.viewport._x, -e.w / 2 + Crafty.viewport.width / 2, "Entity still centered 10 frames later");
 
-		
+		Crafty.viewport.clampToEntities = false;		
 		var e2 = Crafty.e("2D, DOM").attr({ x: 450, y: 450, w: 20, h: 20 });
 		Crafty.viewport.scroll('x', 1500);
 		Crafty.viewport.scroll('y', 300);
 		Crafty.viewport.centerOn(e2, 1);
 		Crafty.timer.simulateFrames(1);
-		equal(Crafty.viewport._x, -(e2.x + e2.w/2 - Crafty.viewport.width / 2), "Entity centered from non-zero origin");
-		equal(Crafty.viewport._y, -(e2.y + e2.h/2 - Crafty.viewport.height / 2), "Entity centered from non-zero origin");
+		equal(Crafty.viewport._x, Math.floor(-(e2.x + e2.w/2 - Crafty.viewport.width / 2)), "Entity centered from non-zero origin");
+		equal(Crafty.viewport._y, Math.floor(-(e2.y + e2.h/2 - Crafty.viewport.height / 2)), "Entity centered from non-zero origin");
 		
+		Crafty.viewport.clampToEntities = true;	
 		Crafty.viewport.scroll('x', 0);
 		Crafty.viewport.scroll('y', 0);
 	});


### PR DESCRIPTION
This fixes a couple of bugs in the centerOn tests.
- Expected values of viewport x/y will be integers
- clampToEntities needs to be turned off for one of the tests to work

Both of theses issues were invisible in phantomJS due to the default viewport size.
