### PR TITLE
Only change background image when necessary

### DIFF
--- a/src/graphics/sprite.js
+++ b/src/graphics/sprite.js
@@ -224,7 +224,12 @@ Crafty.c("Sprite", {
 
             if (bgColor === "initial") bgColor = "";
 
-            style.background = bgColor + " url('" + this.__image + "') no-repeat";
+            // Don't change background if it's not necessary -- this can cause some browsers to reload the image
+            // See [this chrome issue](https://code.google.com/p/chromium/issues/detail?id=102706)
+            var newBackground = bgColor + " url('" + this.__image + "') no-repeat"; 
+            if (newBackground !== style.background) {
+                style.background = newBackground;
+            }
             style.backgroundPosition = "-" + co.x * hscale + "px -" + co.y * vscale + "px";
             // style.backgroundSize must be set AFTER style.background!
             if (vscale != 1 || hscale != 1) {


### PR DESCRIPTION
This makes it so we only set the background property of sprites when it has changed.  This would theoretically fix #668.

However, even when setting no-cache headers or disabling the cache in Chrome, I was unable to reproduce the issue.  So I can't tell if this actually fixes it or not!
