### PR TITLE
Fix naming convention on the Crafty Core file

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -53,7 +53,7 @@ var Crafty = function (selector) {
 initState();
 
 /**@
- * #Crafty Core
+ * #Crafty.Core
  * @category Core
  * @trigger NewEntityName - After setting new name for entity - String - entity name
  * @trigger NewComponent - when a new component is added to the entity - String - Component


### PR DESCRIPTION
The file, Crafty core, gets the wrong name when the API is built.

The wrong file name it gets is: "Crafty Core.html", but it should be "Crafty-Core.html".

The craftyjs website is fixed.
https://github.com/craftyjs/craftyjs.github.com/pull/29
