### PR TITLE
Cache travis-ci modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ node_js:
   - "0.10"
 before_script:
   - npm install -g grunt-cli
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
A small optimization, cache the node modules on travis.

http://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies/
