### PR TITLE
Fix bug in steptype()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1040,14 +1040,14 @@ Crafty.extend({
              *
              */
 
-            steptype: function (mode, option) {
-                if (mode === "variable" || mode === "semifixed") {
-                    mode = "variable";
+            steptype: function (newmode, option) {
+                if (newmode === "variable" || newmode === "semifixed") {
+                    mode = newmode;
                     if (option)
                         maxTimestep = option;
 
-                } else if (mode === "fixed") {
-                    mode = mode;
+                } else if (newmode === "fixed") {
+                    mode = "fixed";
                     if (option)
                         maxFramesPerStep = option;
                 } else {


### PR DESCRIPTION
There were two bugs: the function argument shadowed the mode variable, and the semifixed mode would never actually be set.

As [reported](https://groups.google.com/forum/?fromgroups#!topic/craftyjs/Eq4TClc6WCQ) in the forums by Michael Halas.
