### PR TITLE
Add unbinding by bind reference back

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1366,7 +1366,7 @@ Crafty.extend({
      * @sign public Number bind(String eventName, Function callback)
      * @param eventName - Name of the event to bind to
      * @param callback - Method to execute upon event triggered
-     * @returns ID of the current callback used to unbind
+     * @returns callback function which can be used for unbind
      *
      * Binds to a global event. Method will be executed when `Crafty.trigger` is used
      * with the event name.
@@ -1398,7 +1398,8 @@ Crafty.extend({
         var hdl = handlers[event];
 
         if (!hdl.global) hdl.global = [];
-        return hdl.global.push(callback) - 1;
+        hdl.global.push(callback);
+        return callback;
     },
 
 
@@ -1408,7 +1409,7 @@ Crafty.extend({
      * @sign public Number uniqueBind(String eventName, Function callback)
      * @param eventName - Name of the event to bind to
      * @param callback - Method to execute upon event triggered
-     * @returns ID of the current callback used to unbind
+     * @returns callback function which can be used for unbind
      *
      * Works like Crafty.bind, but prevents a callback from being bound multiple times.
      *
@@ -1416,8 +1417,7 @@ Crafty.extend({
      */
     uniqueBind: function (event, callback) {
         this.unbind(event, callback);
-        this.bind(event, callback);
-
+        return this.bind(event, callback);
     },
 
     /**@
@@ -1426,7 +1426,7 @@ Crafty.extend({
      * @sign public Number one(String eventName, Function callback)
      * @param eventName - Name of the event to bind to
      * @param callback - Method to execute upon event triggered
-     * @returns ID of the current callback used to unbind
+     * @returns callback function which can be used for unbind
      *
      * Works like Crafty.bind, but will be unbound once the event triggers.
      *
@@ -1439,7 +1439,6 @@ Crafty.extend({
             self.unbind(event, oneHandler);
         };
         return self.bind(event, oneHandler);
-
     },
 
     /**@

--- a/tests/events.html
+++ b/tests/events.html
@@ -44,6 +44,12 @@ $(document).ready(function() {
 		strictEqual(x, 0, "Crafty.bind does not fire once unbound");
 
 		x = 0;
+		var ref = Crafty.bind("Increment", add)
+		Crafty.unbind("Increment", ref)
+		Crafty.trigger("Increment")
+		strictEqual(x, 0, "Crafty.bind does not fire once unbound via reference");
+
+		x = 0;
 		Crafty.one("Increment", add)
 		Crafty.trigger("Increment")
 		Crafty.trigger("Increment")


### PR DESCRIPTION
I'm new to craftyjs, and following through a great tutorial on http://buildnewgames.com/introduction-to-crafty/

While upgrading the tutorial to 0.6.1, the first 2 things that I've noticed that broke are:
1. The `animate`/`reel` portion of the code.
2. The `unbind` behavior on the victory page.

The `animate` code is well documented and trivial to track down and fix. Both due to the error messages as well as the clear documentation of the incompatibility.

The `unbind` code was more difficult to track down. It ate the error message (not saying it should be any different) and while #420 ( commit 35d9585caaf17315b ) said it was a rewrite, it highlighted removing the ability to `bind` to regular elements rather than global elements. It said nothing of removing the ability to `unbind` with the reference returned by `bind`. This seems like a simple oversight and possibly wants to make its way back into the code.

Example of code that worked in the 0.5.x but not the 0.6.x branch:

``` javascript
var ref = bind('KeyDown', function() { console.debug('x') });
unbind('KeyDown', ref)
```

The solution is quite easy, but I wonder if there is reason to break this.
working code:

``` javascript
function printDebug() { console.debug('x'); }
bind('KeyDown', printDebug);
unbind('KeyDown', printDebug);
```

The alternatives are to document this change, or have `bind` return the command function passed in, so unbind will work unchanged. **UPDATE**: it is now returning the command passed in, so `one()` and `bind()` both work.

If nothing else, I just wanted to document this changed behavior in an issue, so someone else coming along may be able to stumble upon the fix.

Thanks for the great library,
K
