### PR TITLE
Fix shared coord issue

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -236,6 +236,7 @@ Crafty.extend({
             this.requires("2D, Sprite");
             this.__trim = [0, 0, 0, 0];
             this.__image = url;
+            this.__coord = [this.__coord[0], this.__coord[1], this.__coord[2], this.__coord[3]];
             this.__tile = tile;
             this.__tileh = tileh;
             this.__padding = [paddingX, paddingY];


### PR DESCRIPTION
The recent changes (#665) to how "Sprite" entities  are generated accidentally caused them to share a `__coord` array. 

This one-line patch fixes the issue.

I was going to add a testcase for this, but we don't seem to have any "Sprite" tests at all?  We should fix that, but probably no point in waiting on that for this particular PR.  :)
