### PR TITLE
Process main docblock separately from trigger block to work around bug

### DIFF
--- a/build/api-gen.coffee
+++ b/build/api-gen.coffee
@@ -126,7 +126,7 @@ class DocBlock
     # Method for returning the documentation for this block
     getContent: ()->
         if @isFunctionTag(@prevTag) then @code.push("</dl>")
-        return @code.join("\n") + triggerBlock(@triggers) + seeBlock(@see)
+        return marked(@code.join("\n")) + triggerBlock(@triggers) + seeBlock(@see)
 
 # parse js file
 parseJS = (path) ->


### PR DESCRIPTION
This fixes an issue where the doc generator wasn't parsing fenced codeblocks correctly in some cases.

It seems like it might have been caused by something sitting in the event trigger blocks -- this works around the issue by just processing the blocks separately. 

This is a pretty shallow fix, but we can figure out the real issue after the 0.6.2 release.
