### PR TITLE
Fix bug in _SAT collision test

### DIFF
--- a/src/collision.js
+++ b/src/collision.js
@@ -596,21 +596,21 @@ Crafty.c("Collision", {
             normal.y /= length;
 
             //default min max
-            min1 = min2 = -1;
-            max1 = max2 = -1;
+            min1 = min2 = Infinity;
+            max1 = max2 = -Infinity;
 
             //project all vertices from poly1 onto axis
             for (j = 0; j < l; ++j) {
                 dot = points1[j][0] * normal.x + points1[j][1] * normal.y;
-                if (dot > max1 || max1 === -1) max1 = dot;
-                if (dot < min1 || min1 === -1) min1 = dot;
+                if (dot > max1) max1 = dot;
+                if (dot < min1) min1 = dot;
             }
 
             //project all vertices from poly2 onto axis
             for (j = 0; j < k; ++j) {
                 dot = points2[j][0] * normal.x + points2[j][1] * normal.y;
-                if (dot > max2 || max2 === -1) max2 = dot;
-                if (dot < min2 || min2 === -1) min2 = dot;
+                if (dot > max2) max2 = dot;
+                if (dot < min2 ) min2 = dot;
             }
 
             //calculate the minimum translation vector should be negative
@@ -652,21 +652,21 @@ Crafty.c("Collision", {
             normal.y /= length;
 
             //default min max
-            min1 = min2 = -1;
-            max1 = max2 = -1;
+            min1 = min2 = Infinity;
+            max1 = max2 = -Infinity;
 
             //project all vertices from poly1 onto axis
             for (j = 0; j < l; ++j) {
                 dot = points1[j][0] * normal.x + points1[j][1] * normal.y;
-                if (dot > max1 || max1 === -1) max1 = dot;
-                if (dot < min1 || min1 === -1) min1 = dot;
+                if (dot > max1) max1 = dot;
+                if (dot < min1) min1 = dot;
             }
 
             //project all vertices from poly2 onto axis
             for (j = 0; j < k; ++j) {
                 dot = points2[j][0] * normal.x + points2[j][1] * normal.y;
-                if (dot > max2 || max2 === -1) max2 = dot;
-                if (dot < min2 || min2 === -1) min2 = dot;
+                if (dot > max2) max2 = dot;
+                if (dot < min2) min2 = dot;
             }
 
             //calculate the minimum translation vector should be negative

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -255,11 +255,20 @@
 
 
   // This test assumes that the "circles" are really octagons, as per Crafty.circle.
-  test("SAT", function() {
+  test("SAT overlap with circles", function() {
     var e = Crafty.e("2D, Collision");
     var c1 = new Crafty.circle(100, 100, 10);
     var c2 = new Crafty.circle(100, 105, 10);
     strictEqual((e._SAT(c1, c2).overlap < -13.8 && e._SAT(c1, c2).overlap > -13.9), true, "Expected overlap to be about -13.86 ( or 15 cos[pi/8])");
+
+  });
+
+  // Testcase from issue #828 by VHonzik
+  test("SAT overlap with rectangles", function() {
+    var e = Crafty.e("2D, Collision");
+    var c1 = new Crafty.polygon([[0,1], [50, 1], [50, 51], [0, 51]]);
+    var c2 = new Crafty.polygon([[-10, -10], [-10, 10], [10, 10], [10, -10]]);
+    strictEqual(e._SAT(c1, c2) !== false, true, "Polygons should test as overlapping");
 
   });
 


### PR DESCRIPTION
The SAT function improperly calculated min/max values in some cases.  This fixes that issue by comparing to +/- Infinity instead of special casing the initial values.  (It also gets rid of a now needless comparison, which might help performance.)

This also includes a qunit test that catches the issue.

Fixes issue #828.
