### PR TITLE
Delay modified

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -1012,6 +1012,8 @@ Crafty.c("2D", {
 /**@
  * #Gravity
  * @category 2D
+ * @trigger Moved - When entity has moved on y-axis a Moved event is triggered with an object specifying the old position {x: old_x, y: old_y}
+ * 
  * Adds gravitational pull to the entity.
  */
 Crafty.c("Gravity", {
@@ -1079,6 +1081,7 @@ Crafty.c("Gravity", {
             //if falling, move the players Y
             this._gy += this._gravityConst;
             this.y += this._gy;
+	    this.trigger('Moved', { x: this._x, y: this._y - this._gy });
         } else {
             this._gy = 0; //reset change in y
         }

--- a/src/controls.js
+++ b/src/controls.js
@@ -865,17 +865,17 @@ Crafty.c("Fourway", {
 /**@
  * #Twoway
  * @category Input
+ * @trigger NewDirection - When direction changes a NewDirection event is triggered with an object detailing the new direction: {x: x_movement, y: y_movement}. This is consistent with Fourway and Multiway components.
+ * @trigger Moved - When entity has moved on x-axis a Moved event is triggered with an object specifying the old position {x: old_x, y: old_y}
+ * 
  * Move an entity left or right using the arrow keys or `D` and `A` and jump using up arrow or `W`.
- *
- * When direction changes a NewDirection event is triggered with an object detailing the new direction: {x: x_movement, y: y_movement}. This is consistent with Fourway and Multiway components.
- * When entity has moved on x-axis a Moved event is triggered with an object specifying the old position {x: old_x, y: old_y}
  */
 Crafty.c("Twoway", {
     _speed: 3,
     _up: false,
 
     init: function () {
-        this.requires("Fourway, Keyboard");
+        this.requires("Fourway, Keyboard, Gravity");
     },
 
     /**@
@@ -919,6 +919,7 @@ Crafty.c("Twoway", {
             if (this._up) {
                 this.y -= this._jumpSpeed;
                 this._falling = true;
+		this.trigger('Moved', { x: this._x, y: this._y + this._jumpSpeed });
             }
         }).bind("KeyDown", function (e) {
             if (e.key === Crafty.keys.UP_ARROW || e.key === Crafty.keys.W || e.key === Crafty.keys.Z)

--- a/src/time.js
+++ b/src/time.js
@@ -14,7 +14,7 @@ Crafty.c("Delay", {
             while (--index >= 0) {
                 var item = this._delays[index];
                 if (item.start + item.delay + item.pause < now) {
-                    item.func.call(this);
+                    item.callback.call(this);
                     if (item.repeat > 0) {
                         // reschedule item
                         item.start = now;
@@ -24,6 +24,8 @@ Crafty.c("Delay", {
                     } else if (item.repeat <= 0) {
                         // remove item from array
                         this._delays.splice(index, 1);
+                        if(typeof item.callbackOff === "function")
+                            item.callbackOff.call(this);
                     }
                 }
             }
@@ -45,12 +47,15 @@ Crafty.c("Delay", {
     /**@
      * #.delay
      * @comp Delay
-     * @sign public this.delay(Function callback, Number delay)
-     * @param callback - Method to execute after given amount of milliseconds
-     * @param delay - Amount of milliseconds to execute the method
+     * @sign public this.delay(Function callback, Number delay, Number repeat, Function callbackOff)
+     * @param callback - Method to execute after given amount of milliseconds. if
+     * @param delay - Amount of milliseconds to execute the method. If reference of a method is passed,
+     * there's possibility to cancel the delay.
      * @param repeat - How often to repeat the delayed function. A value of 0 triggers the delayed
      * function exactly once. A value n > 0 triggers the delayed function exactly n+1 times. A
      * value of -1 triggers the delayed function indefinitely.
+     * @param callbackOff - (optional) Method to execute after delay ends(after all iterations are executed). 
+     * If repeat value equals -1, callbackOff will never be triggerred.
      *
      * The delay method will execute a function after a given amount of time in milliseconds.
      *
@@ -68,15 +73,39 @@ Crafty.c("Delay", {
      * }, 100, 0);
      * ~~~
      */
-    delay: function (func, delay, repeat) {
+    delay: function (callback, delay, repeat, callbackOff) {
         this._delays.push({
             start: new Date().getTime(),
-            func: func,
+            callback: callback,
+            callbackOff: callbackOff,
             delay: delay,
             repeat: (repeat < 0 ? Infinity : repeat) || 0,
             pauseBuffer: 0,
             pause: 0
         });
+        return this;
+    },
+    
+    /**@
+     * #.cancelDelay
+     * @comp Delay
+     * @sign public this.cancelDelay(Function callback)
+     * @param callback - Method reference passed to .delay
+     *
+     * The cancelDelay method will cancel a delay set previously.
+     *
+     * @example
+     * ~~~
+     * this.cancelDelay( reference );
+     * ~~~
+     */
+    cancelDelay: function (callback) {
+        for (var index in this._delays) {
+            var item = this._delays[index];
+            if(item.callback == callback) {
+                this._delays.splice(index, 1);
+            }
+        }
         return this;
     }
 });


### PR DESCRIPTION
At its current state, the "Delay" component do not do anything when the delay ends. This modification fixes that, allowing you to pass a "callbackOff" method that will be called after all iterations of delay are executed.

Also, now it's possible to cancel a delay with the method .cancelDelay, passing as argument a method reference, the same method reference passed to .delay.

Finally, fixed a minor inconsistency in the the comments.
