### PR TITLE
Bug Fix: Don't clobber background CSS property for the Image component

### DIFF
--- a/src/drawing.js
+++ b/src/drawing.js
@@ -121,8 +121,10 @@ Crafty.c("Image", {
                 context.fillRect(0, 0, this._w, this._h);
                 context.restore();
             } else if (e.type === "DOM") {
-                if (this.__image)
-                    e.style.background = "url(" + this.__image + ") " + this._repeat;
+                if (this.__image) {
+                  e.style["background-image"] = "url(" + this.__image + ")";
+                  e.style["background-repeat"] = this._repeat;
+                }
             }
         };
 


### PR DESCRIPTION
Expected: when adding a CSS property to an image entity, it should apply the CSS to the image element

Example: Crafty.e("2D, DOM, Image").image("bg.png").css({"background-size": "contain"});

Currently: background-size would not be added to the image element because the general background property wouldn't allow for specific background property
