### PR TITLE
Fixed problem when trying to load already loaded asset

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -292,45 +292,50 @@ Crafty.extend({
             for(asset in data[type]) {
 
                 current = data[type][asset];
+                obj = null;
 
                 if (type === "audio" && audSupport) {
-                    if (typeof current === "object") {
-                        var files = [];
-                        for (var i in current) {
-                            fileUrl = getFilePath(type, current[i]);
-                            if (!isAsset(fileUrl) && isSupportedAudio(current[i]))
-                                files.push(fileUrl);
+                    if (!Crafty.audio.sounds[asset]) {
+                        if (typeof current === "object") {
+                            var files = [];
+                            for (var i in current) {
+                                fileUrl = getFilePath(type, current[i]);
+                                if (!isAsset(fileUrl) && isSupportedAudio(current[i]))
+                                    files.push(fileUrl);
+                            }
+                            if (files.length)
+                                obj = Crafty.audio.add(asset, files).obj;
                         }
-                        obj = Crafty.audio.add(asset, files).obj;
-                    }
-                    else if (typeof current === "string" && isSupportedAudio(current)) {
-                        fileUrl = getFilePath(type, current);
-                        if (!isAsset(fileUrl))
-                            obj = Crafty.audio.add(asset, fileUrl).obj;
-                    }
+                        else if (typeof current === "string" && isSupportedAudio(current)) {
+                            fileUrl = getFilePath(type, current);
+                            if (!isAsset(fileUrl))
+                                obj = Crafty.audio.add(asset, fileUrl).obj;
+                        }
 
-                    //addEventListener is supported on IE9 , Audio as well
-                    if (obj && obj.addEventListener)
-                        obj.addEventListener('canplaythrough', pro, false);
+                        //addEventListener is supported on IE9 , Audio as well
+                        if (obj && obj.addEventListener)
+                            obj.addEventListener('canplaythrough', pro, false);
+                    } else {
+                        var rm = window.location.origin + window.location.pathname;
+                        fileUrl = Crafty.audio.sounds[asset].obj.src.replace(rm, "");
+                    }
                 } else {
                     asset = type === "sprites"? asset : current;
                     fileUrl = getFilePath(type, asset);
-                    if (isValidImage(asset)) {
-                        obj = isAsset(fileUrl);
-                        if (!obj) {
-                            obj = new Image();
-                            if (type === "sprites")
-                                Crafty.sprite(current.tile, current.tileh, fileUrl, current.map,
-                                  current.paddingX, current.paddingY, current.paddingAroundBorder);
-                            Crafty.asset(fileUrl, obj);
-                        }
+                    if (!isAsset(fileUrl) && isValidImage(asset)) {
+                        obj = new Image();
+                        if (type === "sprites")
+                            Crafty.sprite(current.tile, current.tileh, fileUrl, current.map,
+                             current.paddingX, current.paddingY, current.paddingAroundBorder);
+                        Crafty.asset(fileUrl, obj);
                         onImgLoad(obj, fileUrl);
                     }
                 }
-                if (obj)
+                if (obj) {
                     obj.onerror = err;
-                else
-                    --total;
+                } else {
+                    err.call({ src: fileUrl });
+                }
             }
         }
 


### PR DESCRIPTION
Hi!

This patch fixes problem with refactored loader function that occurs when trying to (re)download already loaded assets.

Couple months ago I sent a PR with a fix for this, which made sure the file wouldn't be redownloaded, and still would call the onComplete function - but it wouldn't call the onError function in this specific situation. 

This patch now does all that: avoids redownloading the given asset, calls the onError function, and properly calls onComplete when finished. 

I messed that first PR when trying to push (squashing) this updated version, so please forgive me for sending it again.
