### PR TITLE
Add grunt-contrib-connect package and connect task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -104,6 +104,14 @@ module.exports = function (grunt) {
             files: "crafty.js"
         },
 
+        connect: {
+            server: {
+                options: {
+                    keepalive: true
+                }
+            }
+        }
+
     });
 
     // Load the plugin that provides the "uglify" task.
@@ -111,6 +119,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-qunit');
     grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-contrib-connect');
     grunt.loadNpmTasks('grunt-jsvalidate');
     grunt.loadNpmTasks('grunt-browserify');
     grunt.loadNpmTasks('grunt-banner');
@@ -139,6 +148,5 @@ module.exports = function (grunt) {
 
     // Run only tests
     grunt.registerTask('validate', ['qunit']);
-
 
 };

--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
     "grunt-browserify": "~1.2.9",
     "grunt-banner": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3"
+  },
+  "devDependencies": {
+    "grunt-contrib-connect": "~0.6.0"
   }
 }


### PR DESCRIPTION
`grunt connect` task can be used to run a local HTTP server.

See also #679
