### PR TITLE
if no color is assigned, the Color component should do nothing whatsoever

### DIFF
--- a/src/drawing.js
+++ b/src/drawing.js
@@ -12,11 +12,12 @@ Crafty.c("Color", {
 
     init: function () {
         this.bind("Draw", function (e) {
+            if (!this._color) { return; }
             if (e.type === "DOM") {
                 e.style.backgroundColor = this._color;
                 e.style.lineHeight = 0;
             } else if (e.type === "canvas") {
-                if (this._color) e.ctx.fillStyle = this._color;
+                e.ctx.fillStyle = this._color;
                 e.ctx.fillRect(e.pos._x, e.pos._y, e.pos._w, e.pos._h);
             }
         });


### PR DESCRIPTION
Before this change, in canvas mode, it still does the fillRect command but without specifying a fillStyle. So it fills the rectangle with whatever random color was last used.
