### PR TITLE
Allow animation speed to be varied

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -128,6 +128,14 @@ Crafty.c("SpriteAnimation", {
 	*/
 	_isPlaying: false,
 
+	/**@
+	* #.animationSpeed
+	* @comp SpriteAnimation
+	*
+	* The playback rate of the animation.  This property defaults to 1.
+	*/
+	animationSpeed: 1,
+
 
 	init: function () {
 		this._reels = {};
@@ -464,9 +472,10 @@ Crafty.c("SpriteAnimation", {
 
 	
 	// Bound to "EnterFrame".  Progresses the animation by dt, changing the frame if necessary.
+	// dt is multiplied by the animationSpeed property
 	_animationTick: function(frameData) {
 		var currentReel = this._reels[this._currentReelId];
-		currentReel.easing.tick(frameData.dt);
+		currentReel.easing.tick(frameData.dt * this.animationSpeed);
 		var progress = currentReel.easing.value();
 		var frameNumber = Math.min( Math.floor(currentReel.frames.length * progress), currentReel.frames.length - 1);
 

--- a/tests/animation/sprite-animation.js
+++ b/tests/animation/sprite-animation.js
@@ -357,6 +357,24 @@ test("Play an animation where sprites are displayed for more than one frame", fu
 	}
 });
 
+test("Play an animation at twice the rate", function(){
+	spriteAnimation.animationSpeed = 2;
+	spriteAnimation.animate('count');
+	Crafty.timer.simulateFrames(3);
+	var activeReel = spriteAnimation.getReel();
+	equal(activeReel.currentFrame, 6, "Frame 6 should be displayed after 3 ticks at double speed");
+	spriteAnimation.animationSpeed = 1;
+})
+
+test("Play an animation at half the rate", function(){
+	spriteAnimation.animationSpeed = 0.5;
+	spriteAnimation.animate('count');
+	Crafty.timer.simulateFrames(6);
+	var activeReel = spriteAnimation.getReel();
+	equal(activeReel.currentFrame, 3, "Frame 3 should be displayed after 6 ticks at half speed");
+	spriteAnimation.animationSpeed = 1;
+})
+
 test("Show the last frame after an animation ends", function() {
 	spriteAnimation.animate('count');
 	Crafty.timer.simulateFrames(20);


### PR DESCRIPTION
This adds an `animationSpeed` property to "SpriteAnimation", which controls the rate of playback.  Includes a couple of tests.

Actually a pretty simple change that should be pretty flexible.  You could even tween the `animationSpeed` property, if you like.  :)
