### PR TITLE
Refactor "Delay" to use dt from frameData

### DIFF
--- a/tests/time.js
+++ b/tests/time.js
@@ -2,79 +2,75 @@
   module("Time");
 
   test("Delay", function() {
-    /* jshint -W020 */
-    var oldDate = Date,
-        initDate = Date.now();
     var counter = 0,
         incr = function() { counter++; };
     var ent = Crafty.e("Delay");
 
     // test one execution
     counter = 0;
-    Date = function (arg) { return new oldDate(initDate); }; ent.delay(incr, 49);
-    Date = function (arg) { return new oldDate(initDate + 50); }; Crafty.trigger("EnterFrame");
-    Date = function (arg) { return new oldDate(initDate + 50 + 50); }; Crafty.trigger("EnterFrame");
+    ent.delay(incr, 49);
+    // Tests will assume 20ms per frame (as is the default)
+    Crafty.timer.simulateFrames(5);
     strictEqual(counter, 1, "delayed function should have executed once");
     strictEqual(ent._delays.length, 0, "no more scheduled delays");
 
     // test two executions
     counter = 0;
-    Date = function (arg) { return new oldDate(initDate); }; ent.delay(incr, 49, 1);
-    Date = function (arg) { return new oldDate(initDate + 50); }; Crafty.trigger("EnterFrame");
-    Date = function (arg) { return new oldDate(initDate + 50 + 50); }; Crafty.trigger("EnterFrame");
-    Date = function (arg) { return new oldDate(initDate + 50 + 50 + 50); }; Crafty.trigger("EnterFrame");
+     ent.delay(incr, 49, 1);
+    Crafty.timer.simulateFrames(5);
     strictEqual(counter, 2, "delayed function should have executed twice");
     strictEqual(ent._delays.length, 0, "no more scheduled delays");
 
     // test infinite executions
     counter = 0;
-    Date = function (arg) { return new oldDate(initDate); }; ent.delay(incr, 49, -1);
-    Date = function (arg) { return new oldDate(initDate + 50); }; Crafty.trigger("EnterFrame");
-    Date = function (arg) { return new oldDate(initDate + 50 + 50); }; Crafty.trigger("EnterFrame");
-    Date = function (arg) { return new oldDate(initDate + 50 + 50 + 50); }; Crafty.trigger("EnterFrame");
+    
+    ent.delay(incr, 49, -1);
+    Crafty.timer.simulateFrames(8);
+
     strictEqual(counter, 3, "delayed function should have executed three times");
     strictEqual(ent._delays.length, 1, "one more scheduled delay");
 
     // test cancel
     counter = 0;
     ent.cancelDelay(incr);
-    Date = function (arg) { return new oldDate(initDate + 50 + 50 + 50 + 50); }; Crafty.trigger("EnterFrame");
+    Crafty.timer.simulateFrames(10);
     strictEqual(counter, 0, "delayed function should not have executed");
     strictEqual(ent._delays.length, 0, "no more scheduled delays");
 
+    // test dt > duration
+    counter = 0;
+    ent.delay(incr, 5, 1);
+    Crafty.timer.simulateFrames(1);
+    strictEqual(counter, 2, "function should be executed exactly twice, in a single frame");
+    strictEqual(ent._delays.length, 0, "no more scheduled delays");
+
+
     // test callbackOff
     counter = 0;
-    Date = function (arg) { return new oldDate(initDate); }; ent.delay(incr, 49, 0, function() { counter--; });
-    Date = function (arg) { return new oldDate(initDate + 50); }; Crafty.trigger("EnterFrame");
-    Date = function (arg) { return new oldDate(initDate + 50 + 50); }; Crafty.trigger("EnterFrame");
-    strictEqual(counter, 0, "two functions should have executed once");
+    ent.delay(incr, 49, 0, function() { counter-=5; });
+    Crafty.timer.simulateFrames(10);
+    strictEqual(counter, -4, "two functions should have executed once");
     strictEqual(ent._delays.length, 0, "no more scheduled delays");
 
     // test multiple delays
     counter = 0;
-    Date = function (arg) { return new oldDate(initDate); };
     ent.delay(incr, 49); // x1
     ent.delay(incr, 49, 1); // x2
     ent.delay(incr, 49, -1); // x3
     ent.delay(incr, 49, -1); // x3
-    ent.delay(incr, 51); // x1
-    ent.delay(incr, 51); // x1
-    Date = function (arg) { return new oldDate(initDate + 50); }; Crafty.trigger("EnterFrame");
-    Date = function (arg) { return new oldDate(initDate + 50 + 50); }; Crafty.trigger("EnterFrame");
-    Date = function (arg) { return new oldDate(initDate + 50 + 50 + 50); }; Crafty.trigger("EnterFrame");
+    ent.delay(incr, 65); // x1
+    ent.delay(incr, 65); // x1
+    Crafty.timer.simulateFrames(8);
     strictEqual(counter, 11, "delayed function should have executed eleven times");
     strictEqual(ent._delays.length, 2, "two more scheduled delays");
 
     // test multiple cancels
     counter = 0;
     ent.cancelDelay(incr);
-    Date = function (arg) { return new oldDate(initDate + 50 + 50 + 50 + 50); }; Crafty.trigger("EnterFrame");
+    Crafty.timer.simulateFrames(10);
     strictEqual(counter, 0, "delayed function should not have executed");
     strictEqual(ent._delays.length, 0, "no more scheduled delays");
 
 
-    ent.destroy();
-    Date = oldDate;
-    /* jshint +W020 */
   });
 })();


### PR DESCRIPTION
Rather than explicitly requesting the current time, the "Delay" component should just accumulate the time passed in by the "EnterFrame" event.  This way it doesn't need to worry about tracking the pause state of the game; that's all handled by the main game loop.

This meant drastically simplifying the tests -- they no longer need to overwrite the Date object or anything like that.  They can just use `Crafty.timer.simulateFrame` like we do elsewhere.

This is an alternative to #772.
