### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "crafty",
   "main": "crafty.js",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/craftyjs/Crafty.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crafty",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "title": "Crafty game framework",
   "author": {
     "name": "Louis Stowasser",

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-module.exports = "0.6.0";
+module.exports = "0.6.1";


### PR DESCRIPTION
Bump the version to 0.6.1 for bower.

Unfortunate that I don't see a way to test whether this will work without actually doing a release!
