### PR TITLE
Fixed bug in sound

### DIFF
--- a/src/sound.js
+++ b/src/sound.js
@@ -262,9 +262,6 @@ Crafty.extend({
         maxChannels: 7,
         setChannels: function (n) {
             this.maxChannels = n;
-            if (n > channels.length)
-                this.channels.length = n;
-
         },
 
         channels: [],


### PR DESCRIPTION
Expanding channels without actually adding channels causes errors, as it tries to call methods on undefined.
