### PR TITLE
Update sound.js, Crafty.audio.add not work like example says 

### DIFF
--- a/src/sound.js
+++ b/src/sound.js
@@ -166,7 +166,7 @@ Crafty.extend({
             if (arguments.length === 1 && typeof id === "object") {
                 for (var i in id) {
                     if (typeof id[i] === "string") {
-                        a = Crafty.audio.create(i, id[i])
+                        a = Crafty.audio.create(i, id[i]);
                     }
                     
                     if (typeof id[i] === "object") {

--- a/src/sound.js
+++ b/src/sound.js
@@ -165,10 +165,16 @@ Crafty.extend({
 
             if (arguments.length === 1 && typeof id === "object") {
                 for (var i in id) {
-                    for (src in id[i]) {
-                        a = Crafty.audio.create(i, id[i][src]);
-                        if (a){
-                            break;
+                    if (typeof id[i] === "string") {
+                        a = Crafty.audio.create(i, id[i])
+                    }
+                    
+                    if (typeof id[i] === "object") {
+                        for (src in id[i]) {
+                            a = Crafty.audio.create(i, id[i][src]);
+                            if (a){
+                                break;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
add type detect for `id[i]`, otherwise code like `coin: "sounds/coin.mp3` in example won't work! but only `coin: ["sounds/coin.mp3"]` works
