### PR TITLE
Zoom scale fix

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -300,8 +300,14 @@ Crafty.extend({
                 else
                     v = (1/amount - 1 ) / (1/finalAmount - 1);
 
+                var newZoomScale; // prevents rezooming on pan using fractional scale
+                if (finalAmount === startingZoom)
+                    newZoomScale = startingZoom;
+                else
+                    newZoomScale = startingZoom + ( amount - startingZoom );
+
                 // Set new scale and viewport position
-                Crafty.viewport.scale( startingZoom + ( amount - startingZoom ) );
+                Crafty.viewport.scale( newZoomScale );
                 Crafty.viewport.scroll("_x", startingX * (1-v) + finalX * v );
                 Crafty.viewport.scroll("_y", startingY * (1-v) + finalY * v );
                 Crafty.viewport._clamp();

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -301,7 +301,7 @@ Crafty.extend({
                     v = (1/amount - 1 ) / (1/finalAmount - 1);
 
                 // Set new scale and viewport position
-                Crafty.viewport.scale( amount * startingZoom );
+                Crafty.viewport.scale( startingZoom + ( amount - startingZoom ) );
                 Crafty.viewport.scroll("_x", startingX * (1-v) + finalX * v );
                 Crafty.viewport.scroll("_y", startingY * (1-v) + finalY * v );
                 Crafty.viewport._clamp();
@@ -329,7 +329,7 @@ Crafty.extend({
                 Crafty.trigger("StopCamera");
                 startingZoom = Crafty.viewport._scale;
                 finalAmount = amt;
-                finalZoom = startingZoom * finalAmount;
+                finalZoom = startingZoom + ( amt - startingZoom );
                 
 
                 startingX = Crafty.viewport.x;

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -304,7 +304,7 @@ Crafty.extend({
                 if (finalAmount === startingZoom)
                     newZoomScale = startingZoom;
                 else
-                    newZoomScale = startingZoom + ( amount - startingZoom );
+                    newZoomScale = amount;
 
                 // Set new scale and viewport position
                 Crafty.viewport.scale( newZoomScale );
@@ -335,7 +335,7 @@ Crafty.extend({
                 Crafty.trigger("StopCamera");
                 startingZoom = Crafty.viewport._scale;
                 finalAmount = amt;
-                finalZoom = startingZoom + ( amt - startingZoom );
+                finalZoom = amt;
                 
 
                 startingX = Crafty.viewport.x;

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -297,6 +297,8 @@ Crafty.extend({
                 // And by symmetry they should be parameterized in the same way!  So not much choice here.
                 if (finalAmount === 1)
                     v = easing.value();  // prevent NaN!  If zoom is used this way, it'll just become a pan.
+                else if(amount === 1 && finalAmount === 1)
+                    v = easing.value();
                 else
                     v = (1/amount - 1 ) / (1/finalAmount - 1);
 


### PR DESCRIPTION
This fix changes zoom functionality in crafty

The current zoom function uses multiplication when computing the final
zoom amount.  This is fine except when computing zoom scales that are
not whole numbers.

This fix changes that to, instead of multiplication, use simple addition
and subtraction.  Therefore, it is now possible to use fractional scales
(0.1 - 0.9).

I have not fully tested the change across all of crafty but it does seem
to fix a bug in my particular code.
