### PR TITLE
fix bug in Crafty.DOM.translate

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -383,18 +383,20 @@ Crafty.extend({
         /**@
          * #Crafty.DOM.translate
          * @comp Crafty.DOM
-         * @sign public Object Crafty.DOM.translate(Number x, Number y)
-         * @param x - x position to translate
-         * @param y - y position to translate
-         * @return Object with x and y as keys and translated values
-         *
-         * Method will translate x and y positions to positions on the
-         * stage. Useful for mouse events with `e.clientX` and `e.clientY`.
+         * @sign public Object Crafty.DOM.translate(Number clientX, Number clientY)
+         * @param clientX - clientX position in the browser screen
+         * @param clientY - clientY position in the browser screen
+         * @return Object `{x: ..., y: ...}` with Crafty coordinates.
+         * 
+         * The parameters clientX and clientY are pixel coordinates within the visible
+         * browser window. This function translates those to Crafty coordinates (i.e.,
+         * the coordinates that you might apply to an entity), by taking into account
+         * where the stage is within the screen, what the current viewport is, etc.
          */
-        translate: function (x, y) {
+        translate: function (clientX, clientY) {
             return {
-                x: (x - Crafty.stage.x + document.body.scrollLeft + document.documentElement.scrollLeft - Crafty.viewport._x) / Crafty.viewport._scale,
-                y: (y - Crafty.stage.y + document.body.scrollTop + document.documentElement.scrollTop - Crafty.viewport._y) / Crafty.viewport._scale
+                x: (clientX - Crafty.stage.x + document.body.scrollLeft + document.documentElement.scrollLeft) / Crafty.viewport._scale - Crafty.viewport._x,
+                y: (clientY - Crafty.stage.y + document.body.scrollTop + document.documentElement.scrollTop) / Crafty.viewport._scale - Crafty.viewport._y
             };
         }
     }

--- a/tests/stage.js
+++ b/tests/stage.js
@@ -243,6 +243,11 @@ test("DOMtranslate", function() {
   craftyxy = Crafty.DOM.translate(clientX, clientY);
   strictEqual(craftyxy.x, -Crafty.viewport._x + (Crafty.viewport._width / Crafty.viewport._scale));
   strictEqual(craftyxy.y, -Crafty.viewport._y + (Crafty.viewport._height / Crafty.viewport._scale));
+  
+  // clean up
+  Crafty.viewport.scale(1);
+  Crafty.viewport.x = 0;
+  Crafty.viewport.y = 0;
 });
 
 

--- a/tests/stage.js
+++ b/tests/stage.js
@@ -220,6 +220,32 @@ test("centerOn", function() {
   Crafty.viewport.scroll('y', 0);
 });
 
+test("DOMtranslate", function() {
+  var clientX, clientY, craftyxy;
+
+  Crafty.viewport.scale(1.7);
+  Crafty.viewport.x = 38;
+  Crafty.viewport.y = 94;
+  
+  // pretend to click in the top-left corner. This is supposed to be
+  // (x,y) = (-Crafty.viewport._x, -Crafty.viewport._y)
+  clientX = Crafty.stage.x - document.body.scrollLeft - document.documentElement.scrollLeft;
+  clientY = Crafty.stage.y - document.body.scrollTop - document.documentElement.scrollTop;
+  craftyxy = Crafty.DOM.translate(clientX, clientY);
+  strictEqual(craftyxy.x, -Crafty.viewport._x);
+  strictEqual(craftyxy.y, -Crafty.viewport._y);
+  
+  // pretend to click in the bottom-right corner. This is supposed to be
+  // x = -Crafty.viewport._x + Crafty.viewport._width / Crafty.viewport._scale
+  // y = -Crafty.viewport._y + Crafty.viewport._height / Crafty.viewport._scale
+  clientX = Crafty.stage.x + Crafty.stage.elem.clientWidth - document.body.scrollLeft - document.documentElement.scrollLeft;
+  clientY = Crafty.stage.y + Crafty.stage.elem.clientHeight - document.body.scrollTop - document.documentElement.scrollTop;
+  craftyxy = Crafty.DOM.translate(clientX, clientY);
+  strictEqual(craftyxy.x, -Crafty.viewport._x + (Crafty.viewport._width / Crafty.viewport._scale));
+  strictEqual(craftyxy.y, -Crafty.viewport._y + (Crafty.viewport._height / Crafty.viewport._scale));
+});
+
+
 module("Crafty.timer", {
   setup: function() {
     // prepare something for all following tests


### PR DESCRIPTION
Arithmatic error: The translation calculation was incorrect when the viewport scale is not 1 AND the viewport x or y is not 0. I fixed it. (I also improved the documentation.)

Example:

http://jsfiddle.net/B53CY/ -- Before this change

http://jsfiddle.net/B53CY/1/ -- After this change
