### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "crafty",
   "main": "crafty.js",
-  "version": "0.5.4",
+  "version": "0.6",
   "repository": {
     "type": "git",
     "url": "git://github.com/craftyjs/Crafty.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crafty",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "title": "Crafty game framework",
   "author": {
     "name": "Louis Stowasser",

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-module.exports = "0.5.4";
+module.exports = "0.6.0";


### PR DESCRIPTION
Is this everything necessary to bump the version number?

_e:_ Originally I had just `0.6`, but since `npm` wants proper semantic versioning, it has to be `0.6.0`.
