### PR TITLE
Refactor - Gravity, Twoway, DeltaTime based Movement, Attach to moving platforms, Abstract intersect, Crafty.defineField

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -878,6 +878,7 @@ Crafty.fn = Crafty.prototype = {
         return clone;
     },
 
+
     /**@
      * #.setter
      * @comp Crafty Core
@@ -887,16 +888,43 @@ Crafty.fn = Crafty.prototype = {
      * Will watch a property waiting for modification and will then invoke the
      * given callback when attempting to modify.
      *
+     * This feature is deprecated; use .defineField() instead.
+     * @see .defineField
      */
     setter: function (prop, callback) {
-        if (Crafty.support.setter) {
-            this.__defineSetter__(prop, callback);
-        } else if (Crafty.support.defineProperty) {
-            Object.defineProperty(this, prop, {
-                set: callback,
-                configurable: true
-            });
-        }
+        return this.defineField(prop, function(){}, callback);
+    },
+
+    /**@
+     * #.defineField
+     * @comp Crafty Core
+     * @sign public this .defineField(String property, Function getCallback, Function setCallback)
+     * @param property - Property name to assign getter & setter to
+     * @param getCallback - Method to execute if the property is accessed
+     * @param setCallback - Method to execute if the property is mutated
+     *
+     * Assigns getters and setters to the property. 
+     * A getter will watch a property waiting for access and will then invoke the
+     * given getCallback when attempting to retrieve.
+     * A setter will watch a property waiting for mutation and will then invoke the
+     * given setCallback when attempting to modify.
+     *
+     * @example
+     * ~~~
+     * var ent = Crafty.e("2D");
+     * ent.defineField("customData", function() { 
+     *    return this._customData; 
+     * }, function(newValue) { 
+     *    this._customData = newValue;
+     * });
+     *
+     * ent.customData = "2" // set customData to 2
+     * console.log(ent.customData) // prints 2
+     * ~~~
+     * @see Crafty.defineField
+     */
+    defineField: function (prop, getCallback, setCallback) {
+        Crafty.defineField(this, prop, getCallback, setCallback);
         return this;
     },
 
@@ -1744,6 +1772,44 @@ Crafty.extend({
             }
         };
     })(),
+
+    /**@
+     * #Crafty.defineField
+     * @category Core
+     * @sign public void Crafty.defineField(Object object, String property, Function getCallback, Function setCallback)
+     * @param object - Object to define property on
+     * @param property - Property name to assign getter & setter to
+     * @param getCallback - Method to execute if the property is accessed
+     * @param setCallback - Method to execute if the property is mutated
+     *
+     * Assigns getters and setters to the property in the given object.
+     * A getter will watch a property waiting for access and will then invoke the
+     * given getCallback when attempting to retrieve.
+     * A setter will watch a property waiting for mutation and will then invoke the
+     * given setCallback when attempting to modify.
+     *
+     * @example
+     * ~~~
+     * var ent = Crafty.e("2D");
+     * Crafty.defineField(ent, "customData", function() { 
+     *    return this._customData; 
+     * }, function(newValue) { 
+     *    this._customData = newValue;
+     * });
+     *
+     * ent.customData = "2" // set customData to 2
+     * console.log(ent.customData) // prints 2
+     * ~~~
+     * @see .defineField
+     */
+    defineField: function(obj, prop, getCallback, setCallback) {
+        Object.defineProperty(obj, prop, {
+            get: getCallback,
+            set: setCallback,
+            configurable: false,
+            enumerable: true,
+        });
+    },
 
     clone: clone
 });

