### PR TITLE
Multiway with disableControl movement change

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -706,7 +706,7 @@ Crafty.c("Multiway", {
     _speed: 3,
 
     _keydown: function (e) {
-        if (this._keys[e.key]) {
+        if (this._keys[e.key] && !this.disableControls) {
             this._movement.x = Math.round((this._movement.x + this._keys[e.key].x) * 1000) / 1000;
             this._movement.y = Math.round((this._movement.y + this._keys[e.key].y) * 1000) / 1000;
             this.trigger('NewDirection', this._movement);
@@ -714,7 +714,7 @@ Crafty.c("Multiway", {
     },
 
     _keyup: function (e) {
-        if (this._keys[e.key]) {
+        if (this._keys[e.key] && !this.disableControls) {
             this._movement.x = Math.round((this._movement.x - this._keys[e.key].x) * 1000) / 1000;
             this._movement.y = Math.round((this._movement.y - this._keys[e.key].y) * 1000) / 1000;
             this.trigger('NewDirection', this._movement);
@@ -839,6 +839,8 @@ Crafty.c("Multiway", {
      */
 
     disableControl: function () {
+		this._movement.x = 0;
+		this._movement.y = 0;
         this.disableControls = true;
         return this;
     },

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -323,7 +323,7 @@
 
     e.disableControl();
     Crafty.trigger('EnterFrame');
-    equal(e._movement.x, 1);
+    equal(e._movement.x, 0);
     equal(e._x, 1);
 
     Crafty.trigger('KeyUp', {


### PR DESCRIPTION
`Multiway` component `_movement.x` and `_movement.y` are no longer updated in `_keydown` and `_keyup` methods when `disabledControls` is `true`. Additionally these `_movement` attributes are reset to zero in `disableControl`. 

Updated "disableControl and enableControl" test to reflect the change. 

Fixes issue #842
