### PR TITLE
adjust padding offset

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -213,11 +213,7 @@ Crafty.c("SpriteAnimation", {
 		}
 
 
-		var reel, i, tile, tileh, pos;
-
-		// Get the dimensions of a single frame, as defind in Sprite component.
-		tile = this.__tile + parseInt(this.__padding[0] || 0, 10);
-		tileh = this.__tileh + parseInt(this.__padding[1] || 0, 10);
+		var reel, i;
 
 		reel = {
 			id: reelId,
@@ -235,22 +231,18 @@ Crafty.c("SpriteAnimation", {
 			y = fromY;
 			if (frameCount >= 0) {
 				for (; i < fromX + frameCount ; i++) {
-					reel.frames.push([i * tile, y * tileh]);
+					reel.frames.push([i, y]);
 				}
 			}
 			else {
 				for (; i > fromX + frameCount; i--) {
-					reel.frames.push([i * tile, y * tileh]);
+					reel.frames.push([i, y]);
 				}
 			}
 		}
 		// @sign public this .reel(String reelId, Number duration, Array frames)
 		else if (arguments.length === 3 && typeof fromX === "object") {
-			// In this case, fromX is actually the array of frames
-			for (i=0; i < fromX.length; i++) {
-				pos = fromX[i];
-				reel.frames.push([pos[0] * tile, pos[1] * tileh]);
-			}
+			reel.frames = fromX;
 		}
 		else {
 			throw "Urecognized arguments. Please see the documentation for 'reel(...)'.";
@@ -503,9 +495,7 @@ Crafty.c("SpriteAnimation", {
 	_updateSprite: function() {
 		var currentReel = this._currentReel;
 		var pos = currentReel.frames[currentReel.currentFrame];
-		this.__coord[0] = pos[0];
-		this.__coord[1] = pos[1];
-		this.trigger("Change"); // needed to trigger a redraw
+		this.sprite(pos[0], pos[1]); // .sprite will trigger redraw
 
 	},
 

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -139,13 +139,14 @@ Crafty.extend({
     /**@
      * #Crafty.sprite
      * @category Graphics
-     * @sign public this Crafty.sprite([Number tile, [Number tileh]], String url, Object map[, Number paddingX[, Number paddingY]])
+     * @sign public this Crafty.sprite([Number tile, [Number tileh]], String url, Object map[, Number paddingX[, Number paddingY[, Boolean paddingAroundBorder]]])
      * @param tile - Tile size of the sprite map, defaults to 1
      * @param tileh - Height of the tile; if provided, tile is interpreted as the width
      * @param url - URL of the sprite image
      * @param map - Object where the key is what becomes a new component and the value points to a position on the sprite map
      * @param paddingX - Horizontal space in between tiles. Defaults to 0.
      * @param paddingY - Vertical space in between tiles. Defaults to paddingX.
+     * @param paddingAroundBorder - If padding should be applied around the border of the sprite sheet. If enabled the first tile starts at (paddingX,paddingY) instead of (0,0). Defaults to false.
      * Generates components based on positions in a sprite image to be applied to entities.
      *
      * Accepts a tile size, URL and map for the name of the sprite and its position.
@@ -186,7 +187,7 @@ Crafty.extend({
      *
      * @see Sprite
      */
-    sprite: function (tile, tileh, url, map, paddingX, paddingY) {
+    sprite: function (tile, tileh, url, map, paddingX, paddingY, paddingAroundBorder) {
         var spriteName, temp, x, y, w, h, img;
 
         //if no tile value, default to 1.
@@ -235,12 +236,13 @@ Crafty.extend({
             this.requires("2D, Sprite");
             this.__trim = [0, 0, 0, 0];
             this.__image = url;
-            this.__coord = [this.__coord[0], this.__coord[1], this.__coord[2], this.__coord[3]];
             this.__tile = tile;
             this.__tileh = tileh;
             this.__padding = [paddingX, paddingY];
+            this.__padBorder = paddingAroundBorder;
+            this.sprite(this.__coord[0], this.__coord[1], this.__coord[2], this.__coord[3]);
+            
             this.img = img;
-
             //draw now
             if (this.img.complete && this.img.width > 0) {
                 this.ready = true;
@@ -256,15 +258,11 @@ Crafty.extend({
             if (!map.hasOwnProperty(spriteName)) continue;
 
             temp = map[spriteName];
-            x = temp[0] * (tile + paddingX);
-            y = temp[1] * (tileh + paddingY);
-            w = temp[2] * tile || tile;
-            h = temp[3] * tileh || tileh;
 
             //generates sprite components for each tile in the map
             Crafty.c(spriteName, {
                 ready: false,
-                __coord: [x, y, w, h],
+                __coord: [temp[0], temp[1], temp[2] || 1, temp[3] || 1],
 
                 init: sharedSpriteInit
             });

--- a/src/sprite.js
+++ b/src/sprite.js
@@ -73,13 +73,13 @@ Crafty.c("Sprite", {
     /**@
      * #.sprite
      * @comp Sprite
-     * @sign public this .sprite(Number x, Number y, Number w, Number h)
+     * @sign public this .sprite(Number x, Number y[, Number w, Number h])
      * @param x - X cell position
      * @param y - Y cell position
-     * @param w - Width in cells
-     * @param h - Height in cells
+     * @param w - Width in cells. Optional.
+     * @param h - Height in cells. Optional.
      *
-     * Uses a new location on the sprite map as its sprite.
+     * Uses a new location on the sprite map as its sprite. If w or h are ommitted, the width and height are not changed.
      *
      * Values should be in tiles or cells (not pixels).
      *
@@ -97,11 +97,14 @@ Crafty.c("Sprite", {
      * The coordinate of the slide within the sprite in the format of [x, y, w, h].
      */
     sprite: function (x, y, w, h) {
-        this.__coord = [x * (this.__tile + this.__padding[0]) + this.__trim[0],
-            y * (this.__tileh + this.__padding[1]) + this.__trim[1],
-            this.__trim[2] || w * this.__tile || this.__tile,
-            this.__trim[3] || h * this.__tileh || this.__tileh
-        ];
+        this.__coord = this.__coord || [0, 0, 0, 0];
+
+        this.__coord[0] = x * (this.__tile + this.__padding[0]) + (this.__padBorder ? this.__padding[0] : 0) + this.__trim[0];
+        this.__coord[1] = y * (this.__tileh + this.__padding[1]) + (this.__padBorder ? this.__padding[1] : 0) + this.__trim[1];
+        if (typeof(w)!=='undefined' && typeof(h)!=='undefined') {
+            this.__coord[2] = this.__trim[2] || w * this.__tile || this.__tile;
+            this.__coord[3] = this.__trim[3] || h * this.__tileh || this.__tileh;
+        }
 
         this.trigger("Change");
         return this;

--- a/tests/animation/sprite-animation.js
+++ b/tests/animation/sprite-animation.js
@@ -218,8 +218,8 @@ test("Test using .reel to set an animation using start and end values", function
 	var frames = reel.frames;
 	equal(frames.length, 3, "Reel has correct number of frames.");
 	deepEqual(frames[0], [0, 0], "First frame is correct.");
-	deepEqual(frames[1], [64, 0], "Second frame is correct.");
-	deepEqual(frames[2], [128, 0], "Third frame is correct.");
+	deepEqual(frames[1], [1, 0], "Second frame is correct.");
+	deepEqual(frames[2], [2, 0], "Third frame is correct.");
 
 })
 
@@ -239,8 +239,8 @@ test("Test using .reel to set an animation using an array of frames", function()
 	equal(frames.length, 3, "Reel has correct number of frames.");
 	// This relies on the sprite being defined with a size of 64
 	deepEqual(frames[0], [0, 0], "First frame is correct.");
-	deepEqual(frames[1], [64, 0], "Second frame is correct.");
-	deepEqual(frames[2], [128, 0], "Third frame is correct.");
+	deepEqual(frames[1], [1, 0], "Second frame is correct.");
+	deepEqual(frames[2], [2, 0], "Third frame is correct.");
 
 })
 


### PR DESCRIPTION
PR for #416

This is in current build:

``` javascript
x = temp[0] * (tile + paddingX);
y = temp[1] * (tileh + paddingY);
```

However the author of the issue suggests:

``` javascript
x = temp[0] * (tile + paddingX) + paddingX;
y = temp[1] * (tileh + paddingY) + paddingY;
```

Look at the example tileset in the referenced issue. The tileset has padding before the first tile, so his solution is correct:
let `temp[0] = 0`, then `x = 0*(...) = 0`. Instead `x = 0*(...) + paddingX = paddingX` is required.
left `temp[0] = 1`, then `x = 1*(tileWidth + paddingX)`. Instead  `x = 1*(tileWidth + paddingX) + paddingX` is required (2 paddings required for 2nd x tile).

I have tested it with the example tileset and in the current build the black border is indeed visible. With this fix the black border is not visible. The question is whether **every** spriteset has padding like this?