--- a/src/graphics/canvas-layer.js
+++ b/src/graphics/canvas-layer.js
@@ -146,6 +146,7 @@ Crafty.extend({
                 l = changed.length,
                 dirty = this._dirtyRects,
                 rectManager = Crafty.rectManager,
+                overlap = rectManager.overlap,
                 ctx = this.context,
                 dupes = [],
                 objs = [];
@@ -205,7 +206,7 @@ Crafty.extend({
                 for (j = 0, len = objs.length; j < len; ++j) {
                     obj = objs[j];
                     var area = obj._mbr || obj;
-                    if (rectManager.overlap(area, rect))
+                    if (overlap(area, rect))
                         obj.draw();
                     obj._changed = false;
                 }

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -467,7 +467,7 @@ Crafty.c("2D", {
      * @param w - Width of the rect
      * @param h - Height of the rect
      * @sign public Boolean .intersect(Object rect)
-     * @param rect - An object that must have the `x, y, w, h` values as properties
+     * @param rect - An object that must have the `_x, _y, _w, _h` values as properties
      * Determines if this entity intersects a rectangle.  If the entity is rotated, its MBR is used for the test.
      */
     intersect: function (x, y, w, h) {
@@ -476,15 +476,14 @@ Crafty.c("2D", {
             rect = x;
         } else {
             rect = {
-                x: x,
-                y: y,
-                w: w,
-                h: h
+                _x: x,
+                _y: y,
+                _w: w,
+                _h: h
             };
         }
 
-        return mbr._x < rect.x + rect.w && mbr._x + mbr._w > rect.x &&
-            mbr._y < rect.y + rect.h && mbr._h + mbr._y > rect.y;
+        return Crafty.rectManager.overlap(mbr, rect);
     },
 
     /**@
@@ -1004,12 +1003,8 @@ Crafty.c("Gravity", {
 
         //Increase by 1 to make sure map.search() finds the floor
         pos._y++;
-
-        //map.search wants _x and intersect wants x...
-        pos.x = pos._x;
-        pos.y = pos._y;
-        pos.w = pos._w;
-        pos.h = pos._h;
+        //Decrease width by 1px from left and 1px from right, to fall more gracefully
+        // pos._x++; pos._w--;
 
         q = Crafty.map.search(pos);
         l = q.length;

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -920,20 +920,201 @@ Crafty.c("2D", {
 });
 
 /**@
- * #Gravity
+ * #Supportable
  * @category 2D
- * @trigger Moved - When entity has moved on y-axis a Moved event is triggered with an object specifying the old position {x: old_x, y: old_y}
- * 
- * Adds gravitational pull to the entity.
+ * @trigger LandedOnGround - When entity has landed. This event is triggered with the object the entity landed on.
+ * @trigger LiftedOffGround - When entity has lifted off. This event is triggered with the object the entity stood on before lift-off.
+ * @trigger CheckLanding - When entity is about to land. This event is triggered with the object the entity is about to land on. Third parties can respond to this event and prevent the entity from being able to land.
+ *
+ * Component that detects if the entity collides with the ground. This component is automatically added and managed by the Gravity component.
+ * The appropriate events are fired when the entity state changes (lands on ground / lifts off ground). The current state can also be accessed with .ground().
  */
-Crafty.c("Gravity", {
-    _gravityConst: 0.2,
-    _gy: 0,
-    _falling: true,
-    _anti: null,
+Crafty.c("Supportable", {
+    _ground: false,
+    _groundComp: null,
+
+    /**@
+     * #.canLand
+     * @comp Supportable
+     *
+     * The canLand boolean determines if the entity is allowed to land or not (e.g. perhaps the entity should not land if it's not falling).
+     * The Supportable component will trigger a "CheckLanding" event. 
+     * Interested parties can listen to this event and prevent the entity from landing by setting `canLand` to false.
+     *
+     * @example
+     * ~~~
+     * var player = Crafty.e("2D, Gravity");
+     * player.bind("CheckLanding", function(ground) {
+     *     if (player.isAirplane) // custom behaviour
+     *         player.canLand = false;
+     * });
+     * ~~~
+     */
+    canLand: true,
 
     init: function () {
         this.requires("2D");
+        this.__pos = {_x: 0, _y: 0, _w: 0, _h: 0};
+    },
+    remove: function(destroyed) {
+        this.unbind("EnterFrame", this._detectGroundTick);
+    },
+
+    /*@
+     * #.startGroundDetection
+     * @comp Supportable
+     * @sign private this .startGroundDetection([comp])
+     * @param comp - The name of a component that will be treated as ground
+     *
+     * This method is automatically called by the Gravity component and should not be called by the user.
+     *
+     * Enable ground detection for this entity no matter whether comp parameter is specified or not.
+     * If comp parameter is specified all entities with that component will stop this entity from falling.
+     * For a player entity in a platform game this would be a component that is added to all entities
+     * that the player should be able to walk on.
+     * 
+     * @example
+     * ~~~
+     * Crafty.e("2D, DOM, Color, Gravity")
+     *   .color("red")
+     *   .attr({ w: 100, h: 100 })
+     *   .gravity("platform");
+     * ~~~
+     *
+     * @see Gravity
+     */
+    startGroundDetection: function(ground) {
+        if (ground) this._groundComp = ground;
+        this.uniqueBind("EnterFrame", this._detectGroundTick);
+
+        return this;
+    },
+    /*@
+     * #.stopGroundDetection
+     * @comp Supportable
+     * @sign private this .stopGroundDetection()
+     *
+     * This method is automatically called by the Gravity component and should not be called by the user.
+     *
+     * Disable ground detection for this component. It can be reenabled by calling .startGroundDetection()
+     */
+    stopGroundDetection: function() {
+        this.unbind("EnterFrame", this._detectGroundTick);
+
+        return this;
+    },
+    /**@
+     * #.ground
+     * @comp Supportable
+     * @sign public Object|false .ground()
+     * @return the ground entity if this entity is currently on the ground or false if this entity is not currently on the ground
+     * 
+     * Determine the ground entity and thus whether this entity is currently on the ground or not. 
+     * The information is also available through the events, when the state changes.
+     */
+    ground: function() {
+        return this._ground;
+    },
+    _detectGroundTick: function() {
+        var obj, hit = false,
+            q, i = 0, l;
+
+        var pos = this.__pos;
+            pos._x = this._x;
+            pos._y = this._y + 1; //Increase by 1 to make sure map.search() finds the floor
+            pos._w = this._w;
+            pos._h = this._h;
+        // Decrease width by 1px from left and 1px from right, to fall more gracefully
+        // pos._x++; pos._w--;
+        
+
+        q = Crafty.map.search(pos);
+        l = q.length;
+        for (; i < l; ++i) {
+            obj = q[i];
+            //check for an intersection directly below the player
+            if (obj !== this && obj.has(this._groundComp) && obj.intersect(pos)) {
+                hit = obj;
+                break;
+            }
+        }
+
+
+        if (hit && !this._ground) { // collision with ground was detected for first time
+            this.canLand = true;
+            this.trigger("CheckLanding", hit); // is entity allowed to land?
+            if (this.canLand) {
+                this._ground = hit;
+                this.y = hit._y - this._h; // snap entity to ground object
+                this.trigger("LandedOnGround", this._ground);
+            }
+        } else if (!hit && this._ground) { // no collision with ground was detected for first time
+            var ground = this._ground;
+            this._ground = false;
+            this.trigger("LiftedOffGround", ground);
+        }
+    }
+});
+
+/**@
+ * #GroundAttacher
+ * @category 2D
+ *
+ * Component that attaches the entity to the ground when it lands. Useful for platformers with moving platforms.
+ * Remove the component to disable the functionality.
+ *
+ * @example
+ * ~~~
+ * Crafty.e("2D, Gravity, GroundAttacher")
+ *     .gravity("Platform"); // entity will land on and move with entites that have the "Platform" component
+ * ~~~
+ */
+Crafty.c("GroundAttacher", {
+    _groundAttach: function(ground) {
+        ground.attach(this);
+    },
+    _groundDetach: function(ground) {
+        ground.detach(this);
+    },
+
+    init: function () {
+        this.requires("Supportable");
+
+        this.bind("LandedOnGround", this._groundAttach);
+        this.bind("LiftedOffGround", this._groundDetach);
+    },
+    remove: function(destroyed) {
+        this.unbind("LandedOnGround", this._groundAttach);
+        this.unbind("LiftedOffGround", this._groundDetach);
+    }
+});
+
+
+/**@
+ * #Gravity
+ * @category 2D
+ * @trigger Moved - triggered on movement on either x or y axis. If the entity has moved on both axes for diagonal movement the event is triggered twice - { x:Number, y:Number } - Old position
+ * 
+ * Adds gravitational pull to the entity.
+ *
+ * @see Motion
+ */
+Crafty.c("Gravity", {
+    init: function () {
+        this.requires("2D, Supportable, Motion");
+        this._gravityConst = this.__convertPixelsToMeters(9.81);
+
+        this.bind("LiftedOffGround", this._startGravity); // start gravity if we are off ground
+        this.bind("LandedOnGround", this._stopGravity); // stop gravity once landed
+    },
+    remove: function(removed) {
+        this.unbind("LiftedOffGround", this._startGravity);
+        this.unbind("LandedOnGround", this._stopGravity);
+    },
+
+    _gravityCheckLanding: function(ground) {
+        if (this._dy < 0)
+            this.canLand = false;
     },
 
     /**@
@@ -946,6 +1127,7 @@ Crafty.c("Gravity", {
      * If comp parameter is specified all entities with that component will stop this entity from falling.
      * For a player entity in a platform game this would be a component that is added to all entities
      * that the player should be able to walk on.
+     * See the Supportable component documentation for additional methods & events that are available.
      *
      * @example
      * ~~~
@@ -954,12 +1136,25 @@ Crafty.c("Gravity", {
      *   .attr({ w: 100, h: 100 })
      *   .gravity("platform");
      * ~~~
+     * @see Supportable
      */
     gravity: function (comp) {
-        if (comp) this._anti = comp;
-        if(isNaN(this._jumpSpeed)) this._jumpSpeed = 0; //set to 0 if Twoway component is not present
+        this.bind("CheckLanding", this._gravityCheckLanding);
+        this.startGroundDetection(comp);
+        this._startGravity();
 
-        this.bind("EnterFrame", this._enterFrame);
+        return this;
+    },
+    /**@
+     * #.antigravity
+     * @comp Gravity
+     * @sign public this .antigravity()
+     * Disable gravity for this component. It can be reenabled by calling .gravity()
+     */
+    antigravity: function () {
+        this._stopGravity();
+        this.stopGroundDetection();
+        this.unbind("CheckLanding", this._gravityCheckLanding);
 
         return this;
     },
@@ -970,80 +1165,33 @@ Crafty.c("Gravity", {
      * @sign public this .gravityConst(g)
      * @param g - gravitational constant
      *
-     * Set the gravitational constant to g. The default is .2. The greater g, the faster the object falls.
+     * Set the gravitational constant to g. The default is 9.81 . The greater g, the faster the object falls.
      *
      * @example
      * ~~~
      * Crafty.e("2D, DOM, Color, Gravity")
      *   .color("red")
      *   .attr({ w: 100, h: 100 })
-     *   .gravity("platform")
-     *   .gravityConst(2)
+     *   .gravityConst(5)
+     *   .gravity("platform");
      * ~~~
      */
     gravityConst: function (g) {
-        this._gravityConst = g;
+        var newGravityConst = this.__convertPixelsToMeters(g);
+        if (!this.ground()) { // gravity active, change acceleration
+            this.ay -= this._gravityConst;
+            this.ay += newGravityConst;
+        }
+        this._gravityConst = newGravityConst;
+
         return this;
     },
-
-    _enterFrame: function () {
-        if (this._falling) {
-            //if falling, move the players Y
-            this._gy += this._gravityConst;
-            this.y += this._gy;
-            this.trigger('Moved', { x: this._x, y: this._y - this._gy });
-        } else {
-            this._gy = 0; //reset change in y
-        }
-
-        var obj, hit = false,
-            pos = this.pos(),
-            q, i = 0,
-            l;
-
-        //Increase by 1 to make sure map.search() finds the floor
-        pos._y++;
-        //Decrease width by 1px from left and 1px from right, to fall more gracefully
-        // pos._x++; pos._w--;
-
-        q = Crafty.map.search(pos);
-        l = q.length;
-
-        for (; i < l; ++i) {
-            obj = q[i];
-            //check for an intersection directly below the player
-            if (obj !== this && obj.has(this._anti) && obj.intersect(pos)) {
-                hit = obj;
-                break;
-            }
-        }
-
-        if (hit) { //stop falling if found and player is moving down
-            if (this._falling && ((this._gy > this._jumpSpeed) || !this._up)){
-              this.stopFalling(hit);
-            }
-        } else {
-            this._falling = true; //keep falling otherwise
-        }
+    _startGravity: function() {
+        this.ay += this._gravityConst;
     },
-
-    stopFalling: function (e) {
-        if (e) this.y = e._y - this._h; //move object
-
-        //this._gy = -1 * this._bounce;
-        this._falling = false;
-        if (this._up) this._up = false;
-        this.trigger("hit");
-    },
-
-    /**@
-     * #.antigravity
-     * @comp Gravity
-     * @sign public this .antigravity()
-     * Disable gravity for this component. It can be reenabled by calling .gravity()
-     */
-    antigravity: function () {
-        this.unbind("EnterFrame", this._enterFrame);
+    _stopGravity: function() {
+        this.ay = 0;
+        this.vy = 0;
     }
 });
 
@@ -1215,6 +1363,13 @@ Crafty.c("AngularMotion", {
  * Component that allows moving an entity by applying linear velocity and acceleration.
  */
 Crafty.c("Motion", {
+    /*
+     * Utility function which converts the input argument `pixels` into `meters`.
+     */
+    __convertPixelsToMeters: function(pixels) {
+        return pixels * 100;
+    },
+
     /**@
      * #.vx
      * @comp Motion

--- a/src/spatial/collision.js
+++ b/src/spatial/collision.js
@@ -265,6 +265,7 @@ Crafty.c("Collision", {
             l = results.length,
             dupes = {},
             id, obj, oarea, key,
+            overlap = Crafty.rectManager.overlap,
             hasMap = ('map' in this && 'containsPoint' in this.map),
             finalresult = [];
 
@@ -280,9 +281,7 @@ Crafty.c("Collision", {
             id = obj[0];
 
             //check if not added to hash and that actually intersects
-            if (!dupes[id] && this[0] !== id && obj.__c[comp] &&
-                oarea._x < area._x + area._w && oarea._x + oarea._w > area._x &&
-                oarea._y < area._y + area._h && oarea._h + oarea._y > area._y)
+            if (!dupes[id] && this[0] !== id && obj.__c[comp] && overlap(oarea, area))
                 dupes[id] = obj;
         }
 

--- a/src/spatial/rect-manager.js
+++ b/src/spatial/rect-manager.js
@@ -27,12 +27,20 @@ Crafty.extend({
            return target;
        },
 
-
-
-       /** Checks whether two rectangles overlap */
-       overlap: function (a, b) {
-           return (a._x < b._x + b._w && a._y < b._y + b._h && a._x + a._w > b._x && a._y + a._h > b._y);
-       },
+      /**@
+       * #Crafty.rectManager.overlap
+       * @comp Crafty.rectManager
+       * @sign public Boolean Crafty.rectManager.overlap(Object rectA, Object rectA)
+       * @param rectA - An object that must have the `_x, _y, _w, _h` values as properties
+       * @param rectB - An object that must have the `_x, _y, _w, _h` values as properties
+       * @return true if the rectangles overlap; false otherwise
+       *
+       * Checks whether two rectangles overlap.
+       */
+      overlap: function (rectA, rectB) {
+        return (rectA._x < rectB._x + rectB._w && rectA._x + rectA._w > rectB._x &&
+                rectA._y < rectB._y + rectB._h && rectA._h + rectA._y > rectB._y);
+      },
 
       /**@
       * #Crafty.rectManager.mergeSet

--- a/src/spatial/spatial-grid.js
+++ b/src/spatial/spatial-grid.js
@@ -75,6 +75,7 @@ var Crafty = require('../core/core.js'),
         search: function (rect, filter) {
             var keys = HashMap.key(rect, keyHolder),
                 i, j, k, l, cell,
+                overlap = Crafty.rectManager.overlap,
                 results = [];
 
             if (filter === undefined) filter = true; //default filter to true
@@ -101,8 +102,7 @@ var Crafty = require('../core/core.js'),
                     id = obj[0]; //unique ID
                     obj = obj._mbr || obj;
                     //check if not added to hash and that actually intersects
-                    if (!found[id] && obj._x < rect._x + rect._w && obj._x + obj._w > rect._x &&
-                        obj._y < rect._y + rect._h && obj._h + obj._y > rect._y)
+                    if (!found[id] && overlap(obj, rect))
                         found[id] = results[i];
                 }
 

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -46,10 +46,10 @@
     strictEqual(player.intersect(0, 0, 100, 50), true, "Intersected");
 
     strictEqual(player.intersect({
-      x: 0,
-      y: 0,
-      w: 100,
-      h: 50
+      _x: 0,
+      _y: 0,
+      _w: 100,
+      _h: 50
     }), true, "Intersected Again");
 
     strictEqual(player.intersect(100, 100, 100, 50), false, "Didn't intersect");

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -493,4 +493,98 @@
     ok(e._cbr === null, "_cbr should now be removed along with Collision");
 
   });
+
+  test("Motion", function() {
+    var Vector2D = Crafty.math.Vector2D;
+    var zero = new Vector2D();
+    var ent = Crafty.e("2D, Motion, AngularMotion")
+      .attr({x: 0, y:0});
+
+    ok(ent.velocity().equals(zero), "linear velocity should be zero");
+    strictEqual(ent.vrotation, 0, "angular velocity should be zero");
+    ok(ent.acceleration().equals(zero), "linear acceleration should be zero");
+    strictEqual(ent.arotation, 0, "angular acceleration should be zero");
+    ok(ent.motionDelta().equals(zero), "linear delta should be zero");
+    strictEqual(ent.drotation, 0, "angular delta should be zero");
+
+    ent.motionDelta().x = 20;
+    ok(ent.motionDelta().equals(zero), "linear delta should not have changed");
+    ent.drotation = 10;
+    strictEqual(ent.drotation, 0, "angular delta should not have changed");
+
+
+    var v0 = new Vector2D(2,5); var v0_r = 10;
+    ent.velocity().setValues(v0);
+    ent.vrotation = v0_r;
+    ok(ent.velocity().equals(v0), "linear velocity should be <2,5>");
+    strictEqual(ent.vrotation, v0_r, "angular velocity should be 10");
+
+    var a = new Vector2D(4,2); var a_r = -15;
+    ent.acceleration().setValues(a);
+    ent.arotation = a_r;
+    ok(ent.acceleration().equals(a), "linear acceleration should be <4,2>");
+    strictEqual(ent.arotation, a_r, "angular acceleration should be -15");
+
+    ent.velocity().x += 1;
+    ent.velocity().y *= 2;
+    ent.velocity().y -= 1;
+    ok(ent.velocity().equals(new Vector2D(v0.x+1, v0.y*2-1)), "linear velocity should be <3,9>");
+    ent.arotation += 5;
+    strictEqual(ent.arotation, a_r + 5, "angular acceleration should be -10");
+
+
+    ent.resetMotion();
+    ent.resetAngularMotion();
+    ok(ent.velocity().equals(zero), "linear velocity should be zero");
+    strictEqual(ent.vrotation, 0, "angular velocity should be zero");
+    ok(ent.acceleration().equals(zero), "linear acceleration should be zero");
+    strictEqual(ent.arotation, 0, "angular acceleration should be zero");
+    ok(ent.motionDelta().equals(zero), "linear delta should be zero");
+    strictEqual(ent.drotation, 0, "angular delta should be zero");
+
+
+
+
+    ent.velocity().setValues(v0);
+    ent.vrotation = v0_r;
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    ok(ent.velocity().equals(v0), "velocity should be <2,5>");
+    strictEqual(ent.vrotation, v0_r, "angular velocity should be 10");
+    ok(ent.motionDelta().equals(v0), "delta should be <2,5>");
+    strictEqual(ent.drotation, v0_r, "angular delta should be 10");
+    equal(ent.x, v0.x, "entity x should be 2");
+    equal(ent.y, v0.y, "entity y should be 5");
+    equal(ent.rotation, v0_r, "entity rotation should be 10");
+
+    var dPos = new Vector2D(a).scale(0.5).add(v0), dPos_r = v0_r + 0.5*a_r;
+    ent.acceleration().setValues(a);
+    ent.arotation = a_r;
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    ok(dPos.equals(new Vector2D(4,6)), "should be <4,6>");
+    strictEqual(dPos_r, 2.5, "should be 2.5");
+    ok(ent.motionDelta().equals(dPos), "delta should be <4,6>");
+    strictEqual(ent.drotation, dPos_r, "should be 2.5");
+    equal(ent.x, v0.x + dPos.x, "entity x should be 6");
+    equal(ent.y, v0.y + dPos.y, "entity y should be 11");
+    equal(ent.rotation, v0_r + dPos_r, "entity rotation should be 12.5");
+    var v1 = new Vector2D(v0).add(a), v1_r = v0_r + a_r;
+    ok(ent.velocity().equals(v1), "linear velocity should be <6,7>");
+    strictEqual(ent.vrotation, v1_r, "angular velocity should be -5");
+
+
+
+    ent.attr({x: 0, y: 0})
+       .resetMotion()
+       .resetAngularMotion();
+
+    ent.velocity().x = 10;
+    ent.acceleration().x = 5;
+    Crafty.trigger('EnterFrame', {dt: 500});
+    equal(ent.velocity().x, 10+5*0.5, "velocity x should be 12.5");
+    equal(ent.x, 10*0.5+0.5*5*0.5*0.5, "entity x should be 5.625");
+
+    ent.destroy();
+  });
+
 })();
+

--- a/tests/core.js
+++ b/tests/core.js
@@ -88,28 +88,49 @@
 
   });
 
-  test("setter", function() {
+  test("defineField", function() {
     if (!(Crafty.support.setter || Crafty.support.defineProperty)) {
       // IE8 has a setter() function but it behaves differently. No test is currently written for IE8.
       expect(0);
       return;
     }
+
     var first = Crafty.e("test");
-    first.setter('p1', function(v) {
+
+
+    first.setter('p0', function(v) {
+      this._p0 = v * 5;
+    });
+    first.p0 = 2;
+    strictEqual(first._p0, 10, "single property setter");
+    strictEqual(first.p0, undefined, "single property getter");
+
+
+    first.defineField('p1', function() {
+      return this._p1;
+    }, function(v) {
       this._p1 = v * 2;
     });
     first.p1 = 2;
-    strictEqual(first._p1, 4, "single property setter");
+    strictEqual(first.p1, 4, "single property getter & setter");
 
-    first.setter('p2', function(v) {
+    first.defineField('p2', function() {
+      return this._p2;
+    }, function(v) {
       this._p2 = v * 2;
-    }).setter('p3', function(v) {
+    }).defineField('p3', function() {
+      return this._p3;
+    }, function(v) {
       this._p3 = v * 2;
     });
     first.p2 = 2;
     first.p3 = 3;
-    strictEqual(first._p2 + first._p3, 10, "two property setters");
+    strictEqual(first.p2 + first.p3, 10, "two property getters & setters");
 
+    if (Crafty.support.defineProperty) {
+      delete first.p1;
+      strictEqual(first.p1, 4, "property survived deletion");
+    }
   });
 
   test("bind", function() {
@@ -635,7 +656,6 @@
 
     deepEqual(fox.attr('contact'), {email: 'foxxy@example.com', phone: '555-555-4545'});
   });
-
 
   module("Timer");
 


### PR DESCRIPTION
## Current state
- [x] **Motion** #649 
- [x] **GroundDetector**
- [x] **GroundAttacher** #601 
- [x] **Abstract intersect**
- [x] **Crafty.defineField**

next PR will have:
- [x] **MultiWay** should use Motion for movement, see #876 
- [ ] **Motion.js**: move Multiway, Fourway, Twoway, Gravity into new src file
## Motivation

In my opinion, the sharing and modification of 3-4 properties between Twoway and Gravity was **hard to read & maintain** and did not allow for easy **extendability**. Future components that would like to use velocities & acceleration just have to `require("Motion")` and apply the motion through it's methods.
## Changes

I introduced a new component called **GroundDetector** which does what Gravity did before: It registers if the entity lands on the ground for the first time or if the entity lifts off from the ground for the first time. GroundDetector also snaps the entity to the ground upon landing. 
Gravity manages start/stop of GroundDetector and specifies the function which GroundDetector calls to check if the entity is allowed to land (e.g. currently entity must be falling to be able to land). The functionality was split from Gravity so that the to be implemented component **GroundAttacher** (#601) can also listen for these events.

The next component is called **Motion**. Both Gravity and Twoway use that component to add acceleration (gravity constant) or to add velocity (jump speed) in the y direction. "Motion" has a method `linearDelta()` which returns the relative change that was introduced by all linear motion. The relative change in the y direction is used in order to determine if the entity is falling or rising (jumping) - this function is called in GroundDetector each time the entity wants to land. "Motion" also allows **deltaTime** based movement of entities as described in #649.

A [recent forum post](https://groups.google.com/forum/#!topic/craftyjs/RDXk4ci9-Sk) indicates that users want to configure the ability to jump/land to their preferences. I added two methods `Crafty.e("GroundDetector").canLand()` and `Crafty.e("Twoway").canJump()`. Users can override the default behaviour of these two methods to their liking.

The common intersect check (that was being manually duplicated all over the library) was extracted into the global method `Crafty.intersect(rectA, rectB)`. `Crafty.e("2D").intersect()` was streamlined to operate on `_x, _y, _w, _h` properties rather than `x, y, w, h` - this is the default for similar methods (`isAt`, `contains`, ...). Is there a specific reason it deviated from the rest?

`Crafty.defineField` and `Crafty.e.defineField` were added. `Crafty.e.setter` was adapted to use these two methods. They add a get callback and disable configuration (= deletion & reconfiguration) of the property.
## Backwards Compatibility
- As `Crafty.e("2D").intersect()` was changed to operate on _x, _y, _w, _h. User code may break if it called intersect.

Any input would be greatly appreciated! I'm still vague about the component names. Do you have any ideas?
