### PR TITLE
Remove space character that affected layout

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -20,7 +20,7 @@
 
     <!-- DEPENDCIES -->
     <link rel="stylesheet" href="./lib/qunit.css" type="text/css" media="screen" />
-    <script type="text/javascript" src="./lib/jquery.min.js"></script> 
+    <script type="text/javascript" src="./lib/jquery.min.js"></script>
     <script type="text/javascript" src="./lib/qunit.js"></script>
     <script type="text/javascript" src="./lib/modernizr-2.7.1.min.js"></script>
     <script type="text/javascript" src="./lib/helperFunctions.js"></script>


### PR DESCRIPTION
There was a non-breaking space character after the jQuery script tag.

This was actually affecting the layout of the page, which I noticed when attempting to trigger mouse events.  Ironically, probably one of the more frustrating bugs to diagnose related Crafty to date.  As you might imagine, "is there an invisible character in the source code" was not high on my list of things to check when layout was being weird.  :)  (And while I have Sublime set to show spaces, it didn't show this particular variant!)
