### PR TITLE
Multiway now keeps tracking of keydown's

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -318,11 +318,9 @@ Crafty.extend({
 
         if (e.type === "keydown") {
             if (Crafty.keydown[e.key] !== true) {
-                Crafty.keydown[e.key] = true;
                 Crafty.trigger("KeyDown", e);
             }
         } else if (e.type === "keyup") {
-            delete Crafty.keydown[e.key];
             Crafty.trigger("KeyUp", e);
         }
 
@@ -707,6 +705,7 @@ Crafty.c("Multiway", {
 
     _keydown: function (e) {
         if (this._keys[e.key]) {
+            Crafty.keydown[e.key] = true;
             this._movement.x = Math.round((this._movement.x + this._keys[e.key].x) * 1000) / 1000;
             this._movement.y = Math.round((this._movement.y + this._keys[e.key].y) * 1000) / 1000;
             this.trigger('NewDirection', this._movement);
@@ -715,6 +714,7 @@ Crafty.c("Multiway", {
 
     _keyup: function (e) {
         if (this._keys[e.key]) {
+            delete Crafty.keydown[e.key];
             this._movement.x = Math.round((this._movement.x - this._keys[e.key].x) * 1000) / 1000;
             this._movement.y = Math.round((this._movement.y - this._keys[e.key].y) * 1000) / 1000;
             this.trigger('NewDirection', this._movement);
@@ -926,7 +926,7 @@ Crafty.c("Twoway", {
     _up: false,
 
     init: function () {
-        this.requires("Fourway, Keyboard, Gravity");
+        this.requires("Multiway, Keyboard, Gravity");
     },
 
     /**@


### PR DESCRIPTION
Issue: Currently, keydown will only hold keys activated through actual keyboard input. 

This small change allows the user to keep track of keydowns when **KeyDown** event is triggerred directly using `Crafty.trigger("KeyDown", key)`. It thus allows one to also use Keyboard's component `isDown` function. I did this modification in the making of a simple GUI with directional arrow keys for use with mobiles.
