### PR TITLE
Keep the polygon passed to Collision unchanged

### DIFF
--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -1192,7 +1192,8 @@ Crafty.polygon.prototype = {
      * ~~~
      */
     clone: function() {
-        return new Crafty.polygon(this.points);
+        //Shallow clone, but points should be full of Number primitives that are copied
+        return new Crafty.polygon(this.points.slice(0));
     },
 
     rotate: function (e) {

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -1177,6 +1177,24 @@ Crafty.polygon.prototype = {
         }
     },
 
+    /**@
+     * #.clone
+     * @comp Crafty.polygon
+     * @sign public void .clone()
+     * 
+     * Returns a clone of the polygon.
+     *
+     * @example
+     *
+     * var poly = new Crafty.polygon([50, 0, 100, 100, 0, 100]);
+     * var shiftedpoly = poly.clone().shift(5,5);
+     * //[[55, 5, 105, 5, 5, 105], but the original polygon is unchanged
+     * ~~~
+     */
+    clone: function() {
+        return new Crafty.polygon(this.points);
+    },
+
     rotate: function (e) {
         var i = 0, p = this.points,
             l = p.length,

--- a/src/spatial/collision.js
+++ b/src/spatial/collision.js
@@ -99,6 +99,9 @@ Crafty.c("Collision", {
                 //convert args to array to create polygon
                 var args = Array.prototype.slice.call(arguments, 0);
                 poly = new Crafty.polygon(args);
+            } else {
+                //Clone the poly so we don't modify it for anything else that might be using it
+                poly = poly.clone();
             }
             // Check to see if the polygon sits outside the entity, and set _cbr appropriately
             // On resize, the new bounds will be checked if necessary
@@ -118,7 +121,7 @@ Crafty.c("Collision", {
         }
 
         // Finally, assign the hitbox, and attach it to the "Collision" entity
-        this.map = poly.clone();
+        this.map = poly;
         this.attach(this.map);
         this.map.shift(this._x, this._y);
         this.trigger("NewHitbox", poly);

--- a/src/spatial/collision.js
+++ b/src/spatial/collision.js
@@ -118,7 +118,7 @@ Crafty.c("Collision", {
         }
 
         // Finally, assign the hitbox, and attach it to the "Collision" entity
-        this.map = poly;
+        this.map = poly.clone();
         this.attach(this.map);
         this.map.shift(this._x, this._y);
         this.trigger("NewHitbox", poly);


### PR DESCRIPTION
A common case for this fix is when you make the same polygon and use it with two Collision components. In my case, I discovered it when I created a Polygon rendering component and passed the same Crafty.polygon to both the Collision and Polygon components. This resulted in the polygon component being rendered in the wrong place.

I also added the Crafty.polygon.clone() method to copy the polygon around.
