### PR TITLE
Edit docs for formatting

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -72,7 +72,7 @@ Crafty.extend({
  * Component for any entity that has a position on the stage.
  * @trigger Move - when the entity has moved - { _x:Number, _y:Number, _w:Number, _h:Number } - Old position
  * @trigger Change - when the entity has moved - { _x:Number, _y:Number, _w:Number, _h:Number } - Old position
- * @trigger Rotate - when the entity is rotated - { cos:Number, sin:Number, deg:Number, rad:Number, o: {x:Number, y:Number}, matrix: {M11, M12, M21, M22} }
+ * @trigger Rotate - when the entity is rotated - { cos:Number, sin:Number, deg:Number, rad:Number, o: {x:Number, y:Number}}
  */
 Crafty.c("2D", {
     /**@

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -218,10 +218,11 @@ Crafty.c("DOM", {
     /**@
      * #.css
      * @comp DOM
-     * @sign public * css(String property, String value)
+     * @sign public css(String property, String value)
      * @param property - CSS property to modify
      * @param value - Value to give the CSS property
-     * @sign public * css(Object map)
+     *
+     * @sign public  css(Object map)
      * @param map - Object where the key is the CSS property and the value is CSS value
      *
      * Apply CSS styles to the element.

--- a/src/DebugLayer.js
+++ b/src/DebugLayer.js
@@ -56,9 +56,10 @@ Crafty.c("DebugCanvas", {
      * @comp DebugCanvas
      * @sign public  .debugFill([String fillStyle])
      * @param fillStyle - The color the component will be filled with.  Defaults to "red". Pass the boolean false to turn off filling.
+     * @example
      * ~~~
      * var myEntity = Crafty.e("2D, Collision, SolidHitBox ").debugFill("purple")
-     *~~~
+     * ~~~
      */
     debugFill: function (fillStyle) {
         if (typeof fillStyle === 'undefined')
@@ -72,9 +73,10 @@ Crafty.c("DebugCanvas", {
      * @comp DebugCanvas
      * @sign public  .debugStroke([String strokeStyle])
      * @param strokeStyle - The color the component will be outlined with.  Defaults to "red".  Pass the boolean false to turn this off.
+     * @example
      * ~~~
      * var myEntity = Crafty.e("2D, Collision, WiredHitBox ").debugStroke("white")
-     *~~~
+     * ~~~
      */
     debugStroke: function (strokeStyle) {
         if (typeof strokeStyle === 'undefined')

--- a/src/HashMap.js
+++ b/src/HashMap.js
@@ -307,10 +307,8 @@ var Crafty = require('./core.js'),
      * @category 2D
      * Broad-phase collision detection engine. See background information at
      *
-     * ~~~
      * - [N Tutorial B - Broad-Phase Collision](http://www.metanetsoftware.com/technique/tutorialB.html)
      * - [Broad-Phase Collision Detection with CUDA](http.developer.nvidia.com/GPUGems3/gpugems3_ch32.html)
-     * ~~~
      * @see Crafty.map
      */
 

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -13,8 +13,9 @@ var Crafty = require('./core.js'),
  *
  * Create a canvas entity like this
  * ~~~
- * var myEntity = Crafty.e("2D, Canvas, Color").color("green")
- *                                             .attr({x: 13, y: 37, w: 42, h: 42});
+ * var myEntity = Crafty.e("2D, Canvas, Color")
+ *      .color("green")
+ *      .attr({x: 13, y: 37, w: 42, h: 42});
  *~~~
  */
 Crafty.c("Canvas", {

--- a/src/collision.js
+++ b/src/collision.js
@@ -142,7 +142,7 @@ Crafty.c("Collision", {
      * ~~~
      * [{
      *    obj: [entity],
-     *    type "MBR" or "SAT",
+     *    type: "MBR" or "SAT",
      *    overlap: [number]
      * }]
      * ~~~

--- a/src/controls.js
+++ b/src/controls.js
@@ -55,9 +55,12 @@ Crafty.extend({
      *
      * Notable properties of a MouseEvent e:
      * ~~~
-     * e.clientX, e.clientY	//(x,y) coordinates of mouse event in web browser screen space
-     * e.realX, e.realY		//(x,y) coordinates of mouse event in world/viewport space
-     * e.mouseButton			// Normalized mouse button according to Crafty.mouseButtons
+     * //(x,y) coordinates of mouse event in web browser screen space
+     * e.clientX, e.clientY	
+     * //(x,y) coordinates of mouse event in world/viewport space
+     * e.realX, e.realY		
+     * // Normalized mouse button according to Crafty.mouseButtons
+     * e.mouseButton			
      * ~~~
      * @see Crafty.touchDispatch
      */
@@ -181,7 +184,7 @@ Crafty.extend({
      *
      * TouchEvents have a different structure then MouseEvents.
      * The relevant data lives in e.changedTouches[0].
-     * To normalize TouchEvents we catch em and dispatch a mock MouseEvent instead.
+     * To normalize TouchEvents we catch them and dispatch a mock MouseEvent instead.
      *
      * @see Crafty.mouseDispatch
      */
@@ -378,11 +381,9 @@ Crafty.bind("CraftyStop", function () {
  * @trigger MouseMove - when the mouse is over the entity and moves - MouseEvent
  * Crafty adds the mouseButton property to MouseEvents that match one of
  *
- * ~~~
  * - Crafty.mouseButtons.LEFT
  * - Crafty.mouseButtons.RIGHT
  * - Crafty.mouseButtons.MIDDLE
- * ~~~
  *
  * @example
  * ~~~
@@ -893,10 +894,8 @@ Crafty.c("Twoway", {
      *
      * Constructor to initialize the speed and power of jump. Component will
      * listen for key events and move the entity appropriately. This includes
-     * ~~~
-     * `Up Arrow`, `Right Arrow`, `Left Arrow` as well as W, A, D. Used with the
+     * `Up Arrow`, `Right Arrow`, `Left Arrow` as well as `W`, `A`, `D`. Used with the
      * `gravity` component to simulate jumping.
-     * ~~~
      *
      * The key presses will move the entity in that direction by the speed passed in
      * the argument. Pressing the `Up Arrow` or `W` will cause the entity to jump.

--- a/src/core.js
+++ b/src/core.js
@@ -843,9 +843,12 @@ Crafty.fn = Crafty.prototype = {
 //give the init instances the Crafty prototype
 Crafty.fn.init.prototype = Crafty.fn;
 
-/**
- * Extension method to extend the namespace and
- * selector instances
+
+/**@
+ * #Crafty.extend
+ * @category Core
+ * Used to extend the Crafty namespace.
+ *
  */
 Crafty.extend = Crafty.fn.extend = function (obj) {
     var target = this,
@@ -862,11 +865,7 @@ Crafty.extend = Crafty.fn.extend = function (obj) {
     return target;
 };
 
-/**@
- * #Crafty.extend
- * @category Core
- * Used to extend the Crafty namespace.
- */
+
 Crafty.extend({
     /**@
      * #Crafty.init
@@ -1077,8 +1076,8 @@ Crafty.extend({
             /**@
              * #Crafty.timer.steptype
              * @comp Crafty.timer
-             * Can be called to set the type of timestep the game loop uses
              * @sign public void Crafty.timer.steptype(mode [, maxTimeStep])
+             * Can be called to set the type of timestep the game loop uses
              * @param mode - the type of time loop.  Allowed values are "fixed", "semifixed", and "variable".  Crafty defaults to "fixed".
              * @param mode - For "fixed", sets the max number of frames per step.   For "variable" and "semifixed", sets the maximum time step allowed.
              *
@@ -1203,8 +1202,8 @@ Crafty.extend({
             /**@
              * #Crafty.timer.simulateFrames
              * @comp Crafty.timer
-             * Advances the game state by a number of frames and draws the resulting stage at the end. Useful for tests and debugging.
              * @sign public this Crafty.timer.simulateFrames(Number frames[, Number timestep])
+             * Advances the game state by a number of frames and draws the resulting stage at the end. Useful for tests and debugging.
              * @param frames - number of frames to simulate
              * @param timestep - the duration to pass each frame.  Defaults to milliSecPerFrame (20 ms) if not specified.
              */
@@ -1270,7 +1269,7 @@ Crafty.extend({
      * @category Core
      * @sign public void Crafty.c(String name, Object component)
      * @param name - Name of the component
-     * @param component - Object with the components properties and methods
+     * @param component - Object with the component's properties and methods
      * Creates a component where the first argument is the ID and the second
      * is the object that will be inherited by entities.
      *

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -35,10 +35,10 @@ Crafty.c("Color", {
      * choose to support.
      *
      * @example
-     * ~~~
+     * ```
      * Crafty.e("2D, DOM, Color")
      *    .color("#969696");
-     * ~~~
+     * ```
      */
     color: function (color) {
         if (!color) return this._color;
@@ -426,10 +426,9 @@ Crafty.DrawManager = (function () {
          * @comp Crafty.DrawManager
          * @sign public Crafty.DrawManager.drawAll([Object rect])
          * @param rect - a rectangular region {_x: x_val, _y: y_val, _w: w_val, _h: h_val}
-         * ~~~
+         *
          * - If rect is omitted, redraw within the viewport
          * - If rect is provided, redraw within the rect
-         * ~~~
          */
         drawAll: function (rect) {
             rect = rect || Crafty.viewport.rect();
@@ -457,10 +456,9 @@ Crafty.DrawManager = (function () {
          * @comp Crafty.DrawManager
          * @sign public Crafty.DrawManager.boundingRect(set)
          * @param set - Undocumented
-         * ~~~
+         *
          * - Calculate the common bounding rect of multiple canvas entities.
          * - Returns coords
-         * ~~~
          */
         boundingRect: function (set) {
             if (!set || !set.length) return;
@@ -496,12 +494,11 @@ Crafty.DrawManager = (function () {
          * #Crafty.DrawManager.renderCanvas
          * @comp Crafty.DrawManager
          * @sign public Crafty.DrawManager.renderCanvas()
-         * ~~~
+         *
          * - Triggered by the "RenderScene" event
          * - If the number of rects is over 60% of the total number of objects
          *	do the naive method redrawing `Crafty.DrawManager.drawAll`
          * - Otherwise, clear the dirty regions, and redraw entities overlapping the dirty regions.
-         * ~~~
          *
          * @see Canvas.draw
          */
@@ -616,9 +613,8 @@ Crafty.DrawManager = (function () {
          * #Crafty.DrawManager.renderDOM
          * @comp Crafty.DrawManager
          * @sign public Crafty.DrawManager.renderDOM()
-         * ~~~
+         *
          * When "RenderScene" is triggered, draws all DOM entities that have been flagged
-         * ~~~
          *
          * @see DOM.draw
          */

--- a/src/html.js
+++ b/src/html.js
@@ -26,7 +26,7 @@ Crafty.c("HTML", {
      * ~~~
      * Crafty.e("HTML")
      *    .attr({x:20, y:20, w:100, h:100})
-     *    .replace("<a href='http://www.craftyjs.com'>Crafty.js</a>");
+     *    .replace("<a href='index.html'>Index</a>");
      * ~~~
      */
     replace: function (new_html) {
@@ -48,7 +48,7 @@ Crafty.c("HTML", {
      * ~~~
      * Crafty.e("HTML")
      *    .attr({x:20, y:20, w:100, h:100})
-     *    .append("<a href='http://www.craftyjs.com'>Crafty.js</a>");
+     *    .append("<a href='index.html'>Index</a>");
      * ~~~
      */
     append: function (new_html) {
@@ -70,7 +70,7 @@ Crafty.c("HTML", {
      * ~~~
      * Crafty.e("HTML")
      *    .attr({x:20, y:20, w:100, h:100})
-     *    .prepend("<a href='http://www.craftyjs.com'>Crafty.js</a>");
+     *    .prepend("<a href='index.html'>Index</a>");
      * ~~~
      */
     prepend: function (new_html) {

--- a/src/keycodes.js
+++ b/src/keycodes.js
@@ -199,8 +199,8 @@ Crafty.extend({
     /**@
      * #Crafty.mouseButtons
      * @category Input
-     * Object of mouseButton names and the corresponding button ID.
-     * In all mouseEvents we add the e.mouseButton property with a value normalized to match e.button of modern webkit
+     * An object mapping mouseButton names to the corresponding button ID.
+     * In all mouseEvents, we add the `e.mouseButton` property with a value normalized to match e.button of modern webkit browsers:
      *
      * ~~~
      * LEFT: 0,

--- a/src/sound.js
+++ b/src/sound.js
@@ -436,6 +436,7 @@ Crafty.extend({
          * #Crafty.audio.pause
          * @comp Crafty.audio
          * @sign public this Crafty.audio.pause(string ID)
+         * @param {string} id - The id of the audio object to pause
          *
          * Pause the Audio instance specified by id param.
          *
@@ -444,7 +445,6 @@ Crafty.extend({
          * Crafty.audio.pause('music');
          * ~~~
          *
-         * @param {string} id The id of the audio object to pause
          */
         pause: function (id) {
             if (!Crafty.support.audio || !id || !this.sounds[id])
@@ -462,6 +462,7 @@ Crafty.extend({
          * #Crafty.audio.unpause
          * @comp Crafty.audio
          * @sign public this Crafty.audio.unpause(string ID)
+         * @param {string} id - The id of the audio object to unpause
          *
          * Resume playing the Audio instance specified by id param.
          *
@@ -470,7 +471,6 @@ Crafty.extend({
          * Crafty.audio.unpause('music');
          * ~~~
          *
-         * @param {string} id The id of the audio object to unpause
          */
         unpause: function (id) {
             if (!Crafty.support.audio || !id || !this.sounds[id])
@@ -487,6 +487,7 @@ Crafty.extend({
          * #Crafty.audio.togglePause
          * @comp Crafty.audio
          * @sign public this Crafty.audio.togglePause(string ID)
+         * @param {string} id - The id of the audio object to pause/
          *
          * Toggle the pause status of the Audio instance specified by id param.
          *
@@ -495,7 +496,6 @@ Crafty.extend({
          * Crafty.audio.togglePause('music');
          * ~~~
          *
-         * @param {string} id The id of the audio object to pause/unpause
          */
         togglePause: function (id) {
             if (!Crafty.support.audio || !id || !this.sounds[id])

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -509,13 +509,12 @@ Crafty.extend({
              * `Crafty.stage.inner` is a div inside the `#cr-stage` div that holds all DOM entities.
              * If you use canvas, a `canvas` element is created at the same level in the dom
              * as the the `Crafty.stage.inner` div. So the hierarchy in the DOM is
-             *
-             * `Crafty.stage.elem`
-             * <!-- not sure how to do indentation in the document-->
-             *
-             *     - `Crafty.stage.inner` (a div HTMLElement)
-             *
-             *     - `Crafty.canvas._canvas` (a canvas HTMLElement)
+             *  
+             * ~~~
+             * Crafty.stage.elem
+             *  - Crafty.stage.inner (a div HTMLElement)
+             *  - Crafty.canvas._canvas (a canvas HTMLElement)
+             * ~~~
              */
 
             //create stage div to contain everything


### PR DESCRIPTION
There are some formatting issues on several of the automatically generated [doc pages](http://craftyjs.com/api/).  This patch is for cleaning up formatting and (where I notice them) grammar issues.

The basic idea here is to just skim the docs, and fix anything that jumps out at me.  :)  It'll be ready to land when we've inspected each of the following modules for obvious problems:
- [x] Core
- [x] Game Loop
- [x] Events
- [x] 2D (But not the math stuff)
- [x] Graphics
- [x] Utilities
- [x] Misc
- [x] Stage
- [x] Input
- [x] Animation
- [x] Scenes
- [x] Audio
- [x] Assets
- [x] Debug
