### PR TITLE
Use jsdoc for generating documentation

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -131,6 +131,10 @@ Crafty.extend({
 
 
 
+/**@
+ * My Components
+ * @namespace Components
+ */
 
 
 
@@ -138,6 +142,8 @@ Crafty.extend({
  * #Color
  * @category Graphics
  * Draw a colored rectangle.
+ * @namespace Color
+ * @memberof! Components
  */
 Crafty.c("Color", {
     _red: 0,
@@ -175,6 +181,8 @@ Crafty.c("Color", {
     /**@
      * #.color
      * @comp Color
+     * @memberof! Components.Color#
+     *
      * @trigger Invalidate - when the color changes
      *
      * Will assign the color and opacity, either through a string shorthand, or through explicit rgb values.

--- a/src/text.js
+++ b/src/text.js
@@ -4,6 +4,8 @@ var Crafty = require('./core.js'),
 /**@
  * #Text
  * @category Graphics
+ * @memberof! Components
+ * @namespace Text
  * @trigger Invalidate - when the text is changed
  * @requires Canvas or DOM
  * Component to make a text entity.
@@ -98,6 +100,7 @@ Crafty.c("Text", {
     /**@
      * #.text
      * @comp Text
+     * @memberof Components.Text#
      * @sign public this .text(String text)
      * @sign public this .text(Function textgenerator)
      * @param text - String of text that will be inserted into the DOM or Canvas element.
@@ -152,6 +155,7 @@ Crafty.c("Text", {
     /**@
      * #.textColor
      * @comp Text
+     * @memberof Components.Text#
      * @sign public this .textColor(String color, Number strength)
      * @param color - The color in hexadecimal
      * @param strength - Level of opacity
@@ -178,6 +182,7 @@ Crafty.c("Text", {
     /**@
      * #.textFont
      * @comp Text
+     * @memberof Components.Text#
      * @triggers Invalidate
      * @sign public this .textFont(String key, * value)
      * @param key - Property of the entity to modify
@@ -228,6 +233,7 @@ Crafty.c("Text", {
     /**@
      * #.unselectable
      * @comp Text
+     * @memberof Components.Text#
      * @triggers Invalidate
      * @sign public this .unselectable()
      *

--- a/src/time.js
+++ b/src/time.js
@@ -4,6 +4,8 @@ var Crafty = require('./core.js'),
 /**@
  * #Delay
  * @category Utilities
+ * @memberof! Components
+ * @namespace Delay
  */
 Crafty.c("Delay", {
     init: function () {
@@ -37,6 +39,7 @@ Crafty.c("Delay", {
     /**@
      * #.delay
      * @comp Delay
+     * @memberof! Components.Delay#
      * @sign public this.delay(Function callback, Number delay[, Number repeat[, Function callbackOff]])
      * @param callback - Method to execute after given amount of milliseconds. If reference of a
      * method is passed, there's possibility to cancel the delay.
@@ -89,6 +92,7 @@ Crafty.c("Delay", {
     /**@
      * #.cancelDelay
      * @comp Delay
+     * @memberof! Components.Delay#
      * @sign public this.cancelDelay(Function callback)
      * @param callback - Method reference passed to .delay
      *


### PR DESCRIPTION
I am using jsdoc for creating documentation.

It can be installed via npm by `npm install jsdoc``

I then run this command `jsdoc src/color.js src/text.js src/time.js` because I have only changed the 3 files.

I then get a finished html site like this:

http://kevinsimper.github.io/craftyjsdoc/Components.Color.html

It would be pretty fast to implement.

And you can get the JSON by doing

`jsdoc src/color.js src/text.js src/time.js -X < MYJSON:json` 
