### PR TITLE
Update dependencies - removed tilde to ensure same version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,17 +63,16 @@
     "src/keycodes.js"
   ],
   "dependencies": {
-    "grunt": "~0.4.1",
-    "grunt-contrib-uglify": "0.2.0",
-    "grunt-contrib-concat": "0.3.0",
-    "grunt-contrib-jshint": "0.5.2",
-    "grunt-contrib-qunit": "0.2.1",
-    "grunt-jsvalidate": "0.2.1",
-    "marked": "0.2.9",
-    "coffee-script": "1.6.3",
-    "grunt-browserify": "~1.2.9",
-    "grunt-banner": "~0.2.0",
-    "grunt-contrib-watch": "~0.5.3"
+    "grunt": "0.4.1",
+    "grunt-contrib-uglify": "0.3.2",
+    "grunt-contrib-qunit": "0.4.0",
+    "grunt-jsvalidate": "0.2.2",
+    "marked": "0.3.1",
+    "coffee-script": "1.7.1",
+    "grunt-browserify": "1.3.0",
+    "grunt-banner": "0.2.0",
+    "grunt-contrib-watch": "0.5.3",
+    "grunt-contrib-jshint": "0.8.0"
   },
   "devDependencies": {
     "grunt-contrib-connect": "~0.6.0"

--- a/src/core.js
+++ b/src/core.js
@@ -46,7 +46,7 @@ var Crafty = function (selector) {
 
 
     initState = function () {
-        GUID = 1, //GUID for entity IDs
+        GUID = 1; //GUID for entity IDs
         frame = 0;
 
         components = {}; //map of components and their functions


### PR DESCRIPTION
Updated dependencies since both the qunit now use a two newer version of PhantomJs.

I did check all the changelog and nothing breaking seem introduced in any of them.

Also removed tilde to ensure same version at all contributers.

The new version of JsHint also found a new bug, which properly make this PR look broken.
