### PR TITLE
Chrome workaround and bug in setChannels

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -93,7 +93,8 @@ module.exports = function (grunt) {
                 'tests/isometric.html',
                 'tests/loader.html',
                 'tests/text.html',
-                'tests/dom.html'
+                'tests/dom.html',
+                'tests/sound.html'
             ]
         }, 
 

--- a/src/sound.js
+++ b/src/sound.js
@@ -262,9 +262,8 @@ Crafty.extend({
         maxChannels: 7,
         setChannels: function (n) {
             this.maxChannels = n;
-            if (n > channels.length)
+            if (n < channels.length)
                 this.channels.length = n;
-
         },
 
         channels: [],
@@ -277,7 +276,7 @@ Crafty.extend({
                 }
             }
             // If necessary, create a new element, unless we've already reached the max limit
-            if (i <= this.maxChannels) {
+            if (i < this.maxChannels) {
                 var c = {
                     obj: this.audioElement(),
                     active: true,

--- a/src/sound.js
+++ b/src/sound.js
@@ -217,6 +217,7 @@ Crafty.extend({
             if (!c)
                 return null;
             c.id = id;
+            c.repeat = repeat
             var a = c.obj;
 
 
@@ -230,7 +231,7 @@ Crafty.extend({
             a.play();
             s.played++;
             c.onEnd = function () {
-                if (s.played < repeat || repeat == -1) {
+                if (s.played < c.repeat || repeat == -1) {
                     if (this.currentTime)
                         this.currentTime = 0;
                     this.play();
@@ -270,9 +271,15 @@ Crafty.extend({
         // Finds an unused audio element, marks it as in use, and return it.
         getOpenChannel: function () {
             for (var i = 0; i < this.channels.length; i++) {
-                if (this.channels[i].active === false) {
-                    this.channels[i].active = true;
-                    return this.channels[i];
+                var chan = this.channels[i]
+                if (chan.active === false
+                  /*
+                   * Also look for stuff that's out of use,
+                   * but fallen foul of Chromium bug 280417
+                   */
+                   || chan.obj.ended && chan.repeat <= this.sounds[chan.id].played) {
+                    chan.active = true;
+                    return chan;
                 }
             }
             // If necessary, create a new element, unless we've already reached the max limit

--- a/src/sound.js
+++ b/src/sound.js
@@ -217,7 +217,7 @@ Crafty.extend({
             if (!c)
                 return null;
             c.id = id;
-            c.repeat = repeat
+            c.repeat = repeat;
             var a = c.obj;
 
 
@@ -271,13 +271,13 @@ Crafty.extend({
         // Finds an unused audio element, marks it as in use, and return it.
         getOpenChannel: function () {
             for (var i = 0; i < this.channels.length; i++) {
-                var chan = this.channels[i]
-                if (chan.active === false
+                var chan = this.channels[i];
                   /*
-                   * Also look for stuff that's out of use,
+                   * Second test looks for stuff that's out of use,
                    * but fallen foul of Chromium bug 280417
                    */
-                   || chan.obj.ended && chan.repeat <= this.sounds[chan.id].played) {
+                if (chan.active === false ||
+                      chan.obj.ended && chan.repeat <= this.sounds[chan.id].played) {
                     chan.active = true;
                     return chan;
                 }

--- a/tests/sound.html
+++ b/tests/sound.html
@@ -1,0 +1,122 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" 
+                    "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+  <script src="./lib/jquery.min.js"></script>
+  <link rel="stylesheet" href="./lib/qunit.css" type="text/css" media="screen" />
+  <script type="text/javascript" src="./lib/qunit.js"></script>
+  <script type="text/javascript" src="../crafty.js"></script>
+
+<script>
+$(document).ready(function() {
+  module("Audio");
+  
+  //Set up some test fixtures
+  function MockAudio() {
+    var self = this
+    this.endedListeners = []
+    this.canPlayType = function() {return true}
+    this.addEventListener = function(event, listener) {
+      switch(event) {
+        case "ended":
+          this.endedListeners.push(listener)
+          break
+        default:
+          throw new Exception("Not implemented")
+      }
+    }
+    this.removeEventListener = function(event, listener) {
+      switch(event) {
+        case "ended":
+          var ind = this.endedListeners.indexOf(listener)
+          if (ind) this.endedListeners.splice(ind, 1);
+          break
+        default:
+          throw new Exception("Not implemented")
+      }
+    }
+    function fireEnded() {
+      setTimeout(function() {
+        self.ended = true
+        self.endedListeners.forEach(function(f) {
+          f.call(self)
+        })
+      }, 0)
+    }
+    this.play = function() {
+      if (this.src) {
+        fireEnded()
+      }
+    }
+    this.pause = function() {}
+    this.ended = false
+  }
+  
+  function ChromeBuggedAudio() {
+    var self = this
+    this.canPlayType = function() {return true}
+    this.addEventListener = function(event, listener) {}
+    this.removeEventListener = function(event, listener) {}
+    this.play = function() {
+      if (this.src) {
+        self.ended = true
+        self.src = null
+        ok(true, "Audio played")
+      }
+    }
+    this.pause = function() {}
+    this.ended = false
+  }
+  
+  Crafty.init();
+
+  asyncTest("setChannels", function() {
+    // Test that setChannels doesn't break sound
+    expect(2)
+    window.Audio = MockAudio
+    Crafty.support.audio = true
+    Crafty.audio.setChannels(5)
+    Crafty.audio.add("mockSound",["sound.ogg"])
+    var a = Crafty.audio.play("mockSound", 1)
+    ok(typeof a === "object", "Type of a is object: " + a)
+    a.addEventListener("ended", function() {
+      ok(true, "Sound played")
+      delete window.Audio //reset Audio to platform default
+      Crafty.audio.channels = []
+      Crafty("*").destroy();
+      start()
+    })
+  });
+  
+  test("chromeBug", function() {
+    // Test that we don't exhaust our audio channels if Chrome bug 280417
+    // eats our "ended" events
+    expect(10)
+    window.Audio = ChromeBuggedAudio
+    Crafty.support.audio = true
+    Crafty.audio.setChannels(1)
+    Crafty.support.audio = true
+    Crafty.audio.add("mockSound",["sound.ogg"])
+    
+    var a
+    for (var i = 0; i < 10; i++) {
+      a = Crafty.audio.play("mockSound", 1) // This will trigger an assertion
+    }
+    console.log(Crafty.audio.channels)
+    delete window.Audio //reset Audio to platform default
+    Crafty.audio.channels = []
+    Crafty("*").destroy();
+  });
+});
+</script>
+  
+</head>
+<body>
+<h1 id="qunit-header">Crafty: Core</h1>
+<h2 id="qunit-banner"></h2>
+<div id="qunit-testrunner-toolbar"></div>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests"></ol>
+<div id="qunit-fixture">test markup, will be hidden</div>
+</body>
+</html>


### PR DESCRIPTION
A couple of patches.

One for a bug in setChannels (we unnecessarily increase the size of an array, without populating it - as a consequence, getOpenChannel finds undefined where it was expecting a channel).

Another is a workaround for a bug in Chrome (https://code.google.com/p/chromium/issues/detail?id=280417). Audio objects sometimes don't fire "ended" events for short sounds, so we leak channels. The patch allows us to re-use channels that haven't been marked as inactive, but are ended and over their repeat count.
