### PR TITLE
Use official syntax for setting CSS properties in "Image"

### DIFF
--- a/src/drawing.js
+++ b/src/drawing.js
@@ -122,8 +122,8 @@ Crafty.c("Image", {
                 context.restore();
             } else if (e.type === "DOM") {
                 if (this.__image) {
-                  e.style["background-image"] = "url(" + this.__image + ")";
-                  e.style["background-repeat"] = this._repeat;
+                  e.style.backgroundImage = "url(" + this.__image + ")";
+                  e.style.backgroundRepeat = this._repeat;
                 }
             }
         };


### PR DESCRIPTION
Firefox dislikes the `style.["hyphenated-property"]` syntax.  (Maybe this is by the spec?)

This patch switches to `style.hyphenatedProperty`, which works cross-browser.
