### PR TITLE
Define that the repository should be transformed with brfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "jsfiddle": "disable",
   "homepage": "https://github.com/craftyjs/Crafty",
   "dependencies": {
+    "brfs": "1.0.1"
   },
   "devDependencies": {
     "grunt-contrib-connect": "^0.8.0",
@@ -47,7 +48,9 @@
     "grunt-contrib-uglify": "^0.5.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-jsvalidate": "^0.2.2",
-    "marked": "^0.3.2",
-    "brfs": "1.0.1"
+    "marked": "^0.3.2"
+  },
+  "browserify": { 
+    "transform": [ "brfs" ] 
   }
 }


### PR DESCRIPTION
With the new WebGL component we need to define that the repository needs to be transformed by brfs to work with browserify.

https://github.com/substack/node-browserify#browserifytransform

How to test:

Install with npm `npm install kevinsimper/Crafty#declare-transform`
Write a simple game with Crafty `game.js`

```
var Crafty = require('craftyjs')

Crafty.init(600, 300);
Crafty.background('rgb(127,127,127)');
//Paddles
Crafty.e("Paddle, 2D, DOM, Color, Multiway")
    .color('rgb(255,0,0)')
    .attr({ x: 20, y: 100, w: 10, h: 100 })
    .multiway(4, { W: -90, S: 90 });
```

Run with beefy https://github.com/chrisdickinson/beefy
`$ beefy game.js`
