### PR TITLE
Make mobile act more like standard mode

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -622,15 +622,13 @@ Crafty.extend({
                 });
 
 
-            } else {
-                elem.position = "relative";
-                //find out the offset position of the stage
-                offset = Crafty.DOM.inner(Crafty.stage.elem);
-                Crafty.stage.x = offset.x;
-                Crafty.stage.y = offset.y;
             }
-
             
+            elem.position = "relative";
+            //find out the offset position of the stage
+            offset = Crafty.DOM.inner(Crafty.stage.elem);
+            Crafty.stage.x = offset.x;
+            Crafty.stage.y = offset.y;
         },
 
         // Create setters/getters for x, y, width, height


### PR DESCRIPTION
Currently we don't handle the offset and positioning of cr-stage on mobile the same way we do in regular/desktop mode.  As far as I can see there's no actual reason for this.  (Perhaps it's a legacy from when mobile was forced into fullscreen mode?)

This patch handles the offset/position regardless of whether we're on mobile or not.  This fixes some graphical issues with Chrome/Firefox on Android, but I don't have an iOS device handy to test.  It should hopefully also fix an issue with touche coordinates being registered incorrectly.
