### PR TITLE
Semantic versioning in bower.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "crafty",
   "main": "crafty.js",
-  "version": "0.6",
+  "version": "0.6.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/craftyjs/Crafty.git"


### PR DESCRIPTION
Bower wants semantic versioning:  `0.6.0` and not `0.6`.

I'm not sure if bower checks the `bower.json` file of the version it eventually downloads -- if it does we might have to backport this change somehow.
