### PR TITLE
Allow alternate easing functions

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -134,10 +134,11 @@ Crafty.extend({
 
          * #Crafty.viewport.pan
          * @comp Crafty.viewport
-         * @sign public void Crafty.viewport.pan(Number dx, Number dy, Number time)
+         * @sign public void Crafty.viewport.pan(Number dx, Number dy, Number time[, String|function easingFn])
          * @param Number dx - The distance along the x axis
          * @param Number dy - The distance along the y axis
          * @param Number time - The duration in ms for the entire camera movement
+         * @param easingFn - A string or custom function specifying an easing.  (Defaults to linear behavior.)  See Crafty.easing for more information.
          *
          * Pans the camera a given number of pixels over the specified time
          */
@@ -164,7 +165,7 @@ Crafty.extend({
 
             Crafty.bind("StopCamera", stopPan);
 
-            return function (dx, dy, time) {
+            return function (dx, dy, time, easingFn) {
                 // Cancel any current camera control
                 Crafty.trigger("StopCamera");
 
@@ -178,7 +179,7 @@ Crafty.extend({
                 targetX = startingX - dx;
                 targetY = startingY - dy;
 
-                easing = new Crafty.easing(time);
+                easing = new Crafty.easing(time, easingFn);
 
                 // bind to event, using uniqueBind prevents multiple copies from being bound
                 Crafty.uniqueBind("EnterFrame", enterFrame);
@@ -258,11 +259,12 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.zoom
          * @comp Crafty.viewport
-         * @sign public void Crafty.viewport.zoom(Number amt, Number cent_x, Number cent_y, Number time)
+         * @sign public void Crafty.viewport.zoom(Number amt, Number cent_x, Number cent_y, Number time[, String|function easingFn])
          * @param Number amt - amount to zoom in on the target by (eg. 2, 4, 0.5)
          * @param Number cent_x - the center to zoom on
          * @param Number cent_y - the center to zoom on
          * @param Number time - the duration in ms of the entire zoom operation
+         * @param easingFn - A string or custom function specifying an easing.  (Defaults to linear behavior.)  See Crafty.easing for more information.
          *
          * Zooms the camera in on a given point. amt > 1 will bring the camera closer to the subject
          * amt < 1 will bring it farther away. amt = 0 will reset to the default zoom level
@@ -314,7 +316,7 @@ Crafty.extend({
 
             }
 
-            return function (amt, cent_x, cent_y, time){
+            return function (amt, cent_x, cent_y, time, easingFn){
                 if (!amt) { // we're resetting to defaults
                     Crafty.viewport.scale(1);
                     return;
@@ -337,7 +339,7 @@ Crafty.extend({
                 finalX = - (cent_x - Crafty.viewport.width  / (2 * finalZoom) );
                 finalY = - (cent_y - Crafty.viewport.height / (2 * finalZoom) );
 
-                easing = new Crafty.easing(time);
+                easing = new Crafty.easing(time, easingFn);
 
                 Crafty.uniqueBind("EnterFrame", enterFrame);
             };

--- a/tests/core.js
+++ b/tests/core.js
@@ -514,6 +514,27 @@
     equal(e.value(), 1, "Remains 1 after completion");
   });
 
+  test("Crafty.easing with custom function", function() {
+    var e = new Crafty.easing(80, function(t){return t*t;}) ; // 4 frames == 80ms by default
+    e.tick(20);
+    e.tick(20);
+    equal(e.value(), 0.25, ".25 after two steps");
+    e.tick(20);
+    e.tick(20);
+    equal(e.value(), 1, "1 after completed");
+  });
+
+  test("Crafty.easing with built-in smoothStep function", function() {
+    var e = new Crafty.easing(80, "smoothStep"); // 4 frames == 80ms by default
+    e.tick(20);
+    equal(e.value(), 0.15625, "0.15625 after one step");
+    e.tick(20);
+    equal(e.value(), 0.5, ".5 after two steps");
+    e.tick(20);
+    e.tick(20);
+    equal(e.value(), 1, "1 after completed");
+  });
+
   test('Get', function() {
     var fox;
     Crafty.c('Animal', {

--- a/tests/stage.js
+++ b/tests/stage.js
@@ -118,6 +118,27 @@
     Crafty.viewport.scroll('y', 0);
   });
 
+  test("pan with easing", function() {
+    Crafty.viewport.clampToEntities = false;
+    Crafty.e("2D, DOM").attr({
+      x: 0,
+      y: 0,
+      w: Crafty.viewport.width * 2,
+      h: Crafty.viewport.height * 2
+    });
+
+  
+
+    Crafty.viewport.pan(100, 0, 10 * 20, "easeInQuad");
+    Crafty.timer.simulateFrames(5);
+    equal(Crafty.viewport._x, -25, "Pan quarter of the way on half the time");
+    Crafty.timer.simulateFrames(5);
+    equal(Crafty.viewport._x, -100, "Pan all the way when all the time is spent");
+
+    Crafty.viewport.scroll('x', 0);
+    Crafty.viewport.scroll('y', 0);
+  });
+
   test("zoom", function() {
 
     Crafty.viewport.clampToEntities = false;

--- a/tests/tween.js
+++ b/tests/tween.js
@@ -17,6 +17,19 @@
     equal(e.x, 10, "Fully tweened x");
     equal(e.y, 16, "Fully tweened y");
   });
+
+  test("Tween with quadratic easing function", function() {
+    var e = Crafty.e("2D, Tween");
+    e.x = 0;
+    var ret = e.tween({
+      x: 16
+    }, 200, function(t){return (t*t);}); // 10 frames == 200 ms by efault
+    Crafty.timer.simulateFrames(5);
+    equal(Round(e.x), 4, "At halfway point, x is a quarter of original value");
+    Crafty.timer.simulateFrames(10);
+    equal(e.x, 16, "Fully tweened x");
+  });
+
   asyncTest('correct tweening', function() {
     expect(1);
 


### PR DESCRIPTION
This allows you to specify alternate easing functions, either by giving the name of a built-in function (such as "smoothStep" or "easeInOutQuad"), or by directly passing a function.  Omitting the function defaults to linear behavior.

Currently there's a very limited selection of built-in functions, but it's trivial to add more!

The base functionality is implemented in Crafty.easing.  The "Tween" component, `viewport.zoom()`, and `viewport.pan()` all now support these variant easings.  

This patch also adds a couple of simple tests.
