### PR TITLE
implemented multitouch

### DIFF
--- a/tests/controls.js
+++ b/tests/controls.js
@@ -1,0 +1,72 @@
+(function() {
+  module('Controls');
+  
+  // mock-phantom-touch-events is a PhantomJS plugin, thus the test below is skipped if enviroment is not PhantomJS
+  if (navigator.userAgent.indexOf("PhantomJS") !== -1)
+    test('Multitouch simulation', function() {
+      Crafty.multitouch(true);
+      
+      var touchStartsOverEntities = 0,
+          touchEndsOverEntities = 0,
+          entity1 = Crafty.e('2D, Canvas, Color, Touch')
+              .attr({ x: 100, y: 100, w:200, h:200, z:1 })
+              .color('black')
+              .bind('TouchStart',function(){ 
+                  touchStartsOverEntities++;
+              })
+              .bind('TouchEnd',function(){ 
+                  touchEndsOverEntities++;
+              }),
+          entity2 = Crafty.e('2D, Canvas, Color, Touch')
+              .attr({ x: 40, y: 150, w:90, h:300, z:2 })
+              .color('green')
+              .bind('TouchStart',function(){ 
+                  touchStartsOverEntities++;
+              })
+              .bind('TouchEnd',function(){ 
+                  touchEndsOverEntities++;
+              }),
+         elem = Crafty.stage.elem,
+         sx = Crafty.stage.x,
+         sy = Crafty.stage.y,
+         touchStart1 = createTouchEvent(elem, "touchstart", [[100 + sx, 80 + sy, 0], [150 + sx, 150 + sy, 1], [200 + sx, 50 + sy, 2], [65 + sx, 275 + sy, 3]]),
+         touchEnd1 = createTouchEvent(elem, "touchend", [[65 + sx, 275 + sy, 3]]),
+         touchEnd2 = createTouchEvent(elem, "touchend", [[200 + sx, 50 + sy, 2]]),
+         touchStart2 = createTouchEvent(elem, "touchstart", [[100 + sx, 80 + sy, 4]]),
+         touchEnd3 = createTouchEvent(elem, "touchend", [[150 + sx, 150 + sy, 1]]),
+         touchEnd4 = createTouchEvent(elem, "touchend", [[100 + sx, 80 + sy, 0]]),
+         touchEnd5 = createTouchEvent(elem, "touchend", [[100 + sx, 80 + sy, 4]]);
+    
+      elem.addEventListener("touchstart", function(e){ Crafty.touchDispatch(e); });
+      elem.addEventListener("touchend", function(e){ Crafty.touchDispatch(e); });
+
+      touchStart1();
+    
+      equal(Crafty._touchHandler.fingers.length, 4, "Four fingers currently touching stage");
+    
+      touchEnd1();
+
+      equal(Crafty._touchHandler.fingers.length, 3, "Three fingers currently touching stage");
+    
+      touchEnd2();
+      touchStart2();
+      
+      equal(Crafty._touchHandler.fingers.length, 3, "Three fingers currently touching stage");
+    
+      touchEnd3();
+    
+      equal(Crafty._touchHandler.fingers.length, 2, "Two fingers currently touching stage");
+
+      touchEnd4();
+      
+      equal(Crafty._touchHandler.fingers.length, 1, "One finger currently touching stage");
+
+      touchEnd5();
+    
+      equal(Crafty._touchHandler.fingers.length, 0, "No fingers currently touching stage");
+      
+      equal(touchStartsOverEntities, 2, "Two entities recieved TouchStart");
+      equal(touchEndsOverEntities, 2, "Two entities recieved TouchEnd");
+    });
+    
+})();

--- a/tests/index.html
+++ b/tests/index.html
@@ -24,6 +24,7 @@
     <script type="text/javascript" src="./lib/qunit.js"></script>
     <script type="text/javascript" src="./lib/modernizr-2.7.1.min.js"></script>
     <script type="text/javascript" src="./lib/helperFunctions.js"></script>
+    <script type="text/javascript" src="./plugins/mockTouchEvents.js"></script>
 
 
 
@@ -50,6 +51,7 @@
     <script type="text/javascript" src="./core.js"></script>
     <script type="text/javascript" src="./2d.js"></script>
     <script type="text/javascript" src="./audio.js"></script>
+    <script type="text/javascript" src="./controls.js"></script>
     <script type="text/javascript" src="./dom.js"></script>
     <script type="text/javascript" src="./events.js"></script>
     <script type="text/javascript" src="./isometric.js"></script>

