### PR TITLE
Implement a new strategy for avoiding event queue mutation

### DIFF
--- a/tests/core.js
+++ b/tests/core.js
@@ -123,6 +123,49 @@
 
   });
 
+  test("bind groups of entities", function() {
+    var e1 = Crafty.e("test"), e2 = Crafty.e("test");
+    var test_callback = function(){
+      this.test_flag = true;
+    };
+    Crafty("test").bind("TestEvent", test_callback);
+    e1.trigger("TestEvent");
+    strictEqual(e1.test_flag, true, "Entity event triggered on first entity");
+    notStrictEqual(e2.test_flag, false, "Not triggered on second ");
+
+    e1.test_flag = false;
+
+    Crafty.trigger("TestEvent");
+    strictEqual(e1.test_flag, true, "Global event triggered on first entity");
+    strictEqual(e2.test_flag, true, "Global event triggered on second entity");
+
+  });
+
+  test("trigger groups of entities", function(){
+    var e1 = Crafty.e("test"), e2 = Crafty.e("test");
+    var test_callback = function(){
+      this.test_flag = true;
+    };
+    e1.bind("TestEvent", test_callback);
+    e2.bind("TestEvent", test_callback);
+    Crafty("test").trigger("TestEvent");
+    strictEqual(e1.test_flag, true, "Triggered on first entity");
+    strictEqual(e2.test_flag, true, "Triggered on second entity");
+  });
+
+  test("bind to an event in response to that same event", function() {
+    var first = Crafty.e("test"),
+      triggered = 0;
+    function increment(){ triggered++; }
+    first.bind("myevent", function() {
+      increment();
+      first.bind("myevent", increment);
+    });
+    first.trigger("myevent");
+    strictEqual(triggered, 1, "event added in response to an event should not be triggered by that same event");
+
+  });
+
   test("unbind", function() {
     var first = Crafty.e("test");
     first.bind("myevent", function() {


### PR DESCRIPTION
The event callback queue can mutate in ways that mess up the iteration.  There are two cases we need to handle:
- While iterating through an event's callbacks, a new one is added.  This should not be triggered.
- When a callback is removed, we shouldn't actually mutate the callbacks array if this iteration was triggered in the middle of an iteration over the same array.  (We currently kind of half-handle this case, but there's a better way.)

The first is solved by registering the callback array's length at the time iteration starts.  The second is solved by adding a depth counter to each callback array.  It's iterated at the beginning of iteration, and decremented at the end.  Items are removed from the callbacks array only when the counter indicates a depth of 1.

This patch adds a test for the addition of a callback mid-event.  It also adds one for binding/triggering groups of entities at once, since I noticed a typo I introduced while modifying the code wasn't being caught by the existing tests.

This fixes #824. 
