### PR TITLE
Refactor MultiWay

### DIFF
--- a/tests/2d.js
+++ b/tests/2d.js
@@ -304,53 +304,195 @@
 
   });
 
+  test("Multiway", function() {
+    var e = Crafty.e("2D, Fourway")
+                  .attr({ x: 0, y: 0});
 
-  test("disableControl and enableControl", function() {
+    Crafty.trigger('KeyDown', {
+      key: Crafty.keys.W
+    });
+    Crafty.keydown[Crafty.keys.W] = true;
+    e.multiway(1, { W: -90 });
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vy, e.__convertPixelsToMeters(-1));
+    equal(e._y, e.__convertPixelsToMeters(-1));
+
+    e.multiway(2, { W: 90 });
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vy, e.__convertPixelsToMeters(2));
+    equal(e._y, e.__convertPixelsToMeters(1));
+
+    e.fourway(1);
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vy, e.__convertPixelsToMeters(-1));
+    equal(e._y, e.__convertPixelsToMeters(0));
+
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vy, e.__convertPixelsToMeters(-1));
+    equal(e._y, e.__convertPixelsToMeters(-1));
+
+    
+    Crafty.trigger('KeyDown', {
+      key: Crafty.keys.UP_ARROW
+    });
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vy, e.__convertPixelsToMeters(-1));
+    equal(e._y, e.__convertPixelsToMeters(-2));
+
+    Crafty.trigger('KeyUp', {
+      key: Crafty.keys.W
+    });
+    delete Crafty.keydown[Crafty.keys.W];
+    Crafty.trigger('KeyUp', {
+      key: Crafty.keys.UP_ARROW
+    });
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vy, e.__convertPixelsToMeters(0));
+    equal(e._y, e.__convertPixelsToMeters(-2));
+
+
+    Crafty.trigger('KeyDown', {
+      key: Crafty.keys.DOWN_ARROW
+    });
+    Crafty.trigger('KeyDown', {
+      key: Crafty.keys.LEFT_ARROW
+    });
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vy, e.__convertPixelsToMeters(1));
+    equal(e._y, e.__convertPixelsToMeters(-1));
+    equal(e._vx, e.__convertPixelsToMeters(-1));
+    equal(e._x, e.__convertPixelsToMeters(-1));
+
+    Crafty.trigger('KeyUp', {
+      key: Crafty.keys.DOWN_ARROW
+    });
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vy, e.__convertPixelsToMeters(0));
+    equal(e._y, e.__convertPixelsToMeters(-1));
+    equal(e._vx, e.__convertPixelsToMeters(-1));
+    equal(e._x, e.__convertPixelsToMeters(-2));
+
+    e.removeComponent("Multiway");
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vy, e.__convertPixelsToMeters(0));
+    equal(e._y, e.__convertPixelsToMeters(-1));
+    equal(e._vx, e.__convertPixelsToMeters(0));
+    equal(e._x, e.__convertPixelsToMeters(-2));
+
+    Crafty.trigger('KeyUp', {
+      key: Crafty.keys.LEFT_ARROW
+    });
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vy, e.__convertPixelsToMeters(0));
+    equal(e._y, e.__convertPixelsToMeters(-1));
+    equal(e._vx, e.__convertPixelsToMeters(0));
+    equal(e._x, e.__convertPixelsToMeters(-2));
+
+
+    e.destroy();
+  });
+
+  test("disableControl and enableControl and speed", function() {
     var e = Crafty.e("2D, Twoway")
       .attr({
         x: 0
       })
-      .twoway(1);
+      .twoway(2);
 
-    equal(e._movement.x, 0);
-    equal(e._x, 0);
+    equal(e._vx, e.__convertPixelsToMeters(0));
+    equal(e._x, e.__convertPixelsToMeters(0));
+
+    e.enableControl();
+    e.speed({ x: 1, y: 1 });
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vx, e.__convertPixelsToMeters(0));
+    equal(e._x, e.__convertPixelsToMeters(0));
+
     Crafty.trigger('KeyDown', {
       key: Crafty.keys.D
     });
     Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._movement.x, 1);
