### PR TITLE
Fix for propogating 90deg rotations to child entities

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -699,7 +699,7 @@ Crafty.c("2D", {
             l = children.length,
             obj;
         //rotation
-        if (e.cos) {
+        if (("cos" in e) || ("sin" in e)) {
             for (; i < l; ++i) {
                 obj = children[i];
                 if ('rotate' in obj) obj.rotate(e);

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -224,7 +224,32 @@
     parent.rotation = 100; // Rotation by 90 degrees from initial position
     strictEqual(Round(child.x), -10, "Child moved around parent upon rotation (x).");
     strictEqual(Round(child.y), 10, "Child moved around parent upon rotation (y).");
+  });
 
+  test("child rotate 90deg", function () {
+    var parent = Crafty.e("2D")
+      .attr({
+        x: 0,
+        y: 0,
+        w: 50,
+        h: 50
+      });
+    var child = Crafty.e("2D")
+      .attr({
+        x: 0,
+        y: 0,
+        w: 50,
+        h: 50
+      });
+
+    parent.origin("center");
+    child.origin("center");
+
+    parent.attach(child);
+
+    parent.rotation = 90;
+    strictEqual(parent._rotation, 90, "parent rotates 90deg");
+    strictEqual(child._rotation, 90, "child also rotates 90deg");
   });
 
 


### PR DESCRIPTION
Hi,

I noticed what I'm pretty sure is a bug in Crafty when rotating an entity by 90 degrees; the entity rotates fine, but the rotation doesn't get propagated to its children.

Here is a fiddle demonstrating the bug: http://jsfiddle.net/f8c4c/7/

Here's my suggested fix and an accompanying test. Strange thing though--when I revert my fix and run the test I wrote in grunt, it passes. Opening up the index.html in a browser, however, makes the test fail as expected (and pass with the fix applied). I'm new to grunt, so maybe I'm just missing something..

Anyways, hope this helps!
Justin
