### PR TITLE
Switch to defineProperty; set enumerable flags to be consistent with private/public properties

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -195,8 +195,11 @@ Crafty.c("2D", {
             get: function () {
                 return this._x;
             },
-            configurable: true
+            configurable: true,
+            enumerable: true
         });
+
+        Object.defineProperty(this, '_x', {enumerable:false});
 
         Object.defineProperty(this, 'y', {
             set: function (v) {
@@ -205,8 +208,10 @@ Crafty.c("2D", {
             get: function () {
                 return this._y;
             },
-            configurable: true
+            configurable: true,
+            enumerable: true
         });
+        Object.defineProperty(this, '_y', {enumerable:false});
 
         Object.defineProperty(this, 'w', {
             set: function (v) {
@@ -215,8 +220,10 @@ Crafty.c("2D", {
             get: function () {
                 return this._w;
             },
-            configurable: true
+            configurable: true,
+            enumerable: true
         });
+        Object.defineProperty(this, '_w', {enumerable:false});
 
         Object.defineProperty(this, 'h', {
             set: function (v) {
@@ -225,8 +232,10 @@ Crafty.c("2D", {
             get: function () {
                 return this._h;
             },
-            configurable: true
+            configurable: true,
+            enumerable: true
         });
+        Object.defineProperty(this, '_h', {enumerable:false});
 
         Object.defineProperty(this, 'z', {
             set: function (v) {
@@ -235,8 +244,10 @@ Crafty.c("2D", {
             get: function () {
                 return this._z;
             },
-            configurable: true
+            configurable: true,
+            enumerable: true
         });
+        Object.defineProperty(this, '_z', {enumerable:false});
 
         Object.defineProperty(this, 'rotation', {
             set: function (v) {
@@ -245,8 +256,10 @@ Crafty.c("2D", {
             get: function () {
                 return this._rotation;
             },
-            configurable: true
+            configurable: true,
+            enumerable: true
         });
+        Object.defineProperty(this, '_rotation', {enumerable:false});
 
         Object.defineProperty(this, 'alpha', {
             set: function (v) {
@@ -255,8 +268,10 @@ Crafty.c("2D", {
             get: function () {
                 return this._alpha;
             },
-            configurable: true
+            configurable: true,
+            enumerable: true
         });
+        Object.defineProperty(this, '_alpha', {enumerable:false});
 
         Object.defineProperty(this, 'visible', {
             set: function (v) {
@@ -265,8 +280,10 @@ Crafty.c("2D", {
             get: function () {
                 return this._visible;
             },
-            configurable: true
+            configurable: true,
+            enumerable: true
         });
+        Object.defineProperty(this, '_visible', {enumerable:false});
     },
 
     init: function () {

--- a/src/2D.js
+++ b/src/2D.js
@@ -185,66 +185,9 @@ Crafty.c("2D", {
     _parent: null,
     _changed: false,
 
-    _defineGetterSetter_setter: function () {
-        //create getters and setters using __defineSetter__ and __defineGetter__
-        this.__defineSetter__('x', function (v) {
-            this._attr('_x', v);
-        });
-        this.__defineSetter__('y', function (v) {
-            this._attr('_y', v);
-        });
-        this.__defineSetter__('w', function (v) {
-            this._attr('_w', v);
-        });
-        this.__defineSetter__('h', function (v) {
-            this._attr('_h', v);
-        });
-        this.__defineSetter__('z', function (v) {
-            this._attr('_z', v);
-        });
-        this.__defineSetter__('rotation', function (v) {
-            this._attr('_rotation', v);
-        });
-        this.__defineSetter__('alpha', function (v) {
-            this._attr('_alpha', v);
-        });
-        this.__defineSetter__('visible', function (v) {
-            this._attr('_visible', v);
-        });
+    
 
-        this.__defineGetter__('x', function () {
-            return this._x;
-        });
-        this.__defineGetter__('y', function () {
-            return this._y;
-        });
-        this.__defineGetter__('w', function () {
-            return this._w;
-        });
-        this.__defineGetter__('h', function () {
-            return this._h;
-        });
-        this.__defineGetter__('z', function () {
-            return this._z;
-        });
-        this.__defineGetter__('rotation', function () {
-            return this._rotation;
-        });
-        this.__defineGetter__('alpha', function () {
-            return this._alpha;
-        });
-        this.__defineGetter__('visible', function () {
-            return this._visible;
-        });
-        this.__defineGetter__('parent', function () {
-            return this._parent;
-        });
-        this.__defineGetter__('numChildren', function () {
-            return this._children.length;
-        });
-    },
-
-    _defineGetterSetter_defineProperty: function () {
+    _define2DProperties: function () {
         Object.defineProperty(this, 'x', {
             set: function (v) {
                 this._attr('_x', v);
@@ -341,12 +284,10 @@ Crafty.c("2D", {
 
         this._children = [];
 
-        if (Crafty.support.setter) {
-            this._defineGetterSetter_setter();
-        } else if (Crafty.support.defineProperty) {
-            //IE9 supports Object.defineProperty
-            this._defineGetterSetter_defineProperty();
-        }
+        
+   
+        this._define2DProperties();
+        
 
         //insert self into the HashMap
         this._entry = Crafty.map.insert(this);

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -33,13 +33,6 @@ var Crafty = require('./core.js'),
     if (mobile) Crafty.mobile = mobile[0];
 
     /**@
-     * #Crafty.support.setter
-     * @comp Crafty.support
-     * Is `__defineSetter__` supported?
-     */
-    support.setter = ('__defineSetter__' in this && '__defineGetter__' in this);
-
-    /**@
      * #Crafty.support.defineProperty
      * @comp Crafty.support
      * Is `Object.defineProperty` supported?

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -635,78 +635,44 @@ Crafty.extend({
 
         // Create setters/getters for x, y, width, height
         _defineViewportProperties: function(){
-            if (Crafty.support.setter) {
-                //define getters and setters to scroll the viewport
-                this.__defineSetter__('x', function (v) {
+            Object.defineProperty(this, 'x', {
+                set: function (v) {
                     this.scroll('_x', v);
-                });
-                this.__defineSetter__('y', function (v) {
+                },
+                get: function () {
+                    return this._x;
+                },
+                configurable : true
+            });
+            Object.defineProperty(this, 'y', {
+                set: function (v) {
                     this.scroll('_y', v);
-                });
-                this.__defineSetter__('width', function (v) {
+                },
+                get: function () {
+                    return this._y;
+                },
+                configurable : true
+            });
+            Object.defineProperty(this, 'width', {
+                set: function (v) {
                     this._width = v;
                     Crafty.trigger("ViewportResize");
-                });
-                this.__defineSetter__('height', function (v) {
+                },
+                get: function () {
+                    return this._width;
+                },
+                configurable : true
+            });
+            Object.defineProperty(this, 'height', {
+                set: function (v) {
                     this._height = v;
                     Crafty.trigger("ViewportResize");
-                });
-                this.__defineGetter__('x', function () {
-                    return this._x;
-                });
-                this.__defineGetter__('y', function () {
-                    return this._y;
-                });
-                this.__defineGetter__('width', function () {
-                    return this._width;
-                });
-                this.__defineGetter__('height', function () {
+                },
+                get: function () {
                     return this._height;
-                });
-
-
-
-                //IE9
-            } else if (Crafty.support.defineProperty) {
-                Object.defineProperty(this, 'x', {
-                    set: function (v) {
-                        this.scroll('_x', v);
-                    },
-                    get: function () {
-                        return this._x;
-                    },
-                    configurable : true
-                });
-                Object.defineProperty(this, 'y', {
-                    set: function (v) {
-                        this.scroll('_y', v);
-                    },
-                    get: function () {
-                        return this._y;
-                    },
-                    configurable : true
-                });
-                Object.defineProperty(this, 'width', {
-                    set: function (v) {
-                        this._width = v;
-                        Crafty.trigger("ViewportResize");
-                    },
-                    get: function () {
-                        return this._width;
-                    },
-                    configurable : true
-                });
-                Object.defineProperty(this, 'height', {
-                    set: function (v) {
-                        this._height = v;
-                        Crafty.trigger("ViewportResize");
-                    },
-                    get: function () {
-                        return this._height;
-                    },
-                    configurable : true
-                });
-            }
+                },
+                configurable : true
+            });
         },
 
         /**@


### PR DESCRIPTION
__defineGetter and company are deprecated; this switches completely to defineProperty, and uses the enumerable flag to fix #722.

I've tested in Firefox, Chrome, and Safari.  It still needs testing in IE and mobile browsers.