--- a/tests/plugins/mockTouchEvents.js
+++ b/tests/plugins/mockTouchEvents.js
@@ -1,0 +1,264 @@
+/* This is a modified version of mock-phantom-touch-events.
+ * 
+ * The original mock-phantom-touch-events can be found at https://github.com/gardr/mock-phantom-touch-events
+ * 
+ * mock-phantom-touch-events is licensed under:
+ * 
+ * The MIT License (MIT)
+ * Copyright (c) 2013 FINN.no AS
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * 
+ */
+
+function computedStyle(el, prop) {
+    return (
+        window.getComputedStyle ? window.getComputedStyle(el) : el.currentStyle
+    )[prop.replace(/-(\w)/gi, function (word, letter) {
+        return letter.toUpperCase();
+    })];
+}
+
+function getChildrenSize(container) {
+    if (!container) {
+        return;
+    }
+    var children = [].slice.call(container.children, 0).filter(function (el) {
+        var pos = computedStyle(el, 'position');
+        el.rect = el.getBoundingClientRect(); // store rect for later
+        return !(
+            (pos === 'absolute' || pos === 'fixed') ||
+            (el.rect.width === 0 && el.rect.height === 0)
+        );
+    });
+    if (children.length === 0) {
+        return {
+            width: 0,
+            height: 0
+        };
+    }
+
+    var totRect = children.reduce(function (tot, el) {
+        return (!tot ?
+            el.rect : {
+                top: Math.min(tot.top, el.rect.top),
+                left: Math.min(tot.left, el.rect.left),
+                right: Math.max(tot.right, el.rect.right),
+                bottom: Math.max(tot.bottom, el.rect.bottom)
+            });
+    }, null);
+
+    return {
+        width: totRect.right - totRect.left,
+        height: totRect.bottom - totRect.top
+    };
+}
+
+/*
+    list can be either [[x, y], [x, y]] or [x, y]
+*/
+function createTouchList(target, list) {
+    if (Array.isArray(list) && list[0] && !Array.isArray(list[0])) {
+        list = [list];
+    }
+    list = list.map(function (entry, index) {
+        var x = entry[0], y = entry[1], id = entry[2] ? entry[2] : index + 1;
+        return createTouch(x, y, target, id);
+    });
+    return document.createTouchList.apply(document, list);
+}
+
+function createTouch(x, y, target, id) {
+    return document.createTouch(window, target,
+        //identifier
+        id || 1,
+        //pageX / clientX
+        x,
+        //pageY / clientY
+        y,
+        //screenX
+        x,
+        //screenY
+        y
+    );
+}
+
+//http://stackoverflow.com/questions/7056026/variation-of-e-touches-e-targettouches-and-e-changedtouches
+function initTouchEvent(touchEvent, type, touches) {
+    var touch1 = touches[0];
+    return touchEvent.initTouchEvent(
+        //touches
+        touches,
+        //targetTouches
+        touches,
+        //changedTouches
+        touches,
+        //type
+        type,
+        //view
+        window,
+        //screenX
+        touch1.screenX,
+        //screenY
+        touch1.screenY,
+        //clientX
+        touch1.clientX,
+        //clientY
+        touch1.clientY,
+        //ctrlKey
+        false,
+        //altKey
+        false,
+        //shiftKey
+        false,
+        //metaKey
+        false
+    );
+}
+
+function createTouchEvent(elem, type, touches) {
+    var touchEvent = document.createEvent('TouchEvent');
+    if (Array.isArray(touches)) {
+        touches = createTouchList(elem, touches);
+    }
+
+    function dispatch(getEvent) {
+        initTouchEvent(touchEvent, type, touches);
+        if (typeof getEvent === 'function'){
+            getEvent.call(elem, touchEvent, elem);
+        }
+        elem.dispatchEvent(touchEvent);
+    }
+    dispatch.event = touchEvent;
+    return dispatch;
+}
+
+function apply(fn, arg, args) {
+    return fn.apply(null, [arg].concat(Array.prototype.slice.call(args)));
+}
+
+function swipeLeft() {
+    return apply(swipe, 'left', arguments);
+}
+
+function swipeRight() {
+    return apply(swipe, 'right', arguments);
+}
+
+function swipeTop(){
+    return apply(swipe, 'top', arguments);
+}
+
+function swipeBottom(){
+    return apply(swipe, 'bottom', arguments);
+}
+
+function round(num){
+    return Math.round(num);
+}
+
+var HORIZONTAL_OFFSET = 45;
+var VERTICAL_OFFSET = 10;
+function swipe(direction, elem, ms, frames, getEvent) {
+    var elemSize = getChildrenSize(elem.parentNode);
+
+    var x;
+    var y;
+    var from;
+    var to;
+    var isVertical = direction === 'top' || direction === 'bottom';
+    if (isVertical){
+        y = elemSize.height;
+        x = elemSize.width / 2;
+
+        from = [x*0.95, VERTICAL_OFFSET].map(round);
+        to   = [x*1.01, y-VERTICAL_OFFSET].map(round);
+    } else {
+        // horizontal
+        x = elemSize.width;
+        y = elemSize.height / 2;
+        from = [HORIZONTAL_OFFSET, y*0.98].map(round);
+        to   = [x - HORIZONTAL_OFFSET, y*1.01].map(round);
+    }
+
+    if (direction === 'right' || direction === 'top') {
+        touchActionSequence(elem, from, to, ms, frames, getEvent);
+    } else {
+        touchActionSequence(elem, to, from, ms, frames, getEvent);
+    }
+}
+
+function getDiff(fromList, toList){
+    return [
+        toList[0] - fromList[0],
+        toList[1] - fromList[1]
+    ];
+}
+
+function getXandYFrame(startPoint, diffToWalk, currentProgress){
+    return [
+        Math.round(
+            Math.abs(
+                startPoint[0] + (diffToWalk[0] * currentProgress))),
+        Math.round(
+            Math.abs(
+                startPoint[1] + (diffToWalk[1] * currentProgress)))
+    ];
+}
+
+function touchActionSequence(elem, fromXandY, toXandY, ms, frames, getEvent) {
+    frames       = frames || 10;
+    ms           = Math.round((ms||1000) / frames);
+    // lets find difference from start to end and divide on frames
+    var diff     = getDiff(fromXandY, toXandY);
+    var counter  = frames;
+    var pos             = getXandYFrame(fromXandY, diff, counter/frames);
+    var targetElement;
+
+    targetElement   = document.elementFromPoint(pos[0], pos[1]);
+
+    setTimeout(function handler() {
+        counter--;
+        if (counter) {
+            pos = getXandYFrame(fromXandY, diff, counter/frames);
+            targetElement = document.elementFromPoint(pos[0], pos[1]);
+            createTouchEvent(targetElement||elem, 'touchmove', pos)(getEvent);
+            setTimeout(handler, ms);
+        } else {
+            createTouchEvent(targetElement||elem, 'touchend', [[0, 0]])(getEvent);
+        }
+    }, ms);
+    createTouchEvent(targetElement||elem, 'touchstart', pos)(getEvent);
+}
+
+function factory(){
+    return {
+        _apply: apply,
+        _getXandYFrame: getXandYFrame,
+        _getDiff: getDiff,
+        swipeLeft: swipeLeft,
+        swipeRight: swipeRight,
+        swipeTop: swipeTop,
+        swipeBottom: swipeBottom,
+        touchActionSequence: touchActionSequence,
+        createTouchEvent: createTouchEvent
+    };
+}
+
+if (typeof module !== 'undefined' && module.exports){
+    module.exports = factory();
+} else {
+    window.mockPhantomTouchEvents = factory();
+}