-    equal(e._x, 1);
+    equal(e._vx, e.__convertPixelsToMeters(1));
+    equal(e._x, e.__convertPixelsToMeters(1));
 
     e.disableControl();
     Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._movement.x, 0);
-    equal(e._x, 1);
+    equal(e._vx, e.__convertPixelsToMeters(0));
+    equal(e._x, e.__convertPixelsToMeters(1));
 
     Crafty.trigger('KeyUp', {
       key: Crafty.keys.D
     });
     Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._movement.x, 0);
-    equal(e._x, 1);
+    equal(e._vx, e.__convertPixelsToMeters(0));
+    equal(e._x, e.__convertPixelsToMeters(1));
+
+    e.disableControl();
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vx, e.__convertPixelsToMeters(0));
+    equal(e._x, e.__convertPixelsToMeters(1));
+
 
     e.enableControl();
     Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._movement.x, 0);
-    equal(e._x, 1);
+    equal(e._vx, e.__convertPixelsToMeters(0));
+    equal(e._x, e.__convertPixelsToMeters(1));
 
     Crafty.trigger('KeyDown', {
       key: Crafty.keys.D
     });
     Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._movement.x, 1);
-    equal(e._x, 2);
+    equal(e._vx, e.__convertPixelsToMeters(1));
+    equal(e._x, e.__convertPixelsToMeters(2));
 
     Crafty.trigger('KeyUp', {
       key: Crafty.keys.D
     });
     Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._movement.x, 0);
-    equal(e._x, 2);
+    equal(e._vx, e.__convertPixelsToMeters(0));
+    equal(e._x, e.__convertPixelsToMeters(2));
+
+
+    Crafty.trigger('KeyDown', {
+      key: Crafty.keys.D
+    });
+    Crafty.trigger('KeyDown', {
+      key: Crafty.keys.RIGHT_ARROW
+    });
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vx, e.__convertPixelsToMeters(1));
+    equal(e._x, e.__convertPixelsToMeters(3));
+
+    e.disableControl();
+    e.speed({ x: 2, y: 2 });
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vx, e.__convertPixelsToMeters(0));
+    equal(e._x, e.__convertPixelsToMeters(3));
+
+    e.enableControl();
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vx, e.__convertPixelsToMeters(2));
+    equal(e._x, e.__convertPixelsToMeters(5));
+
+    e.speed({ x: 3, y: 3 });
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vx, e.__convertPixelsToMeters(3));
+    equal(e._x, e.__convertPixelsToMeters(8));
+
+    Crafty.trigger('KeyUp', {
+      key: Crafty.keys.D
+    });
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vx, e.__convertPixelsToMeters(3));
+    equal(e._x, e.__convertPixelsToMeters(11));
+
+    Crafty.trigger('KeyUp', {
+      key: Crafty.keys.RIGHT_ARROW
+    });
+    Crafty.trigger('EnterFrame', {dt: 1000});
+    equal(e._vx, e.__convertPixelsToMeters(0));
+    equal(e._x, e.__convertPixelsToMeters(11));
+
 
     e.destroy();
   });
@@ -586,6 +728,129 @@
     ent.destroy();
   });
 
