### PR TITLE
Improve "Color" init/remove routine

### DIFF
--- a/src/drawing.js
+++ b/src/drawing.js
@@ -11,16 +11,28 @@ Crafty.c("Color", {
     ready: true,
 
     init: function () {
-        this.bind("Draw", function (e) {
-            if (!this._color) { return; }
-            if (e.type === "DOM") {
-                e.style.backgroundColor = this._color;
-                e.style.lineHeight = 0;
-            } else if (e.type === "canvas") {
-                e.ctx.fillStyle = this._color;
-                e.ctx.fillRect(e.pos._x, e.pos._y, e.pos._w, e.pos._h);
-            }
-        });
+        this.bind("Draw", this._drawColor);
+        this.trigger("Invalidate");
+    },
+
+    remove: function(){
+        this.unbind("Draw", this._drawColor);
+        if (this.has("DOM")){
+            this._element.style.backgroundColor = "transparent";
+        }
+        this.trigger("Invalidate");
+    },
+
+    // draw function for "Color"
+    _drawColor: function(e){
+        if (!this._color) { return; }
+        if (e.type === "DOM") {
+            e.style.backgroundColor = this._color;
+            e.style.lineHeight = 0;
+        } else if (e.type === "canvas") {
+            e.ctx.fillStyle = this._color;
+            e.ctx.fillRect(e.pos._x, e.pos._y, e.pos._w, e.pos._h);
+        }
     },
 
     /**@

--- a/tests/dom.js
+++ b/tests/dom.js
@@ -78,3 +78,17 @@ test("removing DOM component cleans up", function(){
   strictEqual(node.parentNode, null, "no parent node after removal of 'DOM'");
 
 });
+
+
+test("Removing Color component resets DOM correctly", function(){
+  var element = Crafty.e("DOM, Color");
+  var node = element._element;
+  element.color("red");
+  
+  // Style won't be updated until rendering occurs
+  Crafty.timer.simulateFrames(1);
+  notEqual(node.style.backgroundColor, "transparent", "Element is not initially transparent");
+  
+  element.removeComponent("Color");
+  equal(node.style.backgroundColor, "transparent", "Transparent after removal of Color");
+});


### PR DESCRIPTION
- Allows the "Color" component to be properly removed from entities.
- Properly invalidates the entity when "Color" is added.

In response to [this post](https://groups.google.com/forum/?fromgroups#!topic/craftyjs/oTPqijDiz9I).
