### PR TITLE
Update the documentation for the Mouse component

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -390,24 +390,34 @@ Crafty.bind("CraftyStop", function () {
  * #Mouse
  * @category Input
  * Provides the entity with mouse related events
- * @trigger MouseOver - when the mouse enters the entity - MouseEvent
- * @trigger MouseOut - when the mouse leaves the entity - MouseEvent
- * @trigger MouseDown - when the mouse button is pressed on the entity - MouseEvent
- * @trigger MouseUp - when the mouse button is released on the entity - MouseEvent
- * @trigger Click - when the user clicks the entity. [See documentation](http://www.quirksmode.org/dom/events/click.html) - MouseEvent
- * @trigger DoubleClick - when the user double clicks the entity - MouseEvent
- * @trigger MouseMove - when the mouse is over the entity and moves - MouseEvent
+ * @trigger MouseOver - when the mouse enters - MouseEvent
+ * @trigger MouseOut - when the mouse leaves - MouseEvent
+ * @trigger MouseDown - when the mouse button is pressed on - MouseEvent
+ * @trigger MouseUp - when the mouse button is released on - MouseEvent
+ * @trigger Click - when the user clicks - MouseEvent
+ * @trigger DoubleClick - when the user double clicks - MouseEvent
+ * @trigger MouseMove - when the mouse is over and moves - MouseEvent
+ *
+ * To be able to use the events on a entity, you have to remember to include the Mouse component, else the events will not get triggered.
+ *
+ * You can read more about the MouseEvent, which are the parameter passed to the callback.
+ * https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent
+ *
  * Crafty adds the mouseButton property to MouseEvents that match one of
  *
  * - Crafty.mouseButtons.LEFT
  * - Crafty.mouseButtons.RIGHT
  * - Crafty.mouseButtons.MIDDLE
  *
+ *
  * @example
  * ~~~
- * myEntity.bind('Click', function() {
- *      console.log("Clicked!!");
- * })
+ * var myEntity = Crafty.e('2D, Canvas, Color, Mouse')
+ * .attr({x: 10, y: 10, w: 40, h: 40})
+ * .color('red')
+ * .bind('Click', function(MouseEvent){
+ *   alert('clicked', MouseEvent);
+ * });
  *
  * myEntity.bind('MouseUp', function(e) {
  *    if( e.mouseButton == Crafty.mouseButtons.RIGHT )

--- a/src/controls.js
+++ b/src/controls.js
@@ -62,6 +62,9 @@ Crafty.extend({
      * Internal method which dispatches mouse events received by Crafty (crafty.stage.elem).
      * The mouse events get dispatched to the closest entity to the source of the event (if available).
      *
+     * You can read more about the MouseEvent, which is the parameter passed to the callback.
+     * https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent
+     *
      * This method also sets a global property Crafty.lastEvent, which holds the most recent event that
      * occured (useful for determining mouse position in every frame).
      * ~~~
@@ -400,7 +403,7 @@ Crafty.bind("CraftyStop", function () {
  *
  * To be able to use the events on a entity, you have to remember to include the Mouse component, else the events will not get triggered.
  *
- * You can read more about the MouseEvent, which are the parameter passed to the callback.
+ * You can read more about the MouseEvent, which is the parameter passed to the callback.
  * https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent
  *
  * Crafty adds the mouseButton property to MouseEvents that match one of


### PR DESCRIPTION
It needed to be more clear that you have to include the Mouse component before you can bind to Mouse events, else you could expect it to be like jQuery and wonder why i do not trigger anything.
Removed the text "the entity" from the triggers because it makes it more easier to read and you do understand that it talks about the entity.
Included a better link for the MouseEvent details.
Updated with a working example you can copy and paste.