+  test("Motion - Events", function() {
+    var Vector2D = Crafty.math.Vector2D;
+    var zero = new Vector2D();
+    var e = Crafty.e("2D, Motion, AngularMotion")
+      .attr({x: 0, y:0});
+
+    var newDirectionEvents = 0,
+        newRevolutionEvents = 0,
+        movedEvents = 0,
+        motionEvents = 0;
+    e.bind("NewDirection", function(evt) {
+      newDirectionEvents++;
+    });
+    e.bind("NewRevolution", function(evt) {
+      newRevolutionEvents++;
+    });
+    e.bind("Moved", function(evt) {
+      movedEvents++;
+    });
+    e.bind("MotionChange", function(evt) {
+      motionEvents++;
+    });
+
+
+    e.one("NewDirection", function(evt) {
+      equal(evt.x, 0);
+      equal(evt.y, 1);
+    });
+    e.one("Moved", function(evt) { strictEqual(evt.axis, "y"); strictEqual(evt.oldValue, 0); });
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, 0); });
+    e.vy = 1;
+    Crafty.trigger('EnterFrame', {dt: 1000});
+
+    e.one("NewDirection", function(evt) {
+      equal(evt.x, -1);
+      equal(evt.y, -1);
+    });
+    e.one("Moved", function(evt) { strictEqual(evt.axis, "x"); strictEqual(evt.oldValue, 0); 
+    e.one("Moved", function(evt) { strictEqual(evt.axis, "y"); strictEqual(evt.oldValue, 1); });});
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vx"); strictEqual(evt.oldValue, 0); });
+    e.vx = -1;
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, 1); });
+    e.vy = 0;
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, 0); });
+    e.vy = -1;
+    Crafty.trigger('EnterFrame', {dt: 1000});
+
+    e.one("Moved", function(evt) { strictEqual(evt.axis, "x"); strictEqual(evt.oldValue, -1); 
+    e.one("Moved", function(evt) { strictEqual(evt.axis, "y"); strictEqual(evt.oldValue, 0); });});
+    e.vx = -1;
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, -1); });
+    e.vy = 0;
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, 0); });
+    e.vy = -1;
+    Crafty.trigger('EnterFrame', {dt: 1000});
+
+    e.one("NewDirection", function(evt) {
+      equal(evt.x, 0);
+      equal(evt.y, -1);
+    });
+    e.one("Moved", function(evt) { strictEqual(evt.axis, "y"); strictEqual(evt.oldValue, -1); });
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vx"); strictEqual(evt.oldValue, -1); });
+    e.vx = 0;
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, -1); });
+    e.vy = 0;
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, 0); });
+    e.vy = -1;
+    Crafty.trigger('EnterFrame', {dt: 1000});
+
+    e.one("NewDirection", function(evt) {
+      equal(evt.x, 0);
+      equal(evt.y, 0);
+      evt.x = 1; // bad boy!
+    });
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, -1); });
+    e.vy = 0;
+    Crafty.trigger('EnterFrame', {dt: 1000});
+
+    e.vx = 0;
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, 0); });
+    e.vy = 1;
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, 1); });
+    e.vy = 0;
+    Crafty.trigger('EnterFrame', {dt: 1000});
+
+
+    e.vrotation = 0;
+    Crafty.trigger('EnterFrame', {dt: 1000});
+
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vrotation"); strictEqual(evt.oldValue, 0); });
+    e.vrotation = 1;
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vrotation"); strictEqual(evt.oldValue, 1); });
+    e.vrotation = 0;
+    Crafty.trigger('EnterFrame', {dt: 1000});
+
+    e.one("NewRevolution", function(evt) {
+      equal(evt, 1);
+    });
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vrotation"); strictEqual(evt.oldValue, 0); });
+    e.vrotation = 1;
+    Crafty.trigger('EnterFrame', {dt: 1000});
+
+    e.one("NewRevolution", function(evt) {
+      equal(evt, -1);
+    });
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vrotation"); strictEqual(evt.oldValue, 1); });
+    e.vrotation = -1;
+    Crafty.trigger('EnterFrame', {dt: 1000});
+
+    e.one("NewRevolution", function(evt) {
+      equal(evt, 0);
+    });
+    e.one("MotionChange", function(evt) { strictEqual(evt.key, "vrotation"); strictEqual(evt.oldValue, -1); });
+    e.vrotation = 0;
+    Crafty.trigger('EnterFrame', {dt: 1000});
+
+    equal(newDirectionEvents, 4);
+    equal(newRevolutionEvents, 3);
+    equal(movedEvents, 6);
+    equal(motionEvents, 17);
+    e.destroy();
+  });
+
   test("Supportable", function() {
     var ground = Crafty.e("2D, Ground").attr({x: 0, y: 10, w:10, h:10}); // [0,10] to [0,20]
 
@@ -745,6 +1010,8 @@
         ground.destroy();
         player.destroy();
 
+        this.trigger("KeyUp", {key: Crafty.keys.UP_ARROW});
+        this.trigger("KeyUp", {key: Crafty.keys.UP_ARROW});
         start();
       }
     });


