### PR TITLE
Fix DOM coordinates translation on Chrome 32

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -394,9 +394,12 @@ Crafty.extend({
          * where the stage is within the screen, what the current viewport is, etc.
          */
         translate: function (clientX, clientY) {
+            var doc = document.documentElement;
+            var body = document.body;
+
             return {
-                x: (clientX - Crafty.stage.x + document.body.scrollLeft + document.documentElement.scrollLeft) / Crafty.viewport._scale - Crafty.viewport._x,
-                y: (clientY - Crafty.stage.y + document.body.scrollTop + document.documentElement.scrollTop) / Crafty.viewport._scale - Crafty.viewport._y
+                x: (clientX - Crafty.stage.x + ( doc && doc.scrollLeft || body && body.scrollLeft || 0 )) / Crafty.viewport._scale - Crafty.viewport._x,
+                y: (clientY - Crafty.stage.y + ( doc && doc.scrollTop  || body && body.scrollTop  || 0 )) / Crafty.viewport._scale - Crafty.viewport._y
             };
         }
     }

--- a/tests/dom_translate.html
+++ b/tests/dom_translate.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html class="no-js">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <!-- Note to developers: this test should be run only in real browsers -->
+
+    <!-- DEPENDCIES -->
+    <link rel="stylesheet" href="./lib/qunit.css" type="text/css" media="screen" />
+    <script type="text/javascript" src="./lib/jquery.min.js"></script> 
+    <script type="text/javascript" src="./lib/qunit.js"></script>
+    <script type="text/javascript" src="./lib/modernizr-2.7.1.min.js"></script>
+    <script type="text/javascript" src="./lib/helperFunctions.js"></script>
+  </head>
+
+  <body>
+    <h1 id="qunit-header">Crafty.js Test Suite</h1>
+    <h2 id="qunit-banner"></h2>
+    <div id="qunit-testrunner-toolbar"></div>
+    <h2 id="qunit-userAgent"></h2>
+    <ol id="qunit-tests"></ol>
+    <div id="qunit-fixture">test markup, will be hidden</div>
+
+    <!-- CRAFTY.JS -->
+    <script type="text/javascript" src="../crafty.js"></script>
+    <script type="text/javascript">
+      Crafty.init(500,500);
+    </script>
+
+    <script type="text/javascript" src="./dom_translate.js"></script>    
+  </body>
+</html>

--- a/tests/dom_translate.js
+++ b/tests/dom_translate.js
@@ -1,0 +1,27 @@
+module("DOM", {
+  setup: function() {
+    var div = document.createElement('div');
+    div.style.position = 'absolute';
+    div.style.top = '10000px';
+    div.textContent = 'test';
+    div.id = 'test';
+    document.body.appendChild(div);
+
+    Crafty.stage.x = 10;
+    Crafty.stage.y = 10;
+    Crafty.viewport.scale();
+    Crafty.viewport.x = 0;
+    Crafty.viewport.y = 0;
+
+    (document.documentElement || document.body).scrollTop = 100;
+  },
+  teardown: function() {
+    // clean up after each test
+    Crafty("*").destroy();
+  }
+});
+
+test("translate coordinates", function() {
+  strictEqual(Crafty.DOM.translate(10, 10).x, 0, "translates x from 10 to 0");
+  strictEqual(Crafty.DOM.translate(10, 10).y, 100, "translates y from 10 to 100");
+});


### PR DESCRIPTION
It happened that on the latest Chrome (32.0.1700.77) both
`document.body.scrollTop` and `document.documentElement.scrollTop` were
valorized, this caused a wrong computation of translated position of mouse
pointer with a missing trigger of a `Click` event on a DOM entity.

Note: I setup a separate test page for this test case to be used only with
_real browsers_ as I found really difficult to handle page scrolling with
phantomjs.

More details about it at https://github.com/ariya/phantomjs/issues/10162
and https://github.com/gruntjs/grunt-contrib-qunit/issues/34
