### PR TITLE
Fix text rotation with canvas

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -62,7 +62,7 @@ Crafty.c("Text", {
                 context.fillStyle = this._textColor || "rgb(0,0,0)";
                 context.font = font;
 
-                context.fillText(this._text, this._x, this._y);
+                context.fillText(this._text, e.pos._x, e.pos._y);
 
                 context.restore();
             }


### PR DESCRIPTION
The text entity was directly using it's x/y coordinates to draw on the canvas.  To account for rotation, it needs to use the coordinates passed by the draw event.

As reported on the [forums](https://groups.google.com/forum/?fromgroups=#!topic/craftyjs/ZLefsBR6zFA).

I manually checked that canvas text appears correctly with this patch.  But the effects are purely visual, so unfortunately there's no easy way to add a test for the correct behavior.  I think there are tools that let you test canvas rendering, so maybe we should investigate those!  :)
