### PR TITLE
Prevent _clamp from altering bounds

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -410,10 +410,8 @@ Crafty.extend({
             bound.max.y *= this._zoom;
             bound.min.y *= this._zoom;
             if (bound.max.x - bound.min.x > Crafty.viewport.width) {
-                bound.max.x -= Crafty.viewport.width;
-
-                if (Crafty.viewport.x < -bound.max.x) {
-                    Crafty.viewport.x = -bound.max.x;
+                if (Crafty.viewport.x < -bound.max.x + Crafty.viewport.width) {
+                    Crafty.viewport.x = -bound.max.x + Crafty.viewport.width;
                 } else if (Crafty.viewport.x > -bound.min.x) {
                     Crafty.viewport.x = -bound.min.x;
                 }
@@ -421,10 +419,8 @@ Crafty.extend({
                 Crafty.viewport.x = -1 * (bound.min.x + (bound.max.x - bound.min.x) / 2 - Crafty.viewport.width / 2);
             }
             if (bound.max.y - bound.min.y > Crafty.viewport.height) {
-                bound.max.y -= Crafty.viewport.height;
-
-                if (Crafty.viewport.y < -bound.max.y) {
-                    Crafty.viewport.y = -bound.max.y;
+                if (Crafty.viewport.y < -bound.max.y + Crafty.viewport.height) {
+                    Crafty.viewport.y = -bound.max.y + Crafty.viewport.height;
                 } else if (Crafty.viewport.y > -bound.min.y) {
                     Crafty.viewport.y = -bound.min.y;
                 }


### PR DESCRIPTION
It's currently possible to specify the viewport bounds, but the _clamp function will overwrite them.

This simply changes how _clamp compares/adjusts the viewport so that the bounds aren't modified.

This fixes #457.

The only thing that bothers me is that someone went out of their way to have _clamp modify the bounds -- is there some reason I'm missing for doing it that way?
