### PR TITLE
Preventing default keyboard actions needs to be on original

### DIFF
--- a/src/controls/controls.js
+++ b/src/controls/controls.js
@@ -331,15 +331,15 @@ Crafty.extend({
         //Among others this prevent the arrow keys from scrolling the parent page
         //of an iframe hosting the game
         if (Crafty.selected && !(e.key == 8 || e.key >= 112 && e.key <= 135)) {
-            if (e.stopPropagation) e.stopPropagation();
-            else e.cancelBubble = true;
+            if (original.stopPropagation) original.stopPropagation();
+            else original.cancelBubble = true;
 
             //Don't prevent default actions if target node is input or textarea.
-            if (e.target && e.target.nodeName !== 'INPUT' && e.target.nodeName !== 'TEXTAREA') {
-                if (e.preventDefault) {
-                    e.preventDefault();
+            if (original.target && original.target.nodeName !== 'INPUT' && original.target.nodeName !== 'TEXTAREA') {
+                if (original.preventDefault) {
+                    original.preventDefault();
                 } else {
-                    e.returnValue = false;
+                    original.returnValue = false;
                 }
             }
             return false;

--- a/tests/controls.js
+++ b/tests/controls.js
@@ -1,0 +1,29 @@
+(function() {
+    module("Controls");
+    
+    test("stopKeyPropagation", function() {
+      var stopPropCalled = false;
+      var preventDefaultCalled = false;
+
+      var mockEvent = {
+        char:"", charCode:"", keyCode:"", type:"", 
+        shiftKey:"", ctrlKey:"", metaKey:"", timestamp:"",
+        target: Crafty.canvas._canvas,
+        stopPropagation: function(){
+          stopPropCalled = true;
+        },
+        preventDefault: function(){
+          preventDefaultCalled = true;
+        },
+        cancelBubble: false,
+        returnValue: false,
+      };
+
+      Crafty.selected = true;
+      Crafty.keyboardDispatch(mockEvent);
+      Crafty.selected = false;
+      
+      ok(stopPropCalled, "stopPropagation Not Called");
+      ok(preventDefaultCalled, "preventDefault Not Called");
+    });
+})();

--- a/tests/controls.js
+++ b/tests/controls.js
@@ -8,7 +8,7 @@
       var mockEvent = {
         char:"", charCode:"", keyCode:"", type:"", 
         shiftKey:"", ctrlKey:"", metaKey:"", timestamp:"",
-        target: Crafty.canvas._canvas,
+        target: document,
         stopPropagation: function(){
           stopPropCalled = true;
         },

--- a/tests/index.html
+++ b/tests/index.html
@@ -66,5 +66,6 @@
     <script type="text/javascript" src="./issue746/pos.js"></script>
     <script type="text/javascript" src="./issue746/mbr.js"></script>
     <script type="text/javascript" src="./2D/collision/sat.js"></script>
+    <script type="text/javascript" src="./controls.js"></script>
   </body>
 </html>


### PR DESCRIPTION
stopPropagation, cancelBubble, etc. need to be used in the original event, not the Crafty copy of it, e.
