### PR TITLE
Rework the viewport animation functions

### DIFF
--- a/src/drawing.js
+++ b/src/drawing.js
@@ -520,7 +520,7 @@ Crafty.DrawManager = (function () {
 
             if (dirtyViewport) {
                 var view = Crafty.viewport;
-                ctx.setTransform(view._scale, 0, 0, view._scale, view.x, view.y);
+                ctx.setTransform(view._scale, 0, 0, view._scale, view._x*view._scale, view._y*view._scale);
 
             }
             //if the amount of changed objects is over 60% of the total objects
@@ -629,8 +629,8 @@ Crafty.DrawManager = (function () {
                     view = Crafty.viewport;
 
                 style.transform = style[Crafty.support.prefix + "Transform"] = "scale(" + view._scale + ", " + view._scale + ")";
-                style.left = view.x + "px";
-                style.top = view.y + "px";
+                style.left = view.x * view._scale + "px";
+                style.top = view.y * view._scale + "px";
                 style.zIndex = 10;
             }
 

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -8,6 +8,8 @@ Crafty.extend({
      * @trigger ViewportScroll - when the viewport's x or y coordinates change
      * @trigger ViewportScale - when the viewport's scale changes
      * @trigger InvalidateViewport - when the viewport changes
+     * @trigger StopCamera - when any camera animations should stop, such as at the start of a new animation.
+     * @trigger CameraAnimationDone - when a camera animation comes reaches completion
      *
      * Viewport is essentially a 2D camera looking at the stage. Can be moved which
      * in turn will react just like a camera moving in that direction.
@@ -68,7 +70,11 @@ Crafty.extend({
          * which are each an object with `x` and `y` properties.
          *
          * If this property is null, Crafty uses the bounding box of all the items
-         * on the stage.  This is the initial value.
+         * on the stage.  This is the initial value.  (To prevent this behavior, set `Crafty.viewport.clampToEntities` to `false`)
+         *
+         * If you wish to bound the viewport along one axis but not the other, you can use `-Infinity` and `+Infinity` as bounds.
+         *
+         * @see Crafty.viewport.clampToEntities
          *
          * @example
          * Set the bounds to a 500 by 500 square:
@@ -82,9 +88,9 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.scroll
          * @comp Crafty.viewport
-         * @sign Crafty.viewport.scroll(String axis, Number v)
+         * @sign Crafty.viewport.scroll(String axis, Number val)
          * @param axis - 'x' or 'y'
-         * @param v - The new absolute position on the axis
+         * @param val - The new absolute position on the axis
          *
          * Will move the viewport to the position given on the specified axis
          *
@@ -96,69 +102,74 @@ Crafty.extend({
          * Crafty.viewport.scroll('_x', 500);
          * ~~~
          */
-        scroll: function (axis, v) {
-            v = Math.floor(v);
-            this[axis] = v;
+        scroll: function (axis, val) {
+            this[axis] = val;
             Crafty.trigger("ViewportScroll");
             Crafty.trigger("InvalidateViewport");
         },
 
         rect: function () {
             return {
-                _x: -this._x / this._scale,
-                _y: -this._y / this._scale,
+                _x: -this._x,
+                _y: -this._y,
                 _w: this.width / this._scale,
                 _h: this.height / this._scale
             };
         },
 
-        /**@
+        /**@ 
+
          * #Crafty.viewport.pan
          * @comp Crafty.viewport
          * @sign public void Crafty.viewport.pan(String axis, Number v, Number time)
          * @param String axis - 'x' or 'y'. The axis to move the camera on
          * @param Number v - the distance to move the camera by
-         * @param Number time - The duration in frames for the entire camera movement
+         * @param Number time - The duration in ms for the entire camera movement
          *
-         * Pans the camera a given number of pixels over a given number of frames
+         * Pans the camera a given number of pixels over the specified time
          */
         pan: (function () {
             var tweens = {}, i, bound = false;
+            var targetX, targetY, startingX, startingY, easing;
 
             function enterFrame(e) {
-                var l = 0;
-                for (var i in tweens) {
-                    var prop = tweens[i];
-                    if (prop.remTime > 0) {
-                        prop.current += prop.diff;
-                        prop.remTime--;
-                        Crafty.viewport[i] = Math.floor(prop.current);
-                        l++;
-                    } else {
-                        delete tweens[i];
-                    }
+                easing.tick(e.dt);
+                var v = easing.value();
+                Crafty.viewport.x = (1-v) * startingX + v * targetX;
+                Crafty.viewport.y = (1-v) * startingY + v * targetY;
+                Crafty.viewport._clamp();
+
+                if (easing.complete){
+                    stopPan();
+                    Crafty.trigger("CameraAnimationDone");
                 }
-                if (l) Crafty.viewport._clamp();
             }
 
-            return function (axis, v, time) {
-                Crafty.viewport.follow();
-                if (axis == 'reset') {
-                    for (var i in tweens) {
-                        tweens[i].remTime = 0;
-                    }
-                    return;
+            function stopPan(){
+                Crafty.unbind("EnterFrame", enterFrame);
+            }
+
+            Crafty.bind("StopCamera", stopPan);
+
+            return function (dx, dy, time) {
+                // Cancel any current camera control
+                Crafty.trigger("StopCamera");
+
+                // Handle request to reset
+                if (dx == 'reset') {
+                   return;
                 }
-                if (time === 0) time = 1;
-                tweens[axis] = {
-                    diff: -v / time,
-                    current: Crafty.viewport[axis],
-                    remTime: time
-                };
-                if (!bound) {
-                    Crafty.bind("EnterFrame", enterFrame);
-                    bound = true;
-                }
+
+                startingX = Crafty.viewport._x;
+                startingY = Crafty.viewport._y;
+                targetX = startingX - dx;
+                targetY = startingY - dy;
+
+                easing = new Crafty.easing(time);
+
+                // bind to event, using uniqueBind prevents multiple copies from being bound
+                Crafty.uniqueBind("EnterFrame", enterFrame);
+                       
             };
         })(),
 
@@ -188,12 +199,17 @@ Crafty.extend({
                 Crafty.viewport._clamp();
             }
 
-            return function (target, offsetx, offsety) {
+            function stopFollow(){
                 if (oldTarget)
                     oldTarget.unbind('Change', change);
+            }
+
+            Crafty.bind("StopCamera", stopFollow);
+
+            return function (target, offsetx, offsety) {
                 if (!target || !target.has('2D'))
                     return;
-                Crafty.viewport.pan('reset');
+                Crafty.trigger("StopCamera");
 
                 oldTarget = target;
                 offx = (typeof offsetx != 'undefined') ? offsetx : 0;
@@ -209,9 +225,9 @@ Crafty.extend({
          * @comp Crafty.viewport
          * @sign public void Crafty.viewport.centerOn(Object target, Number time)
          * @param Object target - An entity with the 2D component
-         * @param Number time - The number of frames to perform the centering over
+         * @param Number time - The duration in ms of the camera motion
          *
-         * Centers the viewport on the given entity
+         * Centers the viewport on the given entity.
          */
         centerOn: function (targ, time) {
             var x = targ.x + Crafty.viewport.x,
@@ -223,9 +239,7 @@ Crafty.extend({
                 new_x = x + mid_x - cent_x,
                 new_y = y + mid_y - cent_y;
 
-            Crafty.viewport.pan('reset');
-            Crafty.viewport.pan('x', new_x, time);
-            Crafty.viewport.pan('y', new_y, time);
+            Crafty.viewport.pan(new_x, new_y, time);
         },
         /**@
          * #Crafty.viewport._zoom
@@ -242,80 +256,87 @@ Crafty.extend({
          * @param Number amt - amount to zoom in on the target by (eg. 2, 4, 0.5)
          * @param Number cent_x - the center to zoom on
          * @param Number cent_y - the center to zoom on
-         * @param Number time - the duration in frames of the entire zoom operation
+         * @param Number time - the duration in ms of the entire zoom operation
          *
          * Zooms the camera in on a given point. amt > 1 will bring the camera closer to the subject
-         * amt < 1 will bring it farther away. amt = 0 will do nothing.
+         * amt < 1 will bring it farther away. amt = 0 will reset to the default zoom level
          * Zooming is multiplicative. To reset the zoom amount, pass 0.
          */
         zoom: (function () {
-            var zoom = 1,
-                zoom_tick = 0,
-                dur = 0,
-                prop = Crafty.support.prefix + "Transform",
-                bound = false,
-                act = {},
-                prct = {};
-            // what's going on:
-            // 1. Get the original point as a percentage of the stage
-            // 2. Scale the stage
-            // 3. Get the new size of the stage
-            // 4. Get the absolute position of our point using previous percentage
-            // 4. Offset inner by that much
+            
 
-            function enterFrame() {
-                if (dur > 0) {
-                    if (isFinite(Crafty.viewport._zoom)) zoom = Crafty.viewport._zoom;
-                    var old = {
-                        width: act.width * zoom,
-                        height: act.height * zoom
-                    };
-                    zoom += zoom_tick;
-                    Crafty.viewport._zoom = zoom;
-                    var new_s = {
-                        width: act.width * zoom,
-                        height: act.height * zoom
-                    },
-                        diff = {
-                            width: new_s.width - old.width,
-                            height: new_s.height - old.height
-                        };
-                    Crafty.stage.inner.style[prop] = 'scale(' + zoom + ',' + zoom + ')';
-                    if (Crafty.canvas._canvas) {
-                        var czoom = zoom / (zoom - zoom_tick);
-                        Crafty.canvas.context.scale(czoom, czoom);
-                        Crafty.trigger("InvalidateViewport");
-                    }
-                    Crafty.viewport.x -= diff.width * prct.width;
-                    Crafty.viewport.y -= diff.height * prct.height;
-                    dur--;
+            function stopZoom(){
+                Crafty.unbind("EnterFrame", enterFrame);
+            }
+            Crafty.bind("StopCamera", stopZoom);
+
+            var startingZoom, finalZoom, finalAmount, startingX, finalX, startingY, finalY, easing;
+
+            function enterFrame(e){
+                var amount, v;
+
+                easing.tick(e.dt);
+
+                // The scaling should happen smoothly -- start at 1, end at finalAmount, and at half way scaling should be by finalAmount^(1/2)
+                // Since value goes smoothly from 0 to 1, this fufills those requirements
+                amount = Math.pow(finalAmount, easing.value() );
+
+                // The viewport should move in such a way that no point reverses
+                // If a and b are the top left/bottom right of the viewport, then the below can be derived from
+                //      (a_0-b_0)/(a-b) = amount,
+                // and the assumption that both a and b have the same form
+                //      a = a_0 * (1-v) + a_f * v,
+                //      b = b_0 * (1-v) + b_f * v.
+                // This is just an arbitrary parameterization of the only sensible path for the viewport corners to take.
+                // And by symmetry they should be parameterized in the same way!  So not much choice here.
+                if (finalAmount === 1)
+                    v = easing.value();  // prevent NaN!  If zoom is used this way, it'll just become a pan.
+                else
+                    v = (1/amount - 1 ) / (1/finalAmount - 1);
+
+                // Set new scale and viewport position
+                Crafty.viewport.scale( amount * startingZoom );
+                Crafty.viewport.scroll("_x", startingX * (1-v) + finalX * v );
+                Crafty.viewport.scroll("_y", startingY * (1-v) + finalY * v );
+                Crafty.viewport._clamp();
+
+                if (easing.complete){
+                    stopZoom();
+                    Crafty.trigger("CameraAnimationDone");
                 }
+
+
             }
 
-            return function (amt, cent_x, cent_y, time) {
-                var bounds = this.bounds || Crafty.map.boundaries(),
-                    final_zoom = amt ? zoom * amt : 1;
+            return function (amt, cent_x, cent_y, time){    
                 if (!amt) { // we're resetting to defaults
-                    zoom = 1;
-                    this._zoom = 1;
+                    Crafty.viewport.scale(1);
+                    return;
+                }  
+
+                if (arguments.length <= 2) {
+                    time = cent_x;
+                    cent_x = Crafty.viewport.x - Crafty.viewport.width;
+                    cent_y = Crafty.viewport.y - Crafty.viewport.height;
                 }
 
-                act.width = bounds.max.x - bounds.min.x;
-                act.height = bounds.max.y - bounds.min.y;
+                Crafty.trigger("StopCamera");
+                startingZoom = Crafty.viewport._zoom;
+                finalAmount = amt;
+                finalZoom = startingZoom * finalAmount;
+                
 
-                prct.width = cent_x / act.width;
-                prct.height = cent_y / act.height;
+                startingX = Crafty.viewport.x;
+                startingY = Crafty.viewport.y;
+                finalX = - (cent_x - Crafty.viewport.width  / (2 * finalZoom) );
+                finalY = - (cent_y - Crafty.viewport.height / (2 * finalZoom) );
 
-                if (time === 0) time = 1;
-                zoom_tick = (final_zoom - zoom) / time;
-                dur = time;
+                easing = new Crafty.easing(time);
 
-                Crafty.viewport.pan('reset');
-                if (!bound) {
-                    Crafty.bind('EnterFrame', enterFrame);
-                    bound = true;
-                }
+                Crafty.uniqueBind("EnterFrame", enterFrame);
             };
+
+            
         })(),
         /**@
          * #Crafty.viewport.scale
@@ -323,9 +344,12 @@ Crafty.extend({
          * @sign public void Crafty.viewport.scale(Number amt)
          * @param Number amt - amount to zoom/scale in on the element on the viewport by (eg. 2, 4, 0.5)
          *
-         * Zooms/scale the camera. amt > 1 increase all entities on stage
+         * Adjusts the. amt > 1 increase all entities on stage
          * amt < 1 will reduce all entities on stage. amt = 0 will reset the zoom/scale.
-         * Zooming/scaling is multiplicative. To reset the zoom/scale amount, pass 0.
+         * To reset the scale amount, pass 0.
+         *
+         * This method sets the absolute scale, while `Crafty.viewport.zoom` sets the scale relative to the existing value.
+         * @see Crafty.viewport.zoom
          *
          * @example
          * ~~~
@@ -334,9 +358,7 @@ Crafty.extend({
          */
         scale: (function () {
             return function (amt) {
-                var bounds = this.bounds || Crafty.map.boundaries(),
-                    final_zoom = amt ? amt : 1;
-
+                var final_zoom = amt ? amt : 1;
 
                 this._zoom = final_zoom;
                 this._scale = final_zoom;
@@ -354,12 +376,17 @@ Crafty.extend({
          * Toggle mouselook on the current viewport.
          * Simply call this function and the user will be able to
          * drag the viewport around.
+         *
+         * If the user starts a drag, "StopCamera" will be triggered, which will cancel any existing camera animations.
          */
         mouselook: (function () {
             var active = false,
                 dragging = false,
                 lastMouse = {};
             old = {};
+            function stopLook(){
+                dragging = false;
+            }
 
 
             return function (op, arg) {
@@ -390,6 +417,7 @@ Crafty.extend({
                     Crafty.viewport._clamp();
                     break;
                 case 'start':
+                    Crafty.trigger("StopCamera");
                     lastMouse.x = arg.clientX;
                     lastMouse.y = arg.clientY;
                     dragging = true;
@@ -691,17 +719,17 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.reset
          * @comp Crafty.stage
+         * @trigger StopCamera - called to cancel camera animations
          *
          * @sign public Crafty.viewport.reset()
          *
-         * Resets the viewport to starting values
+         * Resets the viewport to starting values, and cancels any existing camera animations.
          * Called when scene() is run.
          */
         reset: function () {
-            Crafty.viewport.pan('reset');
-            Crafty.viewport.follow();
-            Crafty.viewport.mouselook('stop');
-            Crafty.viewport.scale();
+            Crafty.viewport.mouselook("stop");
+            Crafty.trigger("StopCamera");
+            Crafty.viewport.scale(1);
         }
     }
 });

--- a/tests/stage.html
+++ b/tests/stage.html
@@ -11,6 +11,15 @@
 	$(document).ready(function () {
 		Crafty.init();
 
+		var reset = function(){
+			Crafty("*").destroy();
+			Crafty.viewport.reset();
+			Crafty.viewport.scroll('_x', 0);
+			Crafty.viewport.scroll('_y', 0);
+			Crafty.viewport.clampToEntities = true;
+
+		}
+
 		test("simulateFrames", function() {
 			var framesPlayed = 0;
 			Crafty.bind("EnterFrame", function () {
@@ -23,7 +32,10 @@
 			equal(framesPlayed, 101, "101 frames should have been simulated");
 		})
 
-	module("Viewport");
+
+
+
+	module("Viewport", {setup:reset});
 
 	test("scroll using _x, _y", function () {
 		var e = Crafty.e("2D, DOM").attr({ x: 50, y: 50 });
@@ -58,53 +70,96 @@
 	});
 
 	test("follow", function () {
+		Crafty.viewport.clampToEntities = false;
 		var e = Crafty.e("2D, DOM").attr({ x: Crafty.viewport.width + 100, y: Crafty.viewport.height + 70 });
 		Crafty.viewport.follow(e, 0, 0);
-		equal(Crafty.viewport._x, -100, "Center viewport on entity.x but take clamp into account");
-		equal(Crafty.viewport._y, -70, "Center viewport on entity.y but take clamp into account");
-		
-		//Make large enough so the viewport won't get clamped
-		Crafty.e("2D, DOM").attr({ x: 0, y: 0, w: Crafty.viewport.width * 2 + 50, h: Crafty.viewport.height*2+35 });
-		Crafty.viewport.follow(e, 0, 0);
-		equal(Crafty.viewport._x, Math.floor(-(Crafty.viewport.width/2 + 100)), "Center viewport on entity.x");
-		equal(Crafty.viewport._y, Math.floor(-(Crafty.viewport.height / 2 + 70)), "Center viewport on entity.y");
+		equal(Crafty.viewport._x, (-(Crafty.viewport.width/2 + 100)), "Center viewport on entity.x");
+		equal(Crafty.viewport._y, (-(Crafty.viewport.height / 2 + 70)), "Center viewport on entity.y");
 
-		Crafty.viewport.scroll('x', 0);
-		Crafty.viewport.scroll('y', 0);
 		});
 
 	test("pan", function () {
+		Crafty.viewport.clampToEntities = false;
 		Crafty.e("2D, DOM").attr({ x: 0, y: 0, w: Crafty.viewport.width * 2, h: Crafty.viewport.height * 2 });
-		Crafty.viewport.pan("x", 100, 10);
+
+		var done = 0;
+		var panDone = function(){ done++ };
+		Crafty.one("CameraAnimationDone", panDone);
+
+		Crafty.viewport.pan(100, 0, 10 * 20);
 		Crafty.timer.simulateFrames(5);
 		equal(Crafty.viewport._x, -50, "Pan half the way on half the time");
+		equal(done, 0, "CameraAnimationDone hasn't fired yet");
 		Crafty.timer.simulateFrames(5);
 		equal(Crafty.viewport._x, -100, "Pan all the way when all the time is spent");
+		equal(done, 1, "CameraAnimationDone has fired once");
 
-		Crafty.viewport.pan("y", 100, 10);
+		done = 0;
+		Crafty.one("CameraAnimationDone", panDone);
+		Crafty.viewport.pan(0, 100, 10);
 		Crafty.timer.simulateFrames(20);
 		equal(Crafty.viewport._y, -100, "Pan all the way and stay there");
+		equal(done, 1, "CameraAnimationDone has fired once");
 
 		Crafty.viewport.scroll('x', 0);
 		Crafty.viewport.scroll('y', 0);
 	});
 
+	test("zoom", function () {
+
+		Crafty.viewport.clampToEntities = false;
+
+		var done = 0;
+		var panDone = function(){ done++ };
+		Crafty.one("CameraAnimationDone", panDone);
+
+		Crafty.e("2D, DOM").attr({ x: 0, y: 0, w: Crafty.viewport.width * 2, h: Crafty.viewport.height * 2 });
+		Crafty.viewport.scroll('x', 0);
+		Crafty.viewport.scroll('y', 0);
+		Crafty.viewport.scale(1);
+
+		Crafty.viewport.zoom(2, 0, 0, 10 * 20);
+		Crafty.timer.simulateFrames(5);
+		
+		equal(Crafty.viewport._scale, Math.sqrt(2), "Zooms sqrt(2) in half the time");
+		equal(done, 0, "CameraAnimationDone hasn't fired yet");
+
+		Crafty.timer.simulateFrames(5);
+		equal(Crafty.viewport._x, Crafty.viewport.width/4, "move all the way when all the time is spent");
+		equal(Crafty.viewport._y, Crafty.viewport.height/4, "move all the way when all the time is spent");	
+		equal(Crafty.viewport._scale, 2, "Zooms all the way in full time.");
+		equal(done, 1, "CameraAnimationDone has fired once");
+	
+	});
+
 	test("centerOn", function () {
 		var e = Crafty.e("2D, DOM").attr({ x: 0, y: 0, w: Crafty.viewport.width * 2, h: Crafty.viewport.height * 2 });
+		Crafty.viewport.clampToEntities = false;
+
+		var done = 0;
+		var panDone = function(){ done++ };
+		Crafty.one("CameraAnimationDone", panDone);
+
+
 		Crafty.viewport.centerOn(e, 10);
 		Crafty.timer.simulateFrames(10);
+
 		equal(Crafty.viewport._x, -e.w / 2 + Crafty.viewport.width / 2, "Entity centered after exact duration");
+		equal(done, 1, "CameraAnimationDone has fired once");
+		done = 0;
+		Crafty.one("CameraAnimationDone", panDone);
 		Crafty.timer.simulateFrames(10);
 		equal(Crafty.viewport._x, -e.w / 2 + Crafty.viewport.width / 2, "Entity still centered 10 frames later");
+		equal(done, 0, "CameraAnimationDone doesn't fire after completion");
 
-		Crafty.viewport.clampToEntities = false;		
+			
 		var e2 = Crafty.e("2D, DOM").attr({ x: 450, y: 450, w: 20, h: 20 });
 		Crafty.viewport.scroll('x', 1500);
 		Crafty.viewport.scroll('y', 300);
 		Crafty.viewport.centerOn(e2, 1);
 		Crafty.timer.simulateFrames(1);
-		equal(Crafty.viewport._x, Math.floor(-(e2.x + e2.w/2 - Crafty.viewport.width / 2)), "Entity centered from non-zero origin");
-		equal(Crafty.viewport._y, Math.floor(-(e2.y + e2.h/2 - Crafty.viewport.height / 2)), "Entity centered from non-zero origin");
+		equal(Crafty.viewport._x, (-(e2.x + e2.w/2 - Crafty.viewport.width / 2)), "Entity centered from non-zero origin");
+		equal(Crafty.viewport._y, (-(e2.y + e2.h/2 - Crafty.viewport.height / 2)), "Entity centered from non-zero origin");
 		
 		Crafty.viewport.clampToEntities = true;	
 		Crafty.viewport.scroll('x', 0);


### PR DESCRIPTION
This isn't quite ready to land yet, but thoguht I'd open the PR so folk could see the changes.  This alters several aspects of the viewport:
- Changes pan and zoom to work with Crafty.easing. (Time based instead of tick based.)
- Makes sure the zoom animation is nice and smooth.  (Surprisingly tricky)
- Fixes a bug in how scale is treated by the DOM/Canvas renderers
- Adds a new "StopCamera" event for stopping any extant camera animation (and uses it when a new animation is requested.)
- Fires an "CameraAnimationDone" event when a camera animation completes

Along the way this fixes #163, #285, #339, and #616