### PR DESCRIPTION
## Overview

This is the continuation of #708 in order to incorporate the new `Motion` component into the library.
This PR focuses on changing `Multiway` to work with `Motion`.
## Details of this PR
- Use Motion component in MultiWay to move entities.
- re-enable movement after control has been disabled and enabled again, during which a key was held the whole time
- allow changing speed on the fly (while keys are pressed)
- allow changing direction ony the fly (while keys are pressed) - think of a "disorient player" effect that inverts all his movement keys suddenly :)
- incorporate detection of multiple keys pressed for same direction as in #794 / #793  
  The current solution prevents keys for the same direction to move the player twice as fast. However, for more complex scenarios, additional modifications will need to be done (see linked PR/issue)
- add tests for detection of multiple keys pressed for same direction
- move `NewDirection` event to `Motion` component, make it trigger before `EnterFrame` motion tick
  also add `NewRevolution` to `AngularMotion` component analoguely
- add tests for `NewDirection` and `NewRevolution` events
- update documentation
## Changes from user point-of-view
- `NewDirection` event changed significantly:
  - direction means something different now: `direction = {x: Math.sign(vx), y: Math.sign(vy)}`
  - the event arguments are thus normalized to `-1`, `0` or `1`
  - it is now triggered only once per frame, if the direction is different from last frame
  - it is triggered immediately before the motion tick, which enables the user to change/limit the direction before it is applied
  - should it behave like before (absolute values instead of sign)? However, multiple components may alter the velocity now, so absolute values change constantly in contrast to before (think gravity and twoway)
## Issues
- ~~if `Multiway` is added, while a key is pressed, the component will not function properly (unfortunately as described in #578 we can not assume access to the keyboard state on the server)  
  I may have a fix for this, but need to test~~ **resolved, see comment**
- despite the changes to `Multiway`, the speed of movement should be approximately close when using the same `speed` argument before and after this change  
  `__convertPixelsToMeters` should multiply by `50`, instead of `100`, but then `Gravity` and `Twoway` don't work well
## Future Changes regarding `Motion`
- move Multiway, Fourway, Twoway, Gravity into new src file, also move the tests accordingly (move control tests from `2D` to `controls`)
- make sure to let user set `vx` and similar in pixels, internally convert to correct scale
- cascade `Motion` changes to children  
  - currently when player jumps from a platform in motion, the player looses all momentum it had
  - it will be tricky to implement: 
    - `_cascade` "MotionChange" events, just like "Move" & "Rotate" events to `_children`  
    - figure out how both can co-exist, because if both "MotionChange" and "Move" event is propagated to child, child will move twice as much  
    - trigger "Move" event after "MotionChange" was applied in next "EnterFrame"
- optionally add some kind of inertia to movement controls, something along the lines of this [tut](http://www.iforce2d.net/b2dtut/constant-speed)  

``` javascript
var gradualIncrease = function(frameData)  {
    switch ( moveState ) {
        case MS_LEFT:  
            vel.x = max( vel.x - 0.1f, -5.0f );
            if (vel.x == -0.5f)
                this.unbind("EnterFrame",  gradualIncrease) 
            break;
        case MS_STOP:  
            vel.x *=  0.98; 
            if (vel.x == 0.0f)
                this.unbind("EnterFrame",  gradualIncrease) 
            break;
        case MS_RIGHT:
            vel.x = min( vel.x + 0.1f,  5.0f ); 
            if (vel.x == 0.5f)
                this.unbind("EnterFrame",  gradualIncrease) 
            break;
    }
};
this.bind("EnterFrame", gradualIncrease);
```
