### PR TITLE
Throw an error if duplicate component function name

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1313,7 +1313,23 @@ Crafty.extend({
      *
      * @see Crafty.e
      */
+    commonComponentFunctions: ['init', 'draw', 'remove', 'matchHitBox'],
+    componentFunctions: [],
     c: function (compName, component) {
+
+        for(var key in component){
+
+            if(typeof component[key] == "function"){
+                // If the function has not been in a component before, add it
+                if(this.componentFunctions.indexOf(key) === -1){
+                    this.componentFunctions.push(key);
+                } else if(this.commonComponentFunctions.indexOf(key) !== -1){
+                    // If the function name is a common name like init, do not throw an exception
+                } else {
+                    throw('Function already defined in another component: ' + key);
+                }
+            }
+        }
         components[compName] = component;
     },
 

--- a/src/core.js
+++ b/src/core.js
@@ -1313,17 +1313,17 @@ Crafty.extend({
      *
      * @see Crafty.e
      */
-    commonComponentFunctions: ['init', 'draw', 'remove', 'matchHitBox'],
-    componentFunctions: [],
+    _commonComponentFunctions: ['init', 'draw', 'remove', 'matchHitBox'],
+    _componentFunctions: [],
     c: function (compName, component) {
 
         for(var key in component){
 
             if(typeof component[key] == "function"){
                 // If the function has not been in a component before, add it
-                if(this.componentFunctions.indexOf(key) === -1){
-                    this.componentFunctions.push(key);
-                } else if(this.commonComponentFunctions.indexOf(key) !== -1){
+                if(this._componentFunctions.indexOf(key) === -1){
+                    this._componentFunctions.push(key);
+                } else if(this._commonComponentFunctions.indexOf(key) !== -1){
                     // If the function name is a common name like init, do not throw an exception
                 } else {
                     throw('Function already defined in another component: ' + key);

--- a/tests/core.js
+++ b/tests/core.js
@@ -276,6 +276,22 @@ test("requires", function() {
 
 });
 
+test("extend", function() {
+
+  try {
+    Crafty.c('TestComp', {
+      move: function() {
+        // Duplicate move function from 2D component
+      }
+    });
+  } catch(e) {
+    // console.log(e);
+    ok(e, 'Duplicate move function gave an error');
+  }
+
+
+});
+
 test("destroy", function() {
   var first = Crafty.e("test"),
     id = first[0]; //id


### PR DESCRIPTION
This pullrequest tried to solve the problem when you accidently make a function with the same name as another component already defined.

If you do define a component with a for an example move function and then add the 2D component to your entity, depending on the order of the components added, you would get weird error depending on what is in the move function, which does not look like your move function. This is not userfriendly.

It should not be possible to overwrite other component functions in a entity.

This is not the solution, as this prevents any two components of having the same object function name. This would make it more errorsafe, but would also force you to come up with new names, eventhrough the components would newer be used together, like a component for a hero and a enemy.
I also tried modifing the `Crafty.fn.extend`, but that made it complex as that function is used to extend the Crafty global namespace and not just the local entity.
I then tried checking every time if the entity had a `.getId` key in the object

Another solution would be to create a extend function only to extend entities with components. This way the normal `Crafty.fn.extend` would stay simple, and we would use a `Crafty.fn.extendEntity` function.

There is a couple of things to keep in mind when solving this problem:
- The init function has to ignored. It gets overwritten multiple times, but only used once every time.
- It should only be functions, as x, y, w, h and suchs variables get declared multiple times in initialization.

What does you others think?
