### PR TITLE
Enabling multiple sprites for same image

### DIFF
--- a/src/sprite.js
+++ b/src/sprite.js
@@ -91,12 +91,32 @@ Crafty.extend({
             img = new Image();
             img.src = url;
             Crafty.asset(url, img);
-            img.onload = function () {
-                //all components with this img are now ready
-                for (var spriteName in map) {
-                    Crafty(spriteName).each(markSpritesReady);
-                }
+            var OnImageLoad = function (map) {
+            	this.map = {};
+            	var self = this;
+            	
+            	
+            	this.onLoad = function() {
+                    //all components with this img are now ready
+            		for (var spriteName in self.map) {
+            			Crafty(spriteName).each(markSpritesReady);
+            		}
+            	}
+            	
+            	this.addMap = function(m) {
+            		for (spriteName in m) {
+                        if (!m.hasOwnProperty(spriteName)) continue;
+                        this.map[spriteName] = m[spriteName];
+            		}
+            	}
+            	
+            	self.addMap(map);
             };
+            img.__loader = new OnImageLoad(map);
+            img.onload = img.__loader.onLoad;
+        } else {
+            // this solves the problem of adding incremental sprite names. 
+        	img.__loader.addMap(map);
         }
 
         var sharedSpriteInit = function() {


### PR DESCRIPTION
Bug description: 
When try to register new sprite name for previously defined (but not yet loaded) image, the previous version was ignoring the new sprite. 

Now we register all the sprite names into the OnImageLoad object, and when onLoad is triggered, all sprites are registered.
