### PR TITLE
Removing a component should actually remove the class from DOM

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -58,7 +58,20 @@ Crafty.c("DOM", {
             this._element.className = str;
         }
 
-        this.bind("NewComponent", updateClass).bind("RemoveComponent", updateClass);
+        function removeClass(removedComponent) {
+            var i = 0,
+                c = this.__c,
+                str = "";
+            for (i in c) {
+              if(i != removedComponent) {
+                str += ' ' + i;
+              }
+            }
+            str = str.substr(1);
+            this._element.className = str;
+        }
+
+        this.bind("NewComponent", updateClass).bind("RemoveComponent", removeClass);
 
         if (Crafty.support.prefix === "ms" && Crafty.support.version < 9) {
             this._filters = {};

--- a/tests/dom.html
+++ b/tests/dom.html
@@ -50,6 +50,19 @@ $(document).ready(function() {
     // Clean up
     Crafty("*").destroy();
   });
+  test("removeComponent removes element class", function() {
+    var element = Crafty.e("DOM");
+    hasClassName = function(el, name) {
+      return el._element.className.indexOf(name) >= 0;
+    };
+    element.addComponent("removeMe");
+    strictEqual(element.has("removeMe"), true, "component added");
+    strictEqual(hasClassName(element, "removeMe"), true, "classname added");
+
+    element.removeComponent("removeMe");
+    strictEqual(element.has("removeMe"), false, "component removed");
+    strictEqual(hasClassName(element, "removeMe"), false, "classname removed");
+  });
 });
 </script>
   


### PR DESCRIPTION
When using the DOM component, I found that removing a previously added component did not correctly remove the component from the DOM element's className.

The reason updateClass doesn't work as expected is that the RemoveComponent event is triggered before the component is actually removed from the entity. A different solution to the same problem would be to move that trigger further down in core.js, but that seemed like the sort of thing that could break other folks.
