### PR TITLE
Work with RequireJS

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1626,9 +1626,9 @@ if (typeof define === 'function') { // AMD
     define('crafty', [], function () {
         return Crafty;
     });
-} else if (typeof exports === 'object') { // CommonJS
-    module.exports = Crafty;
 }
+
+module.exports = Crafty;
 
 window.Crafty = Crafty;
 


### PR DESCRIPTION
require function in the compiled crafty.js expects the exported symbols the be defined in module.exports object. If using RequireJS Crafty was never added to the object. That leads to `var Crafty = require('./core.js'),` returning an empty object which leads to Crafty failing to initialize.
