### PR TITLE
Decouple Crafty.pixelart from individual renderers

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -311,11 +311,33 @@ Crafty.extend({
                 // Resize the viewport
                 Crafty.uniqueBind("ViewportResize", this._resize);
 
+                // Listen for changes in pixel art settings
+                // Since window is inited before stage, can't set right away, but shouldn't need to!
+                Crafty.uniqueBind("PixelartSet", this._setPixelArt);
             },
 
             _resize: function(){
                 Crafty.stage.elem.style.width = Crafty.viewport.width + "px";
                 Crafty.stage.elem.style.height = Crafty.viewport.height + "px";
+            },
+
+            // Handle whether images should be smoothed or not
+            _setPixelArt: function(enabled) {
+                var style = Crafty.stage.inner.style;
+                if (enabled) {
+                    style[Crafty.DOM.camelize("image-rendering")] = "optimizeSpeed";   /* legacy */
+                    style[Crafty.DOM.camelize("image-rendering")] = "-moz-crisp-edges";    /* Firefox */
+                    style[Crafty.DOM.camelize("image-rendering")] = "-o-crisp-edges";  /* Opera */
+                    style[Crafty.DOM.camelize("image-rendering")] = "-webkit-optimize-contrast";   /* Webkit (Chrome & Safari) */
+                    style[Crafty.DOM.camelize("-ms-interpolation-mode")] = "nearest-neighbor";  /* IE */
+                    style[Crafty.DOM.camelize("image-rendering")] = "optimize-contrast";   /* CSS3 proposed */
+                    style[Crafty.DOM.camelize("image-rendering")] = "pixelated";   /* CSS4 proposed */
+                    style[Crafty.DOM.camelize("image-rendering")] = "crisp-edges"; /* CSS4 proposed */
+                } else {
+                    style[Crafty.DOM.camelize("image-rendering")] = "optimizeQuality";   /* legacy */
+                    style[Crafty.DOM.camelize("-ms-interpolation-mode")] = "bicubic";   /* IE */
+                    style[Crafty.DOM.camelize("image-rendering")] = "auto";   /* CSS3 */
+                }
             },
 
             width: 0,

--- a/src/canvas.js
+++ b/src/canvas.js
@@ -206,9 +206,13 @@ Crafty.extend({
             if (zoom != 1)
                 Crafty.canvas.context.scale(zoom, zoom);
 
+            // Set pixelart to current status, and listen for changes
+            this._setPixelart(Crafty._pixelartEnabled);
+            Crafty.uniqueBind("PixelartSet", this._setPixelart);
+
             //Bind rendering of canvas context (see drawing.js)
             Crafty.uniqueBind("RenderScene", Crafty.DrawManager.renderCanvas);
-
+            
             Crafty.uniqueBind("ViewportResize", this._resize);
         },
 
@@ -218,6 +222,15 @@ Crafty.extend({
             c.width = Crafty.viewport.width;
             c.height = Crafty.viewport.height;
 
+        },
+
+        _setPixelart: function(enabled){
+            var context = Crafty.canvas.context;
+            context.imageSmoothingEnabled = !enabled;
+            context.mozImageSmoothingEnabled = !enabled;
+            context.webkitImageSmoothingEnabled = !enabled;
+            context.oImageSmoothingEnabled = !enabled;
+            context.msImageSmoothingEnabled = !enabled;
         }
 
     }

--- a/src/drawing.js
+++ b/src/drawing.js
@@ -675,7 +675,9 @@ Crafty.extend({
      * This feature is experimental and you should be careful with cross-browser compatibility. 
      * The best way to disable image smoothing is to use the Canvas render method and the Sprite component for drawing your entities.
      *
-     * This method will have no effect for Canvas image smoothing if the canvas is not initialized yet.
+     * If you want to switch modes in the middle of a scene, 
+     * be aware that canvas entities won't be drawn in the new style until something else invalidates them. 
+     * (You can manually invalidate all canvas entities with `Crafty("Canvas").trigger("Invalidate");`)
      *
      * Note that Firefox_26 currently has a [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=696630) 
      * which prevents disabling image smoothing for Canvas entities that use the Image component. Use the Sprite
@@ -694,30 +696,9 @@ Crafty.extend({
      * Crafty.e("2D, Canvas, sprite1");
      * ~~~
      */
+    _pixelartEnabled: false,
     pixelart: function(enabled) {
-        var context = Crafty.canvas.context;
-        if (context) {
-            context.imageSmoothingEnabled = !enabled;
-            context.mozImageSmoothingEnabled = !enabled;
-            context.webkitImageSmoothingEnabled = !enabled;
-            context.oImageSmoothingEnabled = !enabled;
-            context.msImageSmoothingEnabled = !enabled;
-        }
-
-        var style = Crafty.stage.inner.style;
-        if (enabled) {
-            style[Crafty.DOM.camelize("image-rendering")] = "optimizeSpeed";   /* legacy */
-            style[Crafty.DOM.camelize("image-rendering")] = "-moz-crisp-edges";    /* Firefox */
-            style[Crafty.DOM.camelize("image-rendering")] = "-o-crisp-edges";  /* Opera */
-            style[Crafty.DOM.camelize("image-rendering")] = "-webkit-optimize-contrast";   /* Webkit (Chrome & Safari) */
-            style[Crafty.DOM.camelize("-ms-interpolation-mode")] = "nearest-neighbor";  /* IE */
-            style[Crafty.DOM.camelize("image-rendering")] = "optimize-contrast";   /* CSS3 proposed */
-            style[Crafty.DOM.camelize("image-rendering")] = "pixelated";   /* CSS4 proposed */
-            style[Crafty.DOM.camelize("image-rendering")] = "crisp-edges"; /* CSS4 proposed */
-        } else {
-            style[Crafty.DOM.camelize("image-rendering")] = "optimizeQuality";   /* legacy */
-            style[Crafty.DOM.camelize("-ms-interpolation-mode")] = "bicubic";   /* IE */
-            style[Crafty.DOM.camelize("image-rendering")] = "auto";   /* CSS3 */
-        }
+        Crafty._pixelartEnabled = enabled;
+        Crafty.trigger("PixelartSet", enabled);
     }
 });


### PR DESCRIPTION
Currently `Crafty.pixelart()` explicitly alters the canvas and DOM renderers.  This PR has it fire an event instead.

The canvas and DOM contexts now listen for the event, and make the appropriate changes.  This will make it simpler to add new contexts (like webgl) or to introduce multiple renderers of the same type.

This patch also tracks the current pixelart setting, and ensures that, when a canvas context is inited, that it matches that value.  It doesn't do something similar for the DOM element because the stage is created as soon as you init Crafty.

The WebGL renderer is what prompted me to whip up this patch, of course.  :)  It passes tests, but TBH I haven't explicitly checked that images are appropriately smoothed or not.  So it shouldn't land until that's confirmed -- I just didn't have a convenient test case lying around.
