### PR TITLE
Round translation in canvas setTransform

### DIFF
--- a/src/drawing.js
+++ b/src/drawing.js
@@ -517,7 +517,7 @@ Crafty.DrawManager = (function () {
 
             if (dirtyViewport) {
                 var view = Crafty.viewport;
-                ctx.setTransform(view._scale, 0, 0, view._scale, view._x*view._scale, view._y*view._scale);
+                ctx.setTransform(view._scale, 0, 0, view._scale, Math.round(view._x*view._scale), Math.round(view._y*view._scale) );
 
             }
             //if the amount of changed objects is over 60% of the total objects


### PR DESCRIPTION
The translation in setTransform should be rounded to the nearest pixel, since canvas implementations deal with fractional coordinates inconsistently.

This helps out #711, but zoomed canvases will still have these types of artifacts.

_e:_ I guess I should note that this doesn't actually round the pixels, but I think all we care about is that they're integral.
