### PR TITLE
No globals

### DIFF
--- a/src/debug/debug-layer.js
+++ b/src/debug/debug-layer.js
@@ -150,7 +150,7 @@ Crafty.c("DebugRectangle", {
 
     drawDebugRect: function () {
 
-        ctx = Crafty.DebugCanvas.context;
+        var ctx = Crafty.DebugCanvas.context;
         var rect = this.debugRect;
         if (rect === null || rect === undefined)
             return;
@@ -235,7 +235,7 @@ Crafty.c("DebugPolygon", {
         if (typeof this.polygon === "undefined")
             return;
 
-        ctx = Crafty.DebugCanvas.context;
+        var ctx = Crafty.DebugCanvas.context;
         ctx.beginPath();
         var p = this.polygon.points, l = p.length;
         for (var i=0; i<l; i+=2){

--- a/src/graphics/canvas-layer.js
+++ b/src/graphics/canvas-layer.js
@@ -263,7 +263,7 @@ Crafty.extend({
 
         /** cleans up current dirty state, stores stale state for future passes */
         _clean: function () {
-            var rect, obj, i,
+            var rect, obj, i, l,
                 changed = this._changedObjs;
              for (i = 0, l = changed.length; i < l; i++) {
                  obj = changed[i];

--- a/src/graphics/sprite-animation.js
+++ b/src/graphics/sprite-animation.js
@@ -138,7 +138,7 @@ Crafty.c("SpriteAnimation", {
 		}
 
 
-		var reel, i;
+		var reel, i, y;
 
 		reel = {
 			id: reelId,

--- a/src/spatial/spatial-grid.js
+++ b/src/spatial/spatial-grid.js
@@ -74,7 +74,7 @@ var Crafty = require('../core/core.js'),
 
         search: function (rect, filter) {
             var keys = HashMap.key(rect, keyHolder),
-                i, j, k,
+                i, j, k, l, cell,
                 results = [];
 
             if (filter === undefined) filter = true; //default filter to true

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -274,7 +274,7 @@
 
 
   test("adjustable boundary", function() {
-    e = Crafty.e("2D").attr({
+    var e = Crafty.e("2D").attr({
       x: 10,
       y: 10,
       w: 10,

--- a/tests/core.js
+++ b/tests/core.js
@@ -285,7 +285,7 @@
   test("Crafty.get with only one object", function() {
     var e = Crafty.e("test");
     var collection = Crafty("test");
-    result = collection.get(0);
+    var result = collection.get(0);
     equal(result.getId(), e.getId(), "result of get(0) is correct entity");
     result = collection.get();
     equal(result.length, 1, "result of get() is array of length 1");

--- a/tests/dom.js
+++ b/tests/dom.js
@@ -38,7 +38,7 @@
 
   test("removeComponent removes element class", function() {
     var element = Crafty.e("DOM");
-    hasClassName = function(el, name) {
+    var hasClassName = function(el, name) {
       return el._element.className.indexOf(name) >= 0;
     };
     element.addComponent("removeMe");

--- a/tests/issue746/mbr.js
+++ b/tests/issue746/mbr.js
@@ -8,7 +8,7 @@ test("mbr Pass In Object", function() {
       h: 150
     }).color("red");
     
-    mbrObject = {};
+    var mbrObject = {};
 
     player.mbr(mbrObject);
 

--- a/tests/issue746/pos.js
+++ b/tests/issue746/pos.js
@@ -8,7 +8,7 @@ test("pos Pass In Object", function() {
       h: 150
     }).color("red");
     
-    posObject = {};
+    var posObject = {};
 
     player.pos(posObject);
 


### PR DESCRIPTION
There were a few global variables being created in both tests and the actual Crafty source code.

I found these by running the QUnit tests in browser, where you get an option to check for globals.  The next version of `grunt-contrib-qunit` will have an option that'll let us do that from grunt as well.
