### PR TITLE
Abstract viewport resizing

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -298,8 +298,15 @@ Crafty.extend({
                 this.height = window.innerHeight || (window.document.documentElement.clientHeight || window.document.body.clientHeight);
 
                 // Bind scene rendering (see drawing.js)
-                Crafty.unbind("RenderScene", Crafty.DrawManager.renderDOM);
-                Crafty.bind("RenderScene", Crafty.DrawManager.renderDOM);
+                Crafty.uniqueBind("RenderScene", Crafty.DrawManager.renderDOM);
+                // Resize the viewport
+                Crafty.uniqueBind("ViewportResize", this._resize);
+
+            },
+
+            _resize: function(){
+                Crafty.stage.elem.style.width = Crafty.viewport.width + "px";
+                Crafty.stage.elem.style.height = Crafty.viewport.height + "px";
             },
 
             width: 0,

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -207,8 +207,17 @@ Crafty.extend({
                 Crafty.canvas.context.scale(zoom, zoom);
 
             //Bind rendering of canvas context (see drawing.js)
-            Crafty.unbind("RenderScene", Crafty.DrawManager.renderCanvas);
-            Crafty.bind("RenderScene", Crafty.DrawManager.renderCanvas);
+            Crafty.uniqueBind("RenderScene", Crafty.DrawManager.renderCanvas);
+
+            Crafty.uniqueBind("ViewportResize", this._resize);
+        },
+
+        // Resize the canvas element to the current viewport
+        _resize: function() {
+            var c = Crafty.canvas._canvas;
+            c.width = Crafty.viewport.width;
+            c.height = Crafty.viewport.height;
+
         }
 
     }

--- a/tests/stage.js
+++ b/tests/stage.js
@@ -66,6 +66,35 @@ test("scroll using x, y", function() {
   equal(before.y - Crafty.DOM.translate(e.x, e.y).y, 0, "Scroll to 0");
 });
 
+test("Viewport resizing", function(){
+  var flag = 0;
+  var e = Crafty("2D, Canvas");
+  Crafty.canvas.init();
+
+  var w = Crafty.viewport.width;
+
+  equal( Crafty.canvas._canvas.width, Crafty.viewport.width, "Initial canvas size matches viewport");
+  equal(Crafty.stage.elem.style.width, Crafty.viewport.width + "px", "Initial stage size matches viewport");
+  Crafty.bind("ViewportResize", function(){flag++;});
+
+  Crafty.viewport.width += 10;
+
+  equal(flag, 1, "ViewportResize triggered");
+  equal(Crafty.viewport.width, w+10, "Viewport increased in width");
+  equal( Crafty.canvas._canvas.width, Crafty.viewport.width , "Canvas size matches viewport after change");
+  equal(Crafty.stage.elem.style.width, Crafty.viewport.width +"px", "Stage size matches viewport after change");
+
+  var h = Crafty.viewport.height;
+
+  Crafty.viewport.height += 10;
+
+  equal(flag, 2, "ViewportResize triggered");
+  equal(Crafty.viewport.height, h+10, "Viewport increased in width");
+  equal( Crafty.canvas._canvas.height, Crafty.viewport.height , "Canvas size matches viewport after change");
+  equal(Crafty.stage.elem.style.height, Crafty.viewport.height +"px", "Stage size matches viewport after change");
+
+});
+
 test("follow", function() {
   Crafty.viewport.clampToEntities = false;
   var e = Crafty.e("2D, DOM").attr({


### PR DESCRIPTION
Add setters/getters for the viewport, and trigger a "ViewportResize" event.  Use that event to alter the dimensions of the stage and canvas appropriately.

There are several places in the viewport code where it's effect on the canvas and DOM is hardcoded.  Using events instead of such special cases will make it easier to land something like a webgl backend, or support multiple canvas/DOM layers.

Adding setters for the viewport width/height should make it easier to change the game size.  That should partially help with the problem described [here](https://groups.google.com/forum/?fromgroups#!topic/craftyjs/gE1oEqh-pQ0).
