### PR TITLE
Force entities to be rendered at integer coordinates

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -88,8 +88,8 @@ Crafty.c("Canvas", {
         }
 
         var pos = this.drawVars.pos;
-        pos._x = (this._x + (x || 0));
-        pos._y = (this._y + (y || 0));
+        pos._x = ~~((this._x + (x || 0))+0.5);
+        pos._y = ~~((this._y + (y || 0))+0.5);
         pos._w = (w || this._w);
         pos._h = (h || this._h);
 


### PR DESCRIPTION
Due to the limitation in canvas that it can only have whole pixels to draw on I inserted a bitwise Math.round (faster on older browsers than the normal Math.round). This removes white lines due to half pixels.
