### PR TITLE
Pause *before* firing "AnimationEnd"

### DIFF
--- a/src/sprite-animation.js
+++ b/src/sprite-animation.js
@@ -396,8 +396,8 @@ Crafty.c("SpriteAnimation", {
 		this._setFrame(frameNumber);
 
 		if(currentReel.easing.complete === true){
-			this.trigger("AnimationEnd", this._currentReel);
 			this.pauseAnimation();
+			this.trigger("AnimationEnd", this._currentReel);
 		}
 	},
 

--- a/tests/animation/sprite-animation.js
+++ b/tests/animation/sprite-animation.js
@@ -556,6 +556,14 @@ test("See if a specific animation is playing", function() {
 	equal(spriteAnimation.isPlaying('short'), true, "The 'short' animation should be playing");
 });
 
+test("Check that it's possible to chain animations", function(){
+	var chain = function(){this.animate('count');}
+	spriteAnimation.one("AnimationEnd", chain);
+	spriteAnimation.animate('short');
+	Crafty.timer.simulateFrames(4);
+	ok(spriteAnimation.isPlaying('count'), "Successfully plays count after short ends");
+
+})
 
 
 


### PR DESCRIPTION
Currently, if you try to play a new animation by binding to "AnimationEnd", it'll be paused right after the event fires.  This just switches the order, and adds a test for animation chaining.  (Which we really need, because I'm pretty certain there have been a bunch of related bugs over time.)

This was reported [on the forums](https://groups.google.com/forum/?fromgroups#!topic/craftyjs/FfVTSBfJXVM).