### PR DESCRIPTION
This PR implements basic multitouch functionality. The downside is it breaks intercompatibility with mouse dependent components (but they still work with Mouse ofc), although I believe this can be addressed without any hassles.

The **Touch** component enables (through **Crafty.touchDispatch**) detection of the events "TouchStart", "TouchMove", "TouchEnd" and "TouchCancel". "TouchLeave" events are treated as "TouchEnd"s. These basic events allow for implementing more complex events, like swipe, drag or (with some "juggling") pinch.

This PR does not support multitouch over the same entity. That is, if the same entity is touched by two or more fingers at the same time, only the last finger will be valid.

The changes in this PR include:
1. Refactored **Crafty.touchDispatch**;
2. **Crafty.touchDispatch** sends "TouchStart", "TouchMove", "TouchEnd" and "TouchCancel" events;
3. Added **Crafty.fingers** array, which keeps track of currently touching fingers;
4. Added **Touch** component;
5. Added **AreaMap** component, which is used by Mouse and Touch;
6. Added **Button** component, which just selects either Mouse or Touch for an entity based on device;
7. Added **Crafty.findClosestEntityByComponent**  function, which is used internally by Mouse and Touch.
8. Altered **Crafty.mouseDispatch** to use **Crafty.findClosestEntityByComponent**
