### PR TITLE
Switch redraw event name to "Invalidate"

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -71,7 +71,7 @@ Crafty.extend({
  * @category 2D
  * Component for any entity that has a position on the stage.
  * @trigger Move - when the entity has moved - { _x:Number, _y:Number, _w:Number, _h:Number } - Old position
- * @trigger Change - when the entity has moved - { _x:Number, _y:Number, _w:Number, _h:Number } - Old position
+ * @trigger Invalidate - when the entity needs to be redrawn
  * @trigger Rotate - when the entity is rotated - { cos:Number, sin:Number, deg:Number, rad:Number, o: {x:Number, y:Number}}
  */
 Crafty.c("2D", {
@@ -871,7 +871,7 @@ Crafty.c("2D", {
     /**@
      * #.flip
      * @comp 2D
-     * @trigger Change - when the entity has flipped
+     * @trigger Invalidate - when the entity has flipped
      * @sign public this .flip(String dir)
      * @param dir - Flip direction
      *
@@ -886,7 +886,7 @@ Crafty.c("2D", {
         dir = dir || "X";
         if (!this["_flip" + dir]) {
             this["_flip" + dir] = true;
-            this.trigger("Change");
+            this.trigger("Invalidate");
         }
         return this;
     },
@@ -894,7 +894,7 @@ Crafty.c("2D", {
     /**@
      * #.unflip
      * @comp 2D
-     * @trigger Change - when the entity has unflipped
+     * @trigger Invalidate - when the entity has unflipped
      * @sign public this .unflip(String dir)
      * @param dir - Unflip direction
      *
@@ -909,7 +909,7 @@ Crafty.c("2D", {
         dir = dir || "X";
         if (this["_flip" + dir]) {
             this["_flip" + dir] = false;
-            this.trigger("Change");
+            this.trigger("Invalidate");
         }
         return this;
     },
@@ -990,8 +990,8 @@ Crafty.c("2D", {
         //everything will assume the value
         this[name] = value;
 
-        //trigger a change
-        this.trigger("Change", old);
+        // flag for redraw
+        this.trigger("Invalidate");
 
         Crafty._rectPool.recycle(old);
     }

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -40,7 +40,7 @@ Crafty.c("DOM", {
         this._element.style.position = "absolute";
         this._element.id = "ent" + this[0];
 
-        this.bind("Change", function () {
+        this.bind("Invalidate", function () {
             if (!this._changed) {
                 this._changed = true;
                 Crafty.DrawManager.addDom(this);
@@ -270,7 +270,7 @@ Crafty.c("DOM", {
             }
         }
 
-        this.trigger("Change");
+        this.trigger("Invalidate");
 
         return this;
     }

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -32,7 +32,7 @@ Crafty.c("Canvas", {
         this._changed = true;
         Crafty.DrawManager.addCanvas(this);
 
-        this.bind("Change", function (e) {
+        this.bind("Invalidate", function (e) {
             //flag if changed
             if (this._changed === false) {
                 this._changed = true;

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -25,7 +25,7 @@ Crafty.c("Color", {
     /**@
      * #.color
      * @comp Color
-     * @trigger Change - when the color changes
+     * @trigger Invalidate - when the color changes
      * @sign public this .color(String color)
      * @sign public String .color()
      * @param color - Color of the rectangle
@@ -43,7 +43,7 @@ Crafty.c("Color", {
     color: function (color) {
         if (!color) return this._color;
         this._color = color;
-        this.trigger("Change");
+        this.trigger("Invalidate");
         return this;
     }
 });
@@ -75,7 +75,7 @@ Crafty.c("Tint", {
     /**@
      * #.tint
      * @comp Tint
-     * @trigger Change - when the tint is applied
+     * @trigger Invalidate - when the tint is applied
      * @sign public this .tint(String color, Number strength)
      * @param color - The color in hexadecimal
      * @param strength - Level of opacity
@@ -92,7 +92,7 @@ Crafty.c("Tint", {
         this._strength = strength;
         this._color = Crafty.toRGB(color, this._strength);
 
-        this.trigger("Change");
+        this.trigger("Invalidate");
         return this;
     }
 });
@@ -136,7 +136,7 @@ Crafty.c("Image", {
     /**@
      * #.image
      * @comp Image
-     * @trigger Change - when the image is loaded
+     * @trigger Invalidate - when the image is loaded
      * @sign public this .image(String url[, String repeat])
      * @param url - URL of the image
      * @param repeat - If the image should be repeated to fill the entity.
@@ -183,7 +183,7 @@ Crafty.c("Image", {
                     self.h = self.img.height;
                 }
 
-                self.trigger("Change");
+                self.trigger("Invalidate");
             };
 
             return this;
@@ -197,7 +197,7 @@ Crafty.c("Image", {
         }
 
 
-        this.trigger("Change");
+        this.trigger("Invalidate");
 
         return this;
     }

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -216,7 +216,7 @@ Crafty.extend({
 
         var markSpritesReady = function() {
             this.ready = true;
-            this.trigger("Change");
+            this.trigger("Invalidate");
         };
 
         img = Crafty.asset(url);
@@ -246,7 +246,7 @@ Crafty.extend({
             //draw now
             if (this.img.complete && this.img.width > 0) {
                 this.ready = true;
-                this.trigger("Change");
+                this.trigger("Invalidate");
             }
 
             //set the width and height to the sprite size

--- a/src/sprite.js
+++ b/src/sprite.js
@@ -4,7 +4,7 @@ var Crafty = require('./core.js'),
 /**@
  * #Sprite
  * @category Graphics
- * @trigger Change - when the sprites change
+ * @trigger Invalidate - when the sprites change
  * Component for using tiles in a sprite map.
  */
 Crafty.c("Sprite", {
@@ -106,7 +106,7 @@ Crafty.c("Sprite", {
             this.__coord[3] = this.__trim[3] || h * this.__tileh || this.__tileh;
         }
 
-        this.trigger("Change");
+        this.trigger("Invalidate");
         return this;
     },
 
@@ -144,7 +144,7 @@ Crafty.c("Sprite", {
         this._w = w;
         this._h = h;
 
-        this.trigger("Change", old);
+        this.trigger("Invalidate", old);
         return this;
     }
 });

--- a/src/text.js
+++ b/src/text.js
@@ -4,7 +4,7 @@ var Crafty = require('./core.js'),
 /**@
  * #Text
  * @category Graphics
- * @trigger Change - when the text is changed
+ * @trigger Invalidate - when the text is changed
  * @requires Canvas or DOM
  * Component to make a text entity.
  *
@@ -129,7 +129,7 @@ Crafty.c("Text", {
         if (this.has("Canvas") )
             this._resizeForCanvas();
 
-        this.trigger("Change");
+        this.trigger("Invalidate");
         return this;
     },
 
@@ -171,14 +171,14 @@ Crafty.c("Text", {
     textColor: function (color, strength) {
         this._strength = strength;
         this._textColor = Crafty.toRGB(color, this._strength);
-        this.trigger("Change");
+        this.trigger("Invalidate");
         return this;
     },
 
     /**@
      * #.textFont
      * @comp Text
-     * @triggers Change
+     * @triggers Invalidate
      * @sign public this .textFont(String key, * value)
      * @param key - Property of the entity to modify
      * @param value - Value to set the property to
@@ -222,13 +222,13 @@ Crafty.c("Text", {
         if (this.has("Canvas") )
             this._resizeForCanvas();
 
-        this.trigger("Change");
+        this.trigger("Invalidate");
         return this;
     },
     /**@
      * #.unselectable
      * @comp Text
-     * @triggers Change
+     * @triggers Invalidate
      * @sign public this .unselectable()
      *
      * This method sets the text so that it cannot be selected (highlighted) by dragging.
@@ -251,7 +251,7 @@ Crafty.c("Text", {
                 '-ms-user-select': 'none',
                 'user-select': 'none'
             });
-            this.trigger("Change");
+            this.trigger("Invalidate");
         }
         return this;
     }

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -201,7 +201,7 @@ Crafty.extend({
 
             function stopFollow(){
                 if (oldTarget)
-                    oldTarget.unbind('Change', change);
+                    oldTarget.unbind('Move', change);
             }
 
             Crafty.bind("StopCamera", stopFollow);
@@ -215,7 +215,7 @@ Crafty.extend({
                 offx = (typeof offsetx != 'undefined') ? offsetx : 0;
                 offy = (typeof offsety != 'undefined') ? offsety : 0;
 
-                target.bind('Change', change);
+                target.bind('Move', change);
                 change.call(target);
             };
         })(),


### PR DESCRIPTION
Currently we use "Change" to indicate both when an attribute has been changed by `attr`, and to indicate when an entity needs to be redrawn.
This patch switches the name of the latter type of event to "Invalidate".

Since every other instance of "Invalidate" doesn't pass any data, this no longer passes the old coordinates when an entity is invalidated because of a move -- the event "Move" already covers that case.

This fixes #482
