### PR TITLE
Kill ie8 specific code in Crafty

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -457,13 +457,7 @@ Crafty.c("2D", {
             sin: Math.sin(drad),
             deg: difference,
             rad: drad,
-            o: o,
-            matrix: {
-                M11: ct,
-                M12: st,
-                M21: -st,
-                M22: ct
-            }
+            o: o
         });
     },
 

--- a/src/2D.js
+++ b/src/2D.js
@@ -318,81 +318,6 @@ Crafty.c("2D", {
         });
     },
 
-    _defineGetterSetter_fallback: function () {
-        //set the public properties to the current private properties
-        this.x = this._x;
-        this.y = this._y;
-        this.w = this._w;
-        this.h = this._h;
-        this.z = this._z;
-        this.rotation = this._rotation;
-        this.alpha = this._alpha;
-        this.visible = this._visible;
-
-        //on every frame check for a difference in any property
-        this.bind("EnterFrame", function () {
-            //if there are differences between the public and private properties
-            if (this.x !== this._x || this.y !== this._y ||
-                this.w !== this._w || this.h !== this._h ||
-                this.z !== this._z || this.rotation !== this._rotation ||
-                this.alpha !== this._alpha || this.visible !== this._visible) {
-
-                //save the old positions
-                var old = Crafty._rectPool.copy(this);
-
-                //if rotation has changed, use the private rotate method
-                if (this.rotation !== this._rotation) {
-                    this._rotate(this.rotation);
-                } else {
-                    //update the MBR
-                    var mbr = this._mbr,
-                        moved = false;
-                    // If the browser doesn't have getters or setters,
-                    // {x, y, w, h, z} and {_x, _y, _w, _h, _z} may be out of sync,
-                    // in which case t checks if they are different on tick and executes the Change event.
-                    if (mbr) { //check each value to see which has changed
-                        if (this.x !== this._x) {
-                            mbr._x -= this.x - this._x;
-                            moved = true;
-                        } else if (this.y !== this._y) {
-                            mbr._y -= this.y - this._y;
-                            moved = true;
-                        } else if (this.w !== this._w) {
-                            mbr._w -= this.w - this._w;
-                            moved = true;
-                        } else if (this.h !== this._h) {
-                            mbr._h -= this.h - this._h;
-                            moved = true;
-                        } else if (this.z !== this._z) {
-                            mbr._z -= this.z - this._z;
-                            moved = true;
-                        }
-                    }
-
-                    //if the moved flag is true, trigger a move
-                    if (moved) this.trigger("Move", old);
-                }
-
-                //set the public properties to the private properties
-                this._x = this.x;
-                this._y = this.y;
-                this._w = this.w;
-                this._h = this.h;
-                this._z = this.z;
-                this._rotation = this.rotation;
-                this._alpha = this.alpha;
-                this._visible = this.visible;
-
-                //trigger the changes
-                this.trigger("Change", old);
-                //without this entities weren't added correctly to Crafty.map.map in IE8.
-                //not entirely sure this is the best way to fix it though
-                this.trigger("Move", old);
-                Crafty._rectPool.recycle(old);
-            }
-        });
-    },
-
     init: function () {
         this._globalZ = this[0];
         this._origin = {
@@ -406,13 +331,6 @@ Crafty.c("2D", {
         } else if (Crafty.support.defineProperty) {
             //IE9 supports Object.defineProperty
             this._defineGetterSetter_defineProperty();
-        } else {
-            /*
-			If no setters and getters are supported (e.g. IE8) supports,
-			check on every frame for a difference between this._(x|y|w|h|z...)
-			and this.(x|y|w|h|z) and update accordingly.
-			*/
-            this._defineGetterSetter_fallback();
         }
 
         //insert self into the HashMap

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -73,21 +73,6 @@ Crafty.c("DOM", {
 
         this.bind("NewComponent", updateClass).bind("RemoveComponent", removeClass);
 
-        if (Crafty.support.prefix === "ms" && Crafty.support.version < 9) {
-            this._filters = {};
-
-            this.bind("Rotate", function (e) {
-                var m = e.matrix,
-                    elem = this._element.style,
-                    M11 = m.M11.toFixed(8),
-                    M12 = m.M12.toFixed(8),
-                    M21 = m.M21.toFixed(8),
-                    M22 = m.M22.toFixed(8);
-
-                this._filters.rotation = "progid:DXImageTransform.Microsoft.Matrix(M11=" + M11 + ", M12=" + M12 + ", M21=" + M21 + ", M22=" + M22 + ",sizingMethod='auto expand')";
-            });
-        }
-
         this.bind("Remove", this.undraw);
         this.bind("RemoveComponent", function (compName) {
             if (compName === "DOM")

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -290,12 +290,6 @@ Crafty.c("DOM", {
     }
 });
 
-/**
- * Fix IE6 background flickering
- */
-try {
-    document.execCommand("BackgroundImageCache", false, true);
-} catch (e) {}
 
 Crafty.extend({
     /**@

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -185,17 +185,6 @@ Crafty.c("DOM", {
             style[prefix + "Opacity"] = this._alpha;
         }
 
-        //if not version 9 of IE
-        if (prefix === "ms" && Crafty.support.version < 9) {
-            //for IE version 8, use ImageTransform filter
-            if (Crafty.support.version === 8) {
-                this._filters.alpha = "progid:DXImageTransform.Microsoft.Alpha(Opacity=" + (this._alpha * 100) + ")"; // first!
-                //all other versions use filter
-            } else {
-                this._filters.alpha = "alpha(opacity=" + (this._alpha * 100) + ")";
-            }
-        }
-
         if (this._mbr) {
             var origin = this._origin.x + "px " + this._origin.y + "px";
             style.transformOrigin = origin;
@@ -206,21 +195,10 @@ Crafty.c("DOM", {
 
         if (this._flipX) {
             trans.push("scaleX(-1)");
-            if (prefix === "ms" && Crafty.support.version < 9) {
-                this._filters.flipX = "fliph";
-            }
         }
 
         if (this._flipY) {
             trans.push("scaleY(-1)");
-            if (prefix === "ms" && Crafty.support.version < 9) {
-                this._filters.flipY = "flipv";
-            }
-        }
-
-        //apply the filters if IE
-        if (prefix === "ms" && Crafty.support.version < 9) {
-            this.applyFilters();
         }
 
         if (this._cssStyles.transform != trans.join(" ")) {
@@ -236,18 +214,6 @@ Crafty.c("DOM", {
         });
 
         return this;
-    },
-
-    applyFilters: function () {
-        this._element.style.filter = "";
-        var str = "";
-
-        for (var filter in this._filters) {
-            if (!this._filters.hasOwnProperty(filter)) continue;
-            str += this._filters[filter] + " ";
-        }
-
-        this._element.style.filter = str;
     },
 
     /**@

--- a/src/core.js
+++ b/src/core.js
@@ -34,7 +34,7 @@ var Crafty = function (selector) {
 },
     // Internal variables
     GUID, frame, components, entities, handlers, onloads,
-    noSetter, slice, rlist, rspace, milliSecPerFrame;
+    slice, rlist, rspace, milliSecPerFrame;
 
 
     initState = function () {
@@ -747,8 +747,6 @@ Crafty.fn = Crafty.prototype = {
      * Will watch a property waiting for modification and will then invoke the
      * given callback when attempting to modify.
      *
-     * *Note: Support in IE<9 is slightly different. The method will be executed
-     * after the property has been set*
      */
     setter: function (prop, callback) {
         if (Crafty.support.setter) {
@@ -757,12 +755,6 @@ Crafty.fn = Crafty.prototype = {
             Object.defineProperty(this, prop, {
                 set: callback,
                 configurable: true
-            });
-        } else {
-            noSetter.push({
-                prop: prop,
-                obj: this,
-                fn: callback
             });
         }
         return this;
@@ -1572,24 +1564,6 @@ function clone(obj) {
         temp[key] = clone(obj[key]);
     return temp;
 }
-
-Crafty.bind("Load", function () {
-    if (!Crafty.support.setter && Crafty.support.defineProperty) {
-        noSetter = [];
-        Crafty.bind("EnterFrame", function () {
-            var i = 0,
-                l = noSetter.length,
-                current;
-            for (; i < l; ++i) {
-                current = noSetter[i];
-                if (current.obj[current.prop] !== current.obj['_' + current.prop]) {
-                    current.fn.call(current.obj, current.obj[current.prop]);
-                }
-            }
-        });
-    }
-});
-
 
 // export Crafty
 if (typeof define === 'function') { // AMD

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -32,7 +32,7 @@ Crafty.c("Color", {
      * Will create a rectangle of solid color for the entity, or return the color if no argument is given.
      *
      * The argument must be a color readable depending on which browser you
-     * choose to support. IE 8 and below doesn't support the rgb() syntax.
+     * choose to support.
      *
      * @example
      * ~~~

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -665,19 +665,6 @@ Crafty.extend({
                     },
                     configurable : true
                 });
-            } else {
-                // IE8 has no getter/setters -- Check for an update each frame.
-                this.x = this._x;
-                this.y = this._y;
-                Crafty.bind("EnterFrame", function () {
-                    if (Crafty.viewport._x !== Crafty.viewport.x) {
-                        Crafty.viewport.scroll('_x', Crafty.viewport.x);
-                    }
-
-                    if (Crafty.viewport._y !== Crafty.viewport.y) {
-                        Crafty.viewport.scroll('_y', Crafty.viewport.y);
-                    }
-                });
             }
         },
 

--- a/tests/core.html
+++ b/tests/core.html
@@ -305,28 +305,22 @@ $(document).ready(function() {
 	module("2D");
 	
 	test("position", function() {
-		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50}).color("red");
 		player.x += 50;
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._x, 50, "X moved");
 		
 		player.y += 50;
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._y, 50, "Y moved");
 		
 		player.w += 50;
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._w, 100, "Width increase");
 		
 		player.h += 50;
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._h, 100, "Height increase");
 		
 		strictEqual(player._globalZ, player[0], "Global Z, Before");
 		
 		player.z = 1;
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(player._z, 1, "Z index");
 		
 		var global_z_guess;
@@ -341,13 +335,11 @@ $(document).ready(function() {
 	});
 	
 	test("intersect", function() {
-		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50}).color("red");
 		player.x = 0;
 		player.y = 0;
 		player.w = 50;
 		player.h = 50;
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
 		strictEqual(player.intersect(0, 0, 100, 50), true, "Intersected");
 
@@ -359,13 +351,11 @@ $(document).ready(function() {
 	});
 
 	test("within", function() {
-		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50});
 		player.x = 0;
 		player.y = 0;
 		player.w = 50;
 		player.h = 50;
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		
 		strictEqual(player.within(0, 0, 50, 50), true, "Within");
 
@@ -377,7 +367,6 @@ $(document).ready(function() {
 		strictEqual(player.within(0, 0, 40, 50), false, "Wasn't within");
 
 		player.rotation = 90;	// Once rotated, the entity should no longer be within the rectangle
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
 		strictEqual(player.within(0, 0, 50, 50), false, "Rotated, Not within");
 		strictEqual(player.within(-50, 0, 50, 50), true, "Rotated, within rotated area");
@@ -389,13 +378,11 @@ $(document).ready(function() {
 	});
 
 	test("contains", function() {
-		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50});
 		player.x = 0;
 		player.y = 0;
 		player.w = 50;
 		player.h = 50;
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		
 
 		strictEqual(player.contains(0, 0, 50, 50), true, "Contains");
@@ -407,7 +394,6 @@ $(document).ready(function() {
 		strictEqual(player.contains(1, 1, 51, 51), false, "Doesn't contain");
 
 		player.rotation = 90;
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
 		strictEqual(player.contains(0, 0, 50, 50), false, "Rotated, no longer contains");
 		strictEqual(player.within(-50, 0, 50, 50), true, "Rotated, contains rotated area");
@@ -419,16 +405,13 @@ $(document).ready(function() {
 
 	
 	test("circle", function() {
-		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var player = Crafty.e("2D, DOM, Color").attr({w:50, h: 50}).color("red");
 		var circle = new Crafty.circle(0, 0, 10);
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		
 		strictEqual(circle.containsPoint(1, 2), true, "Contained the point");
 		strictEqual(circle.containsPoint(8, 9), false, "Didn't contain the point");
 		
 		circle.shift(1, 0);
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		
 		strictEqual(circle.x, 1, "Shifted of one pixel on the x axis");
 		strictEqual(circle.y, 0, "circle.y didn't change");
@@ -438,7 +421,6 @@ $(document).ready(function() {
 	});
 
 	test("child", function () {
-		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var parent0 = Crafty.e("2D, DOM, Color").attr({x:0, y:0, w:50, h:50}).color("red");
 		var child0 = Crafty.e("2D, DOM, Color").attr({x:1, y:1, w:50, h:50}).color("red");
 		var child1 = Crafty.e("2D, DOM, Color").attr({x:2, y:2, w:50, h:50}).color("red");
@@ -453,12 +435,10 @@ $(document).ready(function() {
 		parent0.attach(child2);
 		parent0.attach(child3);
 		parent0.x += 50;
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(child0._x, 51, 'child0 shifted when parent did');
 		strictEqual(child1._x, 52, 'child1 shifted when parent did');
 		child0.x += 1;
 		child1.x += 1;
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(parent0._x, 50, 'child shifts do not move the parent');
 		child1.destroy();
 		deepEqual(parent0._children, [child0,child2,child3], 'child1 cleared itself from parent0._children when destroyed');
@@ -472,7 +452,6 @@ $(document).ready(function() {
 
 	test("child_rotate", function () {
 		var Round = function(x){ return Math.round(x*100)/100 };
-		var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 		var parent = Crafty.e("2D, DOM, Color")
 			.attr({x:0, y:0, w:50, h:50, rotation:10})
 			.color("red");
@@ -482,17 +461,14 @@ $(document).ready(function() {
 		parent.attach(child);
 
 		parent.rotation += 20;
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(parent.rotation, 30, 'parent rotates normally');
 		strictEqual(child.rotation, 35, 'child follows parent rotation');
 
 		child.rotation += 22;
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual(parent.rotation, 30, 'parent ignores child rotation');
 		strictEqual(child.rotation, 57, 'child rotates normally');
 
 		parent.rotation = 100;	// Rotation by 90 degrees from initial position
-		if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 		strictEqual( Round(child.x), -10, "Child moved around parent upon rotation (x).")
 		strictEqual( Round(child.y), 10, "Child moved around parent upon rotation (y).")
 
@@ -514,11 +490,9 @@ $(document).ready(function() {
 
 
         test("disableControl and enableControl", function () {
-            var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
             var e = Crafty.e("2D, Twoway")
                 .attr({ x: 0 })
                 .twoway(1);
-            if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
             equal(e._movement.x, 0);
             equal(e._x, 0);
@@ -557,10 +531,8 @@ $(document).ready(function() {
 
 
 		test("Resizing 2D objects & hitboxes", function(){
-			var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 			var e = Crafty.e("2D, Collision");
 			e.attr({x:0, y:0, w:40, h:50})	
-			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			
 			equal(e.map.points[0][0], 0, "Before rotation: x_0 is 0")
 			equal(e.map.points[0][1], 0, "y_0 is 0")
@@ -568,7 +540,6 @@ $(document).ready(function() {
 			equal(e.map.points[2][1], 50, "y_2 is 50")
 
 			e.rotation = 90;
-			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
 			equal( Math.round(e.map.points[0][0]), 0, "After rotation by 90 deg: x_0 is 0")
 			equal( Math.round(e.map.points[0][1]), 0, "y_0 is 0")
@@ -592,7 +563,6 @@ $(document).ready(function() {
 			// Check that changing the width when rotated resizes correctly for both hitbox and MBR
 			// Rotated by 90 degrees, changing the width of the entity should change the height of the hitbox/mbr
 			e.w = 100;
-			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 
 			equal( Math.round(e.map.points[0][0]), 0, "After rotation and increase in width: x_0 is 0")
 			equal( Math.round(e.map.points[0][1]), 0, "y_0 is 0")
@@ -639,18 +609,13 @@ $(document).ready(function() {
 		});
 
 		test("VisibleMBR and DebugRect", function(){
-			var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 			var e = Crafty.e("2D, VisibleMBR").attr({x:10, y:10, w:10, h:20});
-			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e._assignRect();
-			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.debugRect._x, 10, "debugRect has correct x coord");
 			equal(e.debugRect._h, 20, "debugRect has correct height");
 
 			e.rotation = 90;
-			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e._assignRect();
-			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.debugRect._h, 10, "debugRect has correct height of MBR after rotation");
 
 			e.destroy();
@@ -658,11 +623,8 @@ $(document).ready(function() {
 		});
 
 		test("Hitbox debugging", function(){
-			var no_getter_setters = !(Crafty.support.setter || Crafty.support.defineProperty);
 			var e = Crafty.e("2D, Collision, WiredHitBox").attr({x:10, y:10, w:10, h:20}).collision();
-			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e.matchHitBox(); // only necessary until collision works properly!
-			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.polygon.points[0][0], 10, "WiredHitBox -- correct x coord for upper right corner");
 			equal(e.polygon.points[2][1], 30, "correct y coord for lower right corner");
 			notEqual(typeof e._debug.strokeStyle, "undefined" , "stroke style is assigned");
@@ -671,18 +633,14 @@ $(document).ready(function() {
 			e.destroy();
 
 			var e = Crafty.e("2D, Collision, SolidHitBox").attr({x:10, y:10, w:10, h:20}).collision();
-			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e.matchHitBox(); // only necessary until collision works properly!
-			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.polygon.points[0][0], 10, "SolidHitBox -- correct x coord for upper right corner");
 			equal(e.polygon.points[2][1], 30, "correct y coord for lower right corner");
 			equal(typeof e._debug.strokeStyle, "undefined" , "stroke style is undefined");
 			notEqual(typeof e._debug.fillStyle, "undefined", "fill style is assigned");
 
 			e.collision( new Crafty.polygon([0, 0], [15, 0], [0, 15]) );
-			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			e.matchHitBox();
-			if (no_getter_setters) { Crafty.trigger("EnterFrame"); }
 			equal(e.polygon.points[2][1], 25, "After change -- correct y coord for third point");
 
 			e.destroy();


### PR DESCRIPTION
This removes several chunks of code that exist only to support IE8.

grep was helpful in finding the most explicit stuff, but I'm sure there's more.

I think there was also some stuff added to the tests to work around IE8?
