### PR TITLE
Add cancelAnimationFrame as it is the primary way to cancel Fixed #796

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1061,7 +1061,8 @@ Crafty.extend({
 
                 if (typeof tick === "number") clearInterval(tick);
 
-                var onFrame = window.cancelRequestAnimationFrame ||
+                var onFrame = window.cancelAnimationFrame ||
+                    window.cancelRequestAnimationFrame ||
                     window.webkitCancelRequestAnimationFrame ||
                     window.mozCancelRequestAnimationFrame ||
                     window.oCancelRequestAnimationFrame ||


### PR DESCRIPTION
window.cancelAnimationFrame was missing and it causes an warning in Chrome.
