### PR TITLE
Add get() method to crafty core

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -27,6 +27,14 @@ var version = require('./version');
  *   Crafty(1)
  * ~~~
  * Passing an integer will select the entity with that `ID`.
+ *
+ * To work directly with an array of entities, use the `get()` method on a selection.
+ * To call a function in the context of each entity, use the `.each()` method.
+ *
+ * The event related methods such as `bind` and `trigger` will work on selections of entities.
+ *
+ * @see .get
+ * @see .each
  */
  
 var Crafty = function (selector) {
@@ -452,7 +460,8 @@ Crafty.fn = Crafty.prototype = {
      * @comp Crafty Core
      * @sign public this .toArray(void)
      *
-     * This method will simply return the found entities as an array.
+     * This method will simply return the found entities as an array of ids.  To get an array of the actual entities, use `get()`.
+     * @see .get
      */
     toArray: function () {
         return slice.call(this, 0);
@@ -709,6 +718,53 @@ Crafty.fn = Crafty.prototype = {
             func.call(entities[this[i]], i);
         }
         return this;
+    },
+
+    /**@
+     * #.get
+     * @comp Crafty Core
+     * @sign public Array .get()
+     * @returns An array of entities corresponding to the active selector
+     * 
+     * @sign public Entity .get(Number index)
+     * @returns an entity belonging to the current selection
+     * @param index - The index of the entity to return.  If negative, counts back from the end of the array.
+     * 
+     *
+     * @example
+     * Get an array containing every "2D" entity
+     * ~~~
+     * var arr = Crafty("2D").get()
+     * ~~~
+     * Get the first entity matching the selector
+     * ~~~
+     * // equivalent to Crafty("2D").get()[0], but doesn't create a new array
+     * var e = Crafty("2D").get(0)
+     * ~~~
+     * Get the last "2D" entity matching the selector
+     * ~~~
+     * var e = Crafty("2D").get(-1)
+     * ~~~
+     * 
+     */
+    get: function(index) {
+        var l = this.length;
+        if (typeof index !== "undefined") {
+            if (index >= l || index+l < 0)
+                return undefined;
+            if (index>=0)
+                return entities[this[index]];
+            else
+                return entities[this[index+l]];
+        } else {
+            var i=0, result = [];
+            for (; i < l; i++) {
+                //skip if not exists
+                if (!entities[this[i]]) continue;
+                result.push( entities[this[i]] );
+            }
+            return result;
+        }
     },
 
     /**@

--- a/tests/core.html
+++ b/tests/core.html
@@ -217,6 +217,67 @@ $(document).ready(function() {
 		// Clean up
 		Crafty("*").destroy();
 	});
+
+	test("Crafty.get() to find an array", function(){
+		Crafty.e("test");
+		Crafty.e("test");
+		Crafty.e("test");
+		
+		var collection = Crafty("test");
+		var result = collection.get();
+		equal(result.length, 3, "resultant array should be length 3");
+		equal(result[0].has("test"), true, "Result elements should have correct component");
+		equal(collection[0], result[0].getId(), "First id of result should match first id of Crafty array");
+
+		Crafty("*").destroy();
+	})
+
+	test("Crafty.get(index) to find the indicated entity", function(){
+		Crafty.e("test");
+		Crafty.e("test");
+		Crafty.e("test");
+		var collection, result;
+		
+		collection = Crafty("test");
+		result = collection.get(0);
+		equal(result.has("test"), true, "Result should have correct component");
+		equal(result.getId(), collection[0], "result should be first element of collection");
+
+		result = collection.get(-1);
+		equal(result.has("test"), true, "Result should have correct component");
+		equal(result.getId(), collection[2], "result should be last element of collection");
+
+		Crafty("*").destroy();
+	})
+
+	test("Crafty.get(index) error checking", function(){
+		Crafty.e("test");
+		Crafty.e("test");
+		Crafty.e("test");
+		var collection, result;
+		
+		collection = Crafty("test");
+		
+		result = collection.get(3);
+		equal(typeof result, "undefined", "result of get(3) should be undefined")
+
+		result = collection.get(-4);
+		equal(typeof result, "undefined", "result of get(-4) should be undefined")
+
+
+
+		Crafty("*").destroy();
+	})
+
+	test("Crafty.get with only one object", function(){
+		var e = Crafty.e("test");
+		var collection = Crafty("test");
+		result = collection.get(0);
+		equal(result.getId(), e.getId(), "result of get(0) is correct entity")
+		result = collection.get();
+		equal(result.length, 1, "result of get() is array of length 1");
+		Crafty("*").destroy();
+	})
 	
 	test("requires", function() {
 		var first = Crafty.e("test");


### PR DESCRIPTION
This adds a get method that will convert selections to arrays of entities.  It can also be used to fetch a particular specified entity by index.  It will work as expected an a single entity.  This is modeled directly after jquery's get method: http://api.jquery.com/jQuery.get/

Documentation about the new feature is added (it is now referenced by the Crafty Core docs, as well as  .toArray).  Includes a few tests added to core.html.

This fixes #349
