### PR TITLE
Allow visibility MBR to be manually offset

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -102,7 +102,7 @@ Crafty.c("Canvas", {
         co.w = w || coord[2];
         co.h = h || coord[3];
 
-        if (this._mbr) {
+        if (this._rotation !== 0) {
             context.save();
 
             context.translate(this._origin.x + this._x, this._origin.y + this._y);
@@ -134,7 +134,7 @@ Crafty.c("Canvas", {
         this.drawVars.ctx = context;
         this.trigger("Draw", this.drawVars);
 
-        if (this._mbr || (this._flipX || this._flipY)) {
+        if (this._rotation !== 0 || (this._flipX || this._flipY)) {
             context.restore();
         }
         if (globalpha) {

--- a/tests/core.html
+++ b/tests/core.html
@@ -550,6 +550,40 @@ $(document).ready(function() {
 	});
 
 
+	test("adjustable boundary", function(){
+		e = Crafty.e("2D").attr({
+			x: 10, y:10, w: 10, h: 10
+		})
+
+		// Four argument version
+		e.offsetBoundary(10, 1, 3, 0);
+		equal(e._bx1, 10, "X1 boundary set");
+		equal(e._bx2, 3, "X2 boundary set");
+		equal(e._by1, 1, "Y1 boundary set");
+		equal(e._by2, 0, "Y2 boundary set");	
+
+		e._calculateMBR(10, 10, 0)
+
+		var mbr = e._mbr;
+
+		equal(mbr._h, 11, "MBR height uses boundaries (11)");
+		equal(mbr._w, 23, "MBR width uses boundaries (23)");
+
+		// One argument version
+		e.offsetBoundary(5);
+		equal(e._bx1, 5, "X1 boundary set");
+		equal(e._bx2, 5, "X2 boundary set");
+		equal(e._by1, 5, "Y1 boundary set");
+		equal(e._by2, 5, "Y2 boundary set");
+
+		
+
+		Crafty("*").destroy();
+
+
+	})
+
+
         test("disableControl and enableControl", function () {
             var e = Crafty.e("2D, Twoway")
                 .attr({ x: 0 })


### PR DESCRIPTION
This patch adds internal properties to "2D" that indicate how far beyond an object's default dimensions the visible MBR should be.

These can be set with the public method `offsetBoundary`.

The point of this is that custom rendering might want to create effects that extend beyond the standard dimensions of the entity -- a glow around a sprite, for instance.  It shouldn't really be used anywhere _except_ custom rendering stuff.
