### PR TITLE
report error if scene does not exist

### DIFF
--- a/src/scenes.js
+++ b/src/scenes.js
@@ -154,7 +154,12 @@ Crafty.extend({
             oldScene: oldScene,
             newScene: name
         });
-        this._scenes[name].initialize.call(this, data);
+           
+        if (this._scenes.hasOwnProperty(name)) {
+            this._scenes[name].initialize.call(this, data);
+        } else {
+            console.error('The scene "' + name + '" does not exist');
+        }
 
         return;
 


### PR DESCRIPTION
The error for borking a scene name was a bit misleading. Its not that hard to correlate, but a more direct message should help people new to crafty like me, with our typos. :)

```
Uncaught TypeError: Cannot read property 'initialize' of undefined
```

error reproduced here: http://jsfiddle.net/z3bbzehv/
