### PR TITLE
Autobind parameter for declaring components

### DIFF
--- a/tests/events.js
+++ b/tests/events.js
@@ -191,8 +191,47 @@
     });
     strictEqual(x, 3, "data passed correctly with Crafty.one");
     Crafty.unbind("Increment");
+  });
 
+  test("Events and autobind with function names", function(){
+    Crafty.c("AutoComp", {
+      counter:0,
+      events: {"Test":"_onTest"},
+      _onTest: function(){
+        this.counter++;
+      }
+    });
+    var e = Crafty.e("AutoComp");
+    e.trigger("Test");
+    equal(e.counter, 1, "Function was triggered");
+
+    e.removeComponent("AutoComp");
+    e.counter = 0;
+    e.trigger("Test");
+    equal(e.counter, 0, "Function was not triggered after removal of component");
 
 
   });
+
+  test("Events and autobind with function declared inside object", function(){
+    Crafty.c("AutoComp2", {
+      counter:0,
+      events: {
+        Test:function(){
+          this.counter++;
+        }
+      }
+    });
+    var e = Crafty.e("AutoComp2");
+    e.trigger("Test");
+    equal(e.counter, 1, "Function was triggered");
+
+    e.removeComponent("AutoComp2");
+    e.counter = 0;
+    e.trigger("Test");
+    equal(e.counter, 0, "Function was not triggered after removal of component");
+
+  });
+
 })();
+


### PR DESCRIPTION
Adds a special `events` role when creating components.  This is a shorthand for binding functions to events, with the added benefit that they'll be automatically unbound when the component is removed or destroyed.  You use it like this:

``` javascript
Crafty.c("MyComponent", {
    events: {
        EnterFrame: function(){
            // this function is bound to EnterFrame
        },
        Moved: function(){
            // this function is bound to the "Moved" event
        },
        // We can give a reference to a function instead!
        Change: "_changeFunction"
    },
    _changeFunction: function(){
        // This function is bound to "Change" by its name, but can still be called normally as a method on the component
    }
});

```

I'd probably want to go through and switch some of the built-in components to use this (as well as `remove()`) at some point.
