### PR TITLE
Check for audio support more explicitly

### DIFF
--- a/src/core/extensions.js
+++ b/src/core/extensions.js
@@ -52,7 +52,7 @@ var Crafty = require('../core/core.js'),
      * @comp Crafty.support
      * Is HTML5 `Audio` supported?
      */
-    support.audio = ('Audio' in window);
+    support.audio = ('canPlayType' in document.createElement('audio'));
 
     /**@
      * #Crafty.support.prefix


### PR DESCRIPTION
Currently we only check for `audio in window`.  We should instead create an audio element, and check that it has `canPlayType`.

Fixes #788
