### PR TITLE
Fix the matrix inversion test to avoid floating point issues.

### DIFF
--- a/tests/math.js
+++ b/tests/math.js
@@ -247,8 +247,9 @@ test("determinant()", function() {
 });
 
 test("invert()", function() {
-  equal((new Matrix2D()).scale(2, 3).rotate(Math.PI / 2).invert().equals(new Matrix2D(3.061616997868383e-17, -0.3333333333333333, 0.5, 2.041077998578922e-17, 0, 0)),
-    true, "(new Matrix2D()).scale(2, 3).rotate(Math.PI / 2).invert().equals(new Matrix2D(3.061616997868383e-17, -0.3333333333333333, 0.5, 2.041077998578922e-17, 0, 0))");
+  var m = new Matrix2D(4, 3, 3, 2, 0, 0);
+  var m2 = new Matrix2D(-2, 3, 3, -4, 0, 0);
+  ok( m.invert().equals(m2), "Matrix (4,3,3,2) inverts to (-2,3,3,-4)");
 });
 
 test("isIdentity()", function() {


### PR DESCRIPTION
The current matrix inversion test fails in Chrome due to reliance on very particular floating point errors.

Best just to do the test with a matrix that has an inverse consisting of only integers.

This fixes #677 
