### PR TITLE
Fix problem with DOM sprite animation in webkit browsers

### DIFF
--- a/src/sprite.js
+++ b/src/sprite.js
@@ -56,7 +56,8 @@ Crafty.c("Sprite", {
                     hscale = this._w / co.w,
                     style = this._element.style;
 
-                style.background = style.backgroundColor + " url('" + this.__image + "') no-repeat -" + co.x * hscale + "px -" + co.y * vscale + "px";
+                style.background = style.backgroundColor + " url('" + this.__image + "') no-repeat";
+                style.backgroundPosition = "-" + co.x * hscale + "px -" + co.y * vscale + "px";
                 // style.backgroundSize must be set AFTER style.background!
                 if (vscale != 1 || hscale != 1) {
                     style.backgroundSize = (this.img.width * hscale) + "px" + " " + (this.img.height * vscale) + "px";


### PR DESCRIPTION
The backgroundPosition CSS attribute isn't always getting set correctly in Safari.  This seems to be some sort of hard to trigger webkit-only bug that occurs when we do sprite animation, but not when setting regular sprite positions.

I was unable to produce a simple test case without using Crafty, so I'm not sure what the exact problem is.  This "fixes" things by setting the background position separately from the rest of the background properties.

This fixes issue #656.
