### PR TITLE
Add/remove Sprite components sometimes fails to change background-image

### DIFF
--- a/src/sprite.js
+++ b/src/sprite.js
@@ -193,9 +193,12 @@ Crafty.c("Sprite", {
                 // If needed, we will scale up the entire sprite sheet, and then modify the position accordingly
                 var vscale = this._h / co.h,
                     hscale = this._w / co.w,
-                    style = this._element.style;
+                    style = this._element.style,
+                    bgColor = style.backgroundColor;
 
-                style.background = style.backgroundColor + " url('" + this.__image + "') no-repeat";
+                if (bgColor === "initial") bgColor = "";
+
+                style.background = bgColor + " url('" + this.__image + "') no-repeat";
                 style.backgroundPosition = "-" + co.x * hscale + "px -" + co.y * vscale + "px";
                 // style.backgroundSize must be set AFTER style.background!
                 if (vscale != 1 || hscale != 1) {


### PR DESCRIPTION
When switching between two Sprite components that use different background
images, the second background-image fails to get set properly.

This happens because style.backgroundColor is an invalid value when trying to switch to the second component (it is "initial").
