### PR TITLE
Fix _SAT algorithm, optimize Crafty.polygon

### DIFF
--- a/src/2D.js
+++ b/src/2D.js
@@ -1098,21 +1098,21 @@ Crafty.c("Gravity", {
  * #Crafty.polygon
  * @category 2D
  *
- * Polygon object used for hitboxes and click maps. Must pass an Array for each point as an
- * argument where index 0 is the x position and index 1 is the y position.
+ * Polygon object used for hitboxes and click maps. Takes a set of points as an
+ * argument, giving alternately the x and y coordinates of the polygon's vertices in order.
  *
- * For example one point of a polygon will look like this: `[0,5]` where the `x` is `0` and the `y` is `5`.
- *
- * Can pass an array of the points or simply put each point as an argument.
+ * The constructor accepts the coordinates as either a single array or as a set of individual arguments.
+ * If passed an array, the current implementation will use that array internally -- do not attempt to reuse it.
  *
  * When creating a polygon for an entity, each point should be offset or relative from the entities `x` and `y`
  * (don't include the absolute values as it will automatically calculate this).
  *
  *
  * @example
+ * Two ways to create a triangle with vertices at `(50, 0)`, `(100, 100)` and `(0, 100)`.
  * ~~~
- * new Crafty.polygon([50,0],[100,100],[0,100]);
- * new Crafty.polygon([[50,0],[100,100],[0,100]]);
+ * new Crafty.polygon([50, 0, 100, 100, 0, 100]);
+ * new Crafty.polygon(50, 0, 100, 100, 0, 100);
  * ~~~
  */
 Crafty.polygon = function (poly) {
@@ -1134,17 +1134,17 @@ Crafty.polygon.prototype = {
      *
      * @example
      * ~~~
-     * var poly = new Crafty.polygon([50,0],[100,100],[0,100]);
+     * var poly = new Crafty.polygon([50, 0, 100, 100, 0, 100]);
      * poly.containsPoint(50, 50); //TRUE
      * poly.containsPoint(0, 0); //FALSE
      * ~~~
      */
     containsPoint: function (x, y) {
-        var p = this.points,
+        var p = this.points, l = p.length/2,
             i, j, c = false;
 
-        for (i = 0, j = p.length - 1; i < p.length; j = i++) {
-            if (((p[i][1] > y) != (p[j][1] > y)) && (x < (p[j][0] - p[i][0]) * (y - p[i][1]) / (p[j][1] - p[i][1]) + p[i][0])) {
+        for (i = 0, j = l - 1; i < l; j = i++) {
+            if (((p[2*i+1] > y) != (p[2*j+1] > y)) && (x < (p[2*j] - p[2*i]) * (y - p[2*i+1]) / (p[2*j+1] - p[2*i+1]) + p[2*i])) {
                 c = !c;
             }
         }
@@ -1163,35 +1163,32 @@ Crafty.polygon.prototype = {
      *
      * @example
      * ~~~
-     * var poly = new Crafty.polygon([50,0],[100,100],[0,100]);
+     * var poly = new Crafty.polygon([50, 0, 100, 100, 0, 100]);
      * poly.shift(5,5);
-     * //[[55,5], [105,5], [5,105]];
+     * //[[55, 5, 105, 5, 5, 105];
      * ~~~
      */
     shift: function (x, y) {
-        var i = 0,
-            l = this.points.length,
-            current;
-        for (; i < l; i++) {
-            current = this.points[i];
-            current[0] += x;
-            current[1] += y;
+        var i = 0, p =this.points,
+            l = p.length;
+        for (; i < l; i+=2) {
+            p[i] += x;
+            p[i+1] += y;
         }
     },
 
     rotate: function (e) {
-        var i = 0,
-            l = this.points.length,
-            current, x, y;
+        var i = 0, p = this.points,
+            l = p.length,
+            x, y;
 
-        for (; i < l; i++) {
-            current = this.points[i];
+        for (; i < l; i+=2) {
 
-            x = e.o.x + (current[0] - e.o.x) * e.cos + (current[1] - e.o.y) * e.sin;
-            y = e.o.y - (current[0] - e.o.x) * e.sin + (current[1] - e.o.y) * e.cos;
+            x = e.o.x + (p[i] - e.o.x) * e.cos + (p[i+1] - e.o.y) * e.sin;
+            y = e.o.y - (p[i] - e.o.x) * e.sin + (p[i+1] - e.o.y) * e.cos;
 
-            current[0] = x;
-            current[1] = y;
+            p[i] = x;
+            p[i+1] = y;
         }
     }
 };
@@ -1222,9 +1219,10 @@ Crafty.circle = function (x, y, radius) {
     this.points = [];
     var theta;
 
-    for (var i = 0; i < 8; i++) {
-        theta = i * Math.PI / 4;
-        this.points[i] = [this.x + (Math.sin(theta) * radius), this.y + (Math.cos(theta) * radius)];
+    for (var i = 0; i < 16; i+=2) {
+        theta = i * Math.PI / 8;
+        this.points[i] = this.x + (Math.sin(theta) * radius);
+        this.points[i+1] = this.y + (Math.cos(theta) * radius);
     }
 };
 
@@ -1274,13 +1272,12 @@ Crafty.circle.prototype = {
         this.x += x;
         this.y += y;
 
-        var i = 0,
-            l = this.points.length,
+        var i = 0, p = this.points,
+            l = p.length,
             current;
-        for (; i < l; i++) {
-            current = this.points[i];
-            current[0] += x;
-            current[1] += y;
+        for (; i < l; i+=2) {
+            p[i] += x;
+            p[i+1] += y;
         }
     },
 

--- a/src/DebugLayer.js
+++ b/src/DebugLayer.js
@@ -237,8 +237,9 @@ Crafty.c("DebugPolygon", {
 
         ctx = Crafty.DebugCanvas.context;
         ctx.beginPath();
-        for (var p in this.polygon.points) {
-            ctx.lineTo(this.polygon.points[p][0], this.polygon.points[p][1]);
+        var p = this.polygon.points, l = p.length;
+        for (var i=0; i<l; i+=2){
+            ctx.lineTo(p[i], p[i+1]);
         }
         ctx.closePath();
 

--- a/src/controls.js
+++ b/src/controls.js
@@ -454,7 +454,7 @@ Crafty.c("Mouse", {
      *     .color("red")
      *     .attr({ w: 100, h: 100 })
      *     .bind('MouseOver', function() {console.log("over")})
-     *     .areaMap([0,0], [50,0], [50,50], [0,50])
+     *     .areaMap([0, 0, 50, 0, 50, 50, 0, 50) 
      * ~~~
      *
      * @see Crafty.polygon

--- a/tests/2D/collision/collision.js
+++ b/tests/2D/collision/collision.js
@@ -57,11 +57,11 @@
   module("Collision", {
     setup: function() {
       trapezoid = Crafty.e('Trapezoid, 2D, DOM, Collision, SolidHitBox, Mouse, Draggable').setName('Trapezoid').
-        attr({w: 200, h: 100}).collision(new Crafty.polygon([50, 0], [0, 100], [200, 100], [150, 0]));
+        attr({w: 200, h: 100}).collision(new Crafty.polygon([50, 0, 0, 100, 200, 100, 150, 0]));
       yellow = Crafty.e('Yellow, 2D, DOM, Collision, SolidHitBox, Mouse, Draggable').setName('Yellow').
-        attr({w: 100, h: 100}).collision(new Crafty.polygon([0, 0], [0, 100], [100, 100], [100, 0]));
+        attr({w: 100, h: 100}).collision(new Crafty.polygon([0, 0, 0, 100, 100, 100, 100, 0]));
       parallelogram = Crafty.e('Parallelogram, 2D, DOM, Collision, SolidHitBox, Mouse, Draggable').setName('Parallelogram').
-        attr({w: 100, h: 100}).collision(new Crafty.polygon([0, 0], [25, 100], [100, 100], [75, 0]));
+        attr({w: 100, h: 100}).collision(new Crafty.polygon([0, 0, 25, 100, 100, 100, 75, 0]));
       green = Crafty.e('Green, 2D, DOM, Collision, Color, Mouse, Draggable').setName('Green').
         attr({w: 100, h: 100}).color('rgb(47, 233, 87)').origin('center');
       purple = Crafty.e('Purple, 2D, DOM, Collision, Color, Mouse, Draggable').setName('Purple').
@@ -155,7 +155,6 @@
 
     collision = collisions[0];
     if (!collision) return;
-
     equal(collision[1][0].type, 'SAT', "The collision type should have been SAT");
     equal(Math.abs(collision[1][0].overlap), 100, "The collision overlap should have been 100%");
   });

--- a/tests/2D/collision/sat.js
+++ b/tests/2D/collision/sat.js
@@ -1,0 +1,123 @@
+(function() {
+  module("_SAT");
+
+  test("simple overlap along x axis", function() {
+    var e = Crafty.e("2D, Collision");
+    var poly1 = new Crafty.polygon([0,0, 0,3, 3,3, 3,0]);
+    var poly2 = new Crafty.polygon([2,0, 2,3, 5,3, 5,0]);
+
+    // order 1
+    var o = e._SAT(poly1, poly2);
+    notStrictEqual(o, false, "Overlap exists");
+    equal(o.overlap, -1, "Overlap by 1 unit");
+    equal(o.normal.x, -1, "normal.x is -1");
+    equal(o.normal.y, 0, "normal.y is 0");
+    
+    // order 2
+    o = e._SAT(poly2, poly1);
+    notStrictEqual(o, false, "Overlap exists");
+    equal(o.overlap, -1, "Overlap by 1 unit");
+    equal(o.normal.x, 1, "normal.x is 1");
+    equal(o.normal.y, 0, "normal.y is 0");
+
+  });
+
+  test("simple overlap along y axis", function() {
+    var e = Crafty.e("2D, Collision");
+    var poly1 = new Crafty.polygon([0,0, 0,3, 3,3, 3,0]);
+    var poly2 = new Crafty.polygon([0,2, 0,5, 3,5, 3,2]);
+    var o = e._SAT(poly1, poly2);
+    notStrictEqual(o, false, "Overlap exists");
+    equal(o.overlap, -1, "Overlap by 1 unit");
+    equal(o.normal.y, -1, "normal.y is -1");
+    equal(o.normal.x, 0, "normal.x is 0");
+    
+    // order 2
+    o = e._SAT(poly2, poly1);
+    notStrictEqual(o, false, "Overlap exists");
+    equal(o.overlap, -1, "Overlap by 1 unit");
+    equal(o.normal.y, 1, "normal.y is 1");
+    equal(o.normal.x, 0, "normal.x is 0");
+
+  });
+
+
+
+  test("overlap smaller along x axis", function() {
+    var e = Crafty.e("2D, Collision");
+    var poly1 = new Crafty.polygon([0,0, 0,3, 3,3, 3,0]);
+    var poly2 = new Crafty.polygon([2,1, 2,4, 5,4, 5,1]);
+    var o = e._SAT(poly1, poly2);
+    notStrictEqual(o, false, "Overlap exists");
+    equal(o.overlap, -1, "Overlap by 1 unit");
+    equal(o.normal.x, -1, "normal.x is -1");
+    equal(o.normal.y, 0, "normal.y is 0");
+    
+    // order 2
+    o = e._SAT(poly2, poly1);
+    notStrictEqual(o, false, "Overlap exists");
+    equal(o.overlap, -1, "Overlap by 1 unit");
+    equal(o.normal.x, 1, "normal.x is 1");
+    equal(o.normal.y, 0, "normal.y is 0");
+
+  });
+
+  test("overlap smaller along y axis", function() {
+    var e = Crafty.e("2D, Collision");
+    var poly1 = new Crafty.polygon([0,0, 0,3, 3,3, 3,0]);
+    var poly2 = new Crafty.polygon([1,2, 1,5, 4,5, 4,2]);
+    var o = e._SAT(poly1, poly2);
+    notStrictEqual(o, false, "Overlap exists");
+    equal(o.overlap, -1, "Overlap by 1 unit");
+    equal(o.normal.y, -1, "normal.y is -1");
+    equal(o.normal.x, 0, "normal.x is 0");
+
+    // order 2
+    o = e._SAT(poly2, poly1);
+    notStrictEqual(o, false, "Overlap exists");
+    equal(o.overlap, -1, "Overlap by 1 unit");
+    equal(o.normal.y, 1, "normal.y is 1");
+    equal(o.normal.x, 0, "normal.x is 0");
+  });
+
+  test("overlap with non parallel faces, but axis-aligned normal", function(){
+    var e = Crafty.e("2D, Collision");
+    var poly1 = new Crafty.polygon([0,0, 0,3, 3,3, 3,0]);
+    var poly2 = new Crafty.polygon([2,2, 4,4, 6,2, 4,0]);
+    var o = e._SAT(poly1, poly2);
+    notStrictEqual(o, false, "Overlap exists");
+    equal(o.overlap, -1, "Overlap by 1 unit");
+    equal(o.normal.x, -1, "normal.x is -1");
+    equal(o.normal.y, 0, "normal.x is 0");
+
+    // order 2
+    o = e._SAT(poly2, poly1);
+    notStrictEqual(o, false, "Overlap exists");
+    equal(o.overlap, -1, "Overlap by 1 unit");
+    equal(o.normal.x, 1, "normal.x is 1");
+    equal(o.normal.y, 0, "normal.x is 0");
+  });
+
+  test("overlap with non parallel faces, non-axis-aligned normal", function(){
+    var e = Crafty.e("2D, Collision");
+    var poly1 = new Crafty.polygon([0,0, 0,3, 3,3, 3,0]);
+    var poly2 = new Crafty.polygon([1,4, 4,4, 4,1]);
+    function is_inverse_sqrt2(x){
+      return (x > 0.707) && (x < 0.708);
+    }
+    
+    var o = e._SAT(poly1, poly2);
+    notStrictEqual(o, false, "Overlap exists");
+    ok(is_inverse_sqrt2(-o.overlap), "Overlap by 1/sqrt(2)");
+    ok( is_inverse_sqrt2(-o.normal.x), "normal.x is -1/sqrt(2)");
+    ok( is_inverse_sqrt2(-o.normal.y), "normal.y is -1/sqrt(2)");
+
+
+    // order 2
+    o = e._SAT(poly2, poly1);
+    notStrictEqual(o, false, "Overlap exists");
+    ok(is_inverse_sqrt2(-o.overlap), "Overlap by 1/sqrt(2)");
+    ok( is_inverse_sqrt2(o.normal.x), "normal.x is +1/sqrt(2)");
+    ok( is_inverse_sqrt2(o.normal.y), "normal.y is +1/sqrt(2)");
+  });
+})();

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -266,8 +266,8 @@
   // Testcase from issue #828 by VHonzik
   test("SAT overlap with rectangles", function() {
     var e = Crafty.e("2D, Collision");
-    var c1 = new Crafty.polygon([[0,1], [50, 1], [50, 51], [0, 51]]);
-    var c2 = new Crafty.polygon([[-10, -10], [-10, 10], [10, 10], [10, -10]]);
+    var c1 = new Crafty.polygon([0,1, 50, 1, 50, 51, 0, 51]);
+    var c2 = new Crafty.polygon([-10, -10, -10, 10, 10, 10, 10, -10]);
     strictEqual(e._SAT(c1, c2) !== false, true, "Polygons should test as overlapping");
 
   });
@@ -365,17 +365,17 @@
       h: 50
     });
 
-    equal(e.map.points[0][0], 0, "Before rotation: x_0 is 0");
-    equal(e.map.points[0][1], 0, "y_0 is 0");
-    equal(e.map.points[2][0], 40, "x_2 is 40");
-    equal(e.map.points[2][1], 50, "y_2 is 50");
+    equal(e.map.points[0], 0, "Before rotation: x_0 is 0");
+    equal(e.map.points[1], 0, "y_0 is 0");
+    equal(e.map.points[4], 40, "x_2 is 40");
+    equal(e.map.points[5], 50, "y_2 is 50");
 
     e.rotation = 90;
 
-    equal(Math.round(e.map.points[0][0]), 0, "After rotation by 90 deg: x_0 is 0");
-    equal(Math.round(e.map.points[0][1]), 0, "y_0 is 0");
-    equal(Math.round(e.map.points[2][0]), -50, "x_2 is -50");
-    equal(Math.round(e.map.points[2][1]), 40, "y_2 is 40");
+    equal(Math.round(e.map.points[0]), 0, "After rotation by 90 deg: x_0 is 0");
+    equal(Math.round(e.map.points[1]), 0, "y_0 is 0");
+    equal(Math.round(e.map.points[4]), -50, "x_2 is -50");
+    equal(Math.round(e.map.points[5]), 40, "y_2 is 40");
 
     // After rotation the MBR will have changed
     equal(Math.round(e._mbr._w), 50, "_mbr._w is  50");
@@ -385,20 +385,20 @@
 
     e.collision(); // Check that regenerating the hitbox while rotated works correctly
 
-    equal(Math.round(e.map.points[0][0]), 0, "After rotation and hitbox regeneration: x_0 is 0");
-    equal(Math.round(e.map.points[0][1]), 0, "y_0 is 0");
-    equal(Math.round(e.map.points[2][0]), -50, "x_2 is -50");
-    equal(Math.round(e.map.points[2][1]), 40, "y_2 is 40");
+    equal(Math.round(e.map.points[0]), 0, "After rotation and hitbox regeneration: x_0 is 0");
+    equal(Math.round(e.map.points[1]), 0, "y_0 is 0");
+    equal(Math.round(e.map.points[4]), -50, "x_2 is -50");
+    equal(Math.round(e.map.points[5]), 40, "y_2 is 40");
 
 
     // Check that changing the width when rotated resizes correctly for both hitbox and MBR
     // Rotated by 90 degrees, changing the width of the entity should change the height of the hitbox/mbr
     e.w = 100;
 
-    equal(Math.round(e.map.points[0][0]), 0, "After rotation and increase in width: x_0 is 0");
-    equal(Math.round(e.map.points[0][1]), 0, "y_0 is 0");
-    equal(Math.round(e.map.points[2][0]), -50, "x_2 is -50");
-    equal(Math.round(e.map.points[2][1]), 100, "y_2 is 100");
+    equal(Math.round(e.map.points[0]), 0, "After rotation and increase in width: x_0 is 0");
+    equal(Math.round(e.map.points[1]), 0, "y_0 is 0");
+    equal(Math.round(e.map.points[4]), -50, "x_2 is -50");
+    equal(Math.round(e.map.points[5]), 100, "y_2 is 100");
 
     // After rotation the MBR will have changed
     equal(Math.round(e._mbr._w), 50, "_mbr._w is  50");
@@ -411,11 +411,11 @@
 
   test("Hitboxes outside of entities (CBR)", function() {
     var poly = new Crafty.polygon([
-      [-8, 6],
-      [0, -8],
-      [8, -14],
-      [16, -8],
-      [24, 6]
+      -8, 6,
+      0, -8,
+      8, -14,
+      16, -8,
+      24, 6
     ]);
 
     var e = Crafty.e("2D, Collision").attr({
@@ -446,10 +446,10 @@
 
   test("CBRs on resize", function() {
     var poly = new Crafty.polygon([
-      [0, 0],
-      [0, 12],
-      [12, 12],
-      [12, 0]
+      0, 0,
+      0, 12,
+      12, 12,
+      12, 0
     ]);
 
     var e = Crafty.e("2D, Collision").attr({
@@ -473,10 +473,10 @@
 
   test("CBRs should be removed on removal of component", function() {
     var poly = new Crafty.polygon([
-      [0, 0],
-      [0, 12],
-      [12, 12],
-      [12, 0]
+      0, 0,
+      0, 12,
+      12, 12,
+      12, 0
     ]);
 
     var e = Crafty.e("2D, Collision").attr({

--- a/tests/core.js
+++ b/tests/core.js
@@ -468,8 +468,8 @@
       h: 20
     }).collision();
     e.matchHitBox(); // only necessary until collision works properly!
-    equal(e.polygon.points[0][0], 10, "WiredHitBox -- correct x coord for upper right corner");
-    equal(e.polygon.points[2][1], 30, "correct y coord for lower right corner");
+    equal(e.polygon.points[0], 10, "WiredHitBox -- correct x coord for upper right corner");
+    equal(e.polygon.points[5], 30, "correct y coord for lower right corner");
     notEqual(typeof e._debug.strokeStyle, "undefined", "stroke style is assigned");
     equal(typeof e._debug.fillStyle, "undefined", "fill style is undefined");
 
@@ -482,14 +482,14 @@
       h: 20
     }).collision();
     e2.matchHitBox(); // only necessary until collision works properly!
-    equal(e2.polygon.points[0][0], 10, "SolidHitBox -- correct x coord for upper right corner");
-    equal(e2.polygon.points[2][1], 30, "correct y coord for lower right corner");
+    equal(e2.polygon.points[0], 10, "SolidHitBox -- correct x coord for upper right corner");
+    equal(e2.polygon.points[5], 30, "correct y coord for lower right corner");
     equal(typeof e2._debug.strokeStyle, "undefined", "stroke style is undefined");
     notEqual(typeof e2._debug.fillStyle, "undefined", "fill style is assigned");
 
-    e2.collision(new Crafty.polygon([0, 0], [15, 0], [0, 15]));
+    e2.collision(new Crafty.polygon([0, 0, 15, 0, 0, 15]));
     e2.matchHitBox();
-    equal(e2.polygon.points[2][1], 25, "After change -- correct y coord for third point");
+    equal(e2.polygon.points[5], 25, "After change -- correct y coord for third point");
 
     e2.destroy();
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -65,5 +65,6 @@
     <script type="text/javascript" src="./2D/collision/collision.js"></script>
     <script type="text/javascript" src="./issue746/pos.js"></script>
     <script type="text/javascript" src="./issue746/mbr.js"></script>
+    <script type="text/javascript" src="./2D/collision/sat.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Our current implementation of the SAT (Separating Axis Theorem) algorithm is both a bit slow and somewhat incorrect.

To improve the speed, this patch changes the behavior of Crafty.polygon to store points as a single flat array, rather than an array of smaller arrays.  This is a breaking change -- code that interacts with this (e.g. by creating collision regions) will have to be modified.  I'm pretty sure it's worth it, though.  Doing some jsperf tests indicates that dealing with a single array is much faster.

This patch also prevents the creation of temporary objects within each step of the SAT algorithm, which also increases the speed a bit.

The algorithm also seemed somewhat incorrect; it calculated the minimal overlap for each edge of each polygon, but never actually did anything with the first result.  This doesn't matter when dealing with simple rectangles, which is probably why this went unnoticed til now.

I added some tests to make sure our _SAT behavior isn't broken in the future.
