### PR TITLE
Create the Crafty model component with core `attr` updates.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "src/math.js",
     "src/time.js",
     "src/DebugLayer.js",
-    "src/keycodes.js"
+    "src/keycodes.js",
+    "src/model.js"
   ],
   "dependencies": {
     "grunt": "~0.4.1",

--- a/src/model.js
+++ b/src/model.js
@@ -1,0 +1,101 @@
+var Crafty = require('./core.js'),
+    document = window.document;
+
+/**@
+ * #Model
+ * @category Model
+ * Model is a component that offers new features for isolating business
+ * logic in your application. It offers default values, dirty values,
+ * and deep events on your data.
+ *
+ * All data should be accessed via the appropriate methods `.get`, `.set`,
+ * and `.data` for the proper events to be triggered. It is not encouraged
+ * to access them directly.
+ *
+ * Dirty values make it simple to inspect a model and see what values have changed.
+ *
+ * Deep events allow you to bind to specific fields, like `name` or even deep fields
+ * like `contact.email` and get notified when those specific fields are updated.
+ *
+ * @trigger Change - When any data on the model has changed.
+ * @trigger Change[key] - When the specific key on the model has changed.
+ * @trigger Change[key.key] - The nested key value has changed.
+ * @example
+ * ~~~
+ * Crafty.c('Person', {
+ *   name: 'Fox',
+ *   init: function() { this.requires('Model'); }
+ * });
+ * person = Crafty.e('Person').attr({name: 'blaine'});
+ * person.bind('Change[name]', function() {
+ *   console.log('name changed!');
+ * });
+ * person.attr('name', 'blainesch'); // Triggers event
+ * person.is_dirty('name'); // true
+ * person.changed // name
+ * ~~~
+ */
+Crafty.c('Model', {
+  init: function() {
+    this.changed = [];
+    this.bind('Change', this._changed_attributes);
+    this.bind('Change', this._changed_triggers);
+  },
+
+  /**
+   * Fires more specific `Change` events.
+   *
+   * For instance a `Change[name]` may get fired when you
+   * update the name data attribute on the model.
+   */
+  _changed_triggers: function(data, options) {
+    var key, trigger_data;
+    options = Crafty.extend.call({pre: ''}, options);
+    for (key in data) {
+      this.trigger('Change[' + options.pre + key + ']', data[key]);
+      if (data[key].constructor.name === 'Object') {
+        this._changed_triggers(data[key], {
+          pre: options.pre + key + '.'
+        });
+      }
+    }
+  },
+
+  /**
+   * Pushes all top-levle changed attribute names to the
+   * changed array.
+   */
+  _changed_attributes: function(data) {
+    var key;
+    for (key in data) {
+      this.changed.push(key);
+    }
+    return this;
+  },
+
+  /**@
+   * #.is_dirty
+   * @comp Model
+   * Helps determine when data or the entire component is "dirty" or has changed attributes.
+   *
+   * @example
+   * ~~~
+   * person = Crafty.e('Person').attr({name: 'Fox', age: 24})
+   * person.is_dirty() // false
+   * person.is_dirty('name') // false
+   *
+   * person.attr('name', 'Lucky');
+   * person.is_dirty(); // true
+   * person.is_dirty('name'); // true
+   * person.is_dirty('age'); // false
+   * person.changed; // ['name']
+   * ~~~
+   */
+  is_dirty: function(key) {
+    if (arguments.length === 0) {
+      return !!this.changed.length;
+    } else {
+      return this.changed.indexOf(key) > -1;
+    }
+  }
+});

--- a/tests/core.js
+++ b/tests/core.js
@@ -489,3 +489,99 @@ test("Crafty.easing", function() {
   e.tick(20);
   equal(e.value(), 1, "Remains 1 after completion");
 });
+
+test('Get', function() {
+  var fox;
+  Crafty.c('Animal', {
+    contact: {
+      email: 'test@example.com',
+      address: {
+        city: 'Portland',
+        state: 'Oregon'
+      }
+    },
+    name: 'Fox'
+  });
+  fox = Crafty.e('Animal, Model');
+
+  equal(fox.attr('contact.address.city'), 'Portland');
+  equal(fox.attr('contact.email'), 'test@example.com');
+  equal(fox.attr('name'), 'Fox');
+});
+
+test('Set', function() {
+  var fox;
+  Crafty.c('Animal', {
+    name: 'Fox'
+  });
+
+  fox = Crafty.e('Animal, Model');
+
+  fox.attr('name', 'Foxxy');
+  equal(fox.attr('name'), 'Foxxy');
+
+  fox.attr('name', 'Slick', {});
+  equal(fox.attr('name'), 'Slick');
+
+  fox.attr({name: 'Lucky'});
+  equal(fox.attr('name'), 'Lucky');
+
+  fox.attr({name: 'Spot'}, {});
+  equal(fox.attr('name'), 'Spot');
+});
+
+test('Set with dot notation', function() {
+  var fox;
+  Crafty.c('Animal', {
+    contact: {
+      email: 'test@example.com',
+      address: {
+        city: 'Portland',
+        state: 'Oregon'
+      }
+    },
+    name: 'Fox'
+  });
+  fox = Crafty.e('Animal, Model');
+
+  fox.attr('contact.address.city', 'Salem');
+
+  deepEqual(fox.attr('contact.address'), {city: 'Salem', state: 'Oregon'});
+});
+
+test('Set Silent', function() {
+  var fox, called;
+  Crafty.c('Animal', {
+    name: 'Fox'
+  });
+
+  fox = Crafty.e('Animal, Model');
+
+  called = false;
+  fox.bind('Change', function() {
+    called = true;
+  });
+
+  fox.attr({name: 'Lucky'}, true);
+  equal(called, false);
+
+  fox.attr({name: 'Spot'}, false);
+  equal(called, true);
+});
+
+test('Set Recursive', function() {
+  var fox;
+  Crafty.c('Animal', {
+    name: 'Fox',
+    contact: {
+      email: 'fox@example.com',
+      phone: '555-555-4545'
+    }
+  });
+
+  fox = Crafty.e('Animal, Model');
+
+  fox.attr({contact: {email: 'foxxy@example.com'}}, false, true);
+
+  deepEqual(fox.attr('contact'), {email: 'foxxy@example.com', phone: '555-555-4545'});
+});

--- a/tests/index.html
+++ b/tests/index.html
@@ -55,6 +55,7 @@
     <script type="text/javascript" src="./text.js"></script>
     <script type="text/javascript" src="./tween.js"></script>
     <script type="text/javascript" src="./storage.js"></script>
-    
+    <script type="text/javascript" src="./model.js"></script>
+
   </body>
 </html>

--- a/tests/model.js
+++ b/tests/model.js
@@ -1,0 +1,64 @@
+module("Model", {
+  setup: function() {},
+  teardown: function() {
+    Crafty("*").destroy();
+  }
+});
+
+test('Set triggers change events', function() {
+  var fox, results = [];
+  Crafty.c('Animal', {
+    name: 'Fox',
+    contact: {
+      email: 'fox@example.com',
+      phone: '555-555-4545'
+    }
+  });
+
+  fox = Crafty.e('Animal, Model');
+
+  fox.bind('Change', function() {
+    results.push('Change');
+  });
+  fox.bind('Change[name]', function() {
+    results.push('Change[name]');
+  });
+  fox.bind('Change[contact.email]', function() {
+    results.push('Change[contact.email]');
+  });
+
+  fox.attr({name: 'Lucky'});
+  fox.attr({contact: {email: 'foxxy@example.com'}}, false, true);
+
+  deepEqual(results, [
+    'Change[name]',
+    'Change',
+    'Change[contact.email]',
+    'Change'
+  ]);
+
+});
+
+test('Dirty', function() {
+  var fox;
+  Crafty.c('Animal', {
+    name: 'Fox',
+    dob: 'March 21',
+    age: 24
+  });
+
+  fox = Crafty.e('Animal, Model');
+
+  equal(fox.is_dirty(), false);
+  equal(fox.is_dirty('name'), false);
+  equal(fox.is_dirty('age'), false);
+
+  fox.attr('name', 'Lucky');
+  fox.attr('dob', 'March 22');
+
+  equal(fox.is_dirty(), true);
+  equal(fox.is_dirty('name'), true);
+  equal(fox.is_dirty('age'), false);
+
+  deepEqual(fox.changed, ['name', 'dob']);
+});


### PR DESCRIPTION
This is an alternative to #693

The main differences are:
- Saves data to the root of the component.
- Triggers `Change[*]` events, compared to `ChangeData` events.
- Updates on `Crafty.attr` to work with recursive setting/getting. BACKWARDS COMPATIBLE! [:
