### PR TITLE
Add a new global method: Crafty.system()

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -163,14 +163,14 @@ Crafty.fn = Crafty.prototype = {
 
             //update from the cache
             if (!this.__c) this.__c = {};
-            if (!this._callbacks) addCallbackMethods(this);
+            if (!this._callbacks) Crafty._addCallbackMethods(this);
 
             //update to the cache if NULL
             if (!entities[selector]) entities[selector] = this;
             return entities[selector]; //return the cached selector
         }
 
-        addCallbackMethods(this);
+        Crafty._addCallbackMethods(this);
         return this;
     },
 
@@ -944,9 +944,7 @@ Crafty.fn = Crafty.prototype = {
                 if (comp && "remove" in comp)
                     comp.remove.call(this, true);
             }
-            for (var e in handlers) {
-                this.unbind(e);
-            }
+            this._unbindAll();
             delete entities[this[0]];
         });
     }
@@ -1010,7 +1008,7 @@ Crafty.extend = Crafty.fn.extend = function (obj) {
 // Objects, which can listen to events (or collections of such objects) have varying logic 
 // on how the events are bound/triggered/unbound.  Since the underlying operations on the callback array are the same,
 // the single-object operations are implemented in the following object.  
-// Calling `addCallbackMethods` on an object will extend that object with these methods.
+// Calling `Crafty._addCallbackMethods(obj)` on an object will extend that object with these methods.
 
 
  
@@ -1021,6 +1019,7 @@ Crafty._callbackMethods = {
         var callbacks = this._callbacks[event];
         if (!callbacks) {
             callbacks = this._callbacks[event] = ( handlers[event] || ( handlers[event] = {} ) )[this[0]] = [];
+            callbacks.context = this;
             callbacks.depth = 0;
         }
         // Push to callback array
@@ -1039,10 +1038,12 @@ Crafty._callbackMethods = {
         // callbacks.depth tracks whether this function was invoked in the middle of a previous iteration through the same callback array
         callbacks.depth++;
         for (i = 0; i < l; i++) {
-            if (typeof callbacks[i] === "undefined" && callbacks.depth <= 1) {
-                callbacks.splice(i, 1);
-                i--;
-                l--;
+            if (typeof callbacks[i] === "undefined") {
+                if (callbacks.depth <= 1) {
+                    callbacks.splice(i, 1);
+                    i--;
+                    l--;
+                }
             } else {
                 callbacks[i].call(this, data);
             }
@@ -1065,17 +1066,30 @@ Crafty._callbackMethods = {
                 delete callbacks[i];
             }
         }
+    },
+
+    // Completely all callbacks for every event, such as on object destruction
+    _unbindAll: function() {
+        if (!this._callbacks) return;
+        for (var event in this._callbacks) {
+            if (this._callbacks[event]) {
+                // Remove the normal way, in case we've got a nested loop
+                this._unbindCallbacks(event);
+                // Also completely delete the registered callback from handlers
+                delete handlers[event][this[0]];
+            }
+        }
     }
 };
 
 // Helper function to add the callback methods above to an object, as well as initializing the callbacks object
 // it provies the "low level" operations; bind, unbind, and trigger will still need to be implemented for that object
-addCallbackMethods = function(context) {
+Crafty._addCallbackMethods = function(context) {
     context.extend(Crafty._callbackMethods);
     context._callbacks = {};
 };
 
-addCallbackMethods(Crafty);
+Crafty._addCallbackMethods(Crafty);
 
 Crafty.extend({
     // Define Crafty's id
@@ -1578,23 +1592,15 @@ Crafty.extend({
 
         //  To learn how the event system functions, see the comments for Crafty._callbackMethods
         var hdl = handlers[event] || (handlers[event] = {}),
-            h, i, l, callbacks, context;
+            h, callbacks;
         //loop over every object bound
         for (h in hdl) {
-
             // Check whether h needs to be processed
             if (!hdl.hasOwnProperty(h)) continue;
             callbacks = hdl[h];
             if (!callbacks || callbacks.length === 0) continue;
 
-            //if an entity, call with that context; else the global context
-            if (entities[h])
-                context = Crafty(+h);
-            else if (h === 'global')
-                context = Crafty;
-            else
-                continue;
-            context._runCallbacks(event, data);
+            callbacks.context._runCallbacks(event, data);
         }
     },
 

--- a/src/core/systems.js
+++ b/src/core/systems.js
@@ -1,0 +1,148 @@
+var Crafty = require('../core/core.js');
+
+
+// Dictionary of existing systems
+Crafty._systems = {};
+
+/**@
+ * #Crafty.s
+ * @category Core
+ *
+ * Objects which handle entities might want to subscribe to the event system without being entities themselves.  
+ * When you declare a system with a template object, all the methods and properties of that template are copied to a new object.
+ * This new system will automatically have the following event related methods, which function like those of components: `.bind()`, `unbind()`, `trigger()`, `one()`, `uniqueBind()`, `destroy()`.
+ * Much like components, you can also provide `init()` and `remove()` methods, as well as an `events` parameter for automatically binding to events.
+ *
+ * *Note*: The `init()` method is for setting up the internal state of the system -- if you create entities in it that then reference the system, that'll create an infinite loop.
+ *
+ * @sign void Crafty.s(String name, Obj template[, Boolean lazy])
+ * Register a system
+ * @param name - The name of the system
+ * @param template - an object whose methods and properties will be copied to the new system
+ * @param lazy - a flag that indicates whether the system should be initialized right away or the first time it is referenced
+ *
+ * @sign System Crafty.s(String name)
+ * Access the named system
+ * @param name - The system to return
+ * @returns The referenced system.  If the system has not been initialized, it will be before it is returned.
+ *
+ * @trigger SystemLoaded - When the system has initialized itself - obj - system object
+ * @trigger SystemDestroyed - Right before the system is destroyed - obj - system object
+ */
+Crafty.s = function(name, obj, lazy) {
+	if (obj) {
+		if (lazy === false ) {
+			Crafty._systems[name] = new Crafty.CraftySystem(name, obj);
+			Crafty.trigger("SystemLoaded", name);
+		} else {
+			Crafty._registerLazySystem(name, obj);
+		}
+	} else {
+		return Crafty._systems[name];
+	}
+};
+
+
+
+Crafty._registerLazySystem = function(name, obj) {
+	// This is a bit of magic to only init a system if it's requested at least once.
+	// We define a getter for _systems[name] that will first initialize the system, 
+	// and then redefine _systems[name] to ` that getter.
+	Object.defineProperty(Crafty._systems, name, {
+		get: function() {
+			Object.defineProperty(Crafty._systems, name, { 
+				value: new Crafty.CraftySystem(name, obj),
+				writable: true,
+				enumerable: true,
+				configurable: true
+			});
+			Crafty.trigger("SystemLoaded", name);
+			return Crafty._systems[name];
+		},
+		configurable: true
+	});
+
+};
+
+// Each system has its properties and methods copied onto an object of this type
+Crafty.CraftySystem = (function(){
+	systemID = 1;
+	return function(name, template) {
+		this.name = name;
+		if (!template) return this;
+		this._systemTemplate = template;
+		this.extend(template);
+
+		// Add the "low leveL" callback methods
+		Crafty._addCallbackMethods(this);
+
+		// Give this object a global ID.  Used for event handlers.
+		this[0] = "system" + (systemID++);
+		// Run any instantiation code
+		if (typeof this.init === "function") {
+			this.init(name);
+		}
+		// If an events object is provided, bind the listed event handlers
+		if ("events" in template){
+			var auto = template.events;
+			for (var eventName in auto){
+				var fn = typeof auto[eventName] === "function" ? auto[eventName] : template[auto[eventName]];
+				this.bind(eventName, fn);
+			}
+		}
+	};
+})();
+
+
+
+Crafty.CraftySystem.prototype = {
+	extend: function(obj) {
+		// Copy properties and methods of obj
+		for (var key in obj) {
+			if (typeof this[key] === "undefined") {
+				this[key] = obj[key];
+			}
+		}
+	},
+
+	// Event methods
+	bind: function(event, callback) {
+		this._bindCallback(event, callback);
+		return this;
+	},
+
+	trigger: function(event, data) {
+		this._runCallbacks(event, data);
+		return this;
+	},
+
+	unbind: function(event, callback) {
+		this._unbindCallbacks(event, callback);
+		return this;
+	},
+
+	one: function (event, callback) {
+		var self = this;
+		var oneHandler = function (data) {
+			callback.call(self, data);
+			self.unbind(event, oneHandler);
+		};
+		return self.bind(event, oneHandler);
+	},
+
+	uniqueBind: function(event, callback) {
+		this.unbind(event, callback);
+		return this.bind(event, callback);
+	},
+
+	destroy: function() {
+		Crafty.trigger("SystemDestroyed", this);
+		// Check the template itself
+		if (typeof this.remove === "function") {
+			this.remove();
+		}
+		this._unbindAll();
+		delete Crafty._systems[this.name];
+	}
+
+};

--- a/src/crafty.js
+++ b/src/crafty.js
@@ -6,6 +6,7 @@ require('./core/loader');
 require('./core/model');
 require('./core/scenes');
 require('./core/storage');
+require('./core/systems');
 require('./core/time');
 require('./core/version');
 

--- a/tests/events.js
+++ b/tests/events.js
@@ -150,6 +150,27 @@
 
   });
 
+  // Catch bugs in unbinding logic when something is unbound at depth > 1
+  test("Unbinding mid-iteration", function() {
+    var e = Crafty.e("Triggerable");
+    var counter = 0;
+    // Each of these functions can be run at most once, because they unbind on triggering
+    var a = function() {
+        counter++;
+        this.unbind("Test", a);
+        this.trigger("Test");
+    };
+    var b = function() {
+        counter++;
+        this.unbind("Test", b);
+        this.trigger("Test");
+    };
+    e.bind("Test", a);
+    e.bind("Test", b);
+    e.trigger("Test");
+    equal(counter, 2, "Total number of triggers should be 2 (regardless of bind/unbind order).");
+  });
+
   test("Data passing", function() {
     var x = 0,
       e;

--- a/tests/index.html
+++ b/tests/index.html
@@ -54,6 +54,7 @@
     <script type="text/javascript" src="./controls.js"></script>
     <script type="text/javascript" src="./dom.js"></script>
     <script type="text/javascript" src="./events.js"></script>
+    <script type="text/javascript" src="./systems.js"></script>
     <script type="text/javascript" src="./isometric.js"></script>
     <script type="text/javascript" src="./loader.js"></script>
     <script type="text/javascript" src="./math.js"></script>

--- a/tests/systems.js
+++ b/tests/systems.js
@@ -1,0 +1,196 @@
+(function() {
+  module("Systems");
+
+  test("Create a system using Crafty.ss", function() {
+    var sys =  {
+        n: 0,
+        add: function(m) { this.n+=m; }
+    };
+    Crafty.s("Adder", sys);
+    var s = Crafty.s("Adder");
+    ok(s, "System is returned");
+    ok(s.n===0, "System has property copied");
+    ok(typeof s.add === "function", "System has method copied");
+    ok(typeof s.bind === "function", "System has bind method");
+    ok(typeof s.unbind === "function", "System has unbind method");
+    ok(typeof s.trigger === "function", "System has trigger method");
+    ok(typeof s.one === "function", "System has one method");
+    ok(typeof s.uniqueBind === "function", "System has uniqueBind method");
+
+    s.destroy();
+
+  });
+
+  test("Create a system, then access it using Crafty.s", function() {
+    var sys =  {
+        n: 0,
+        add: function(m) { this.n+=m; }
+    };
+    Crafty.s("Adder", sys);
+    var s = Crafty._systems.Adder;
+    var s2 = Crafty.s("Adder");
+    ok(s===s2, "Crafty.s returns correct object;");
+
+    s.destroy();
+
+  });
+
+  test("Create a system, then destroy it", function() {
+    var sys =  {
+        n: 0,
+        add: function(m) { this.n+=m; }
+    };
+    Crafty.s("Adder", sys);
+    var s = Crafty.s("Adder");
+    s.destroy();
+    var s2 = Crafty.s("Adder");
+    equal(typeof s2, "undefined", "Crafty.s returns undefined after system is destroyed;");
+  });
+
+  test("Create a non-lazy system with an init method", function(){
+    var loaded = false;
+    var sys =  {
+        init: function() { loaded = true; }
+    };
+    Crafty.s("Loader", sys, false);
+    equal(loaded, true, "System loaded on creation");
+
+    var s = Crafty.s("Loader");
+    s.destroy();
+  });
+
+  test("Create a lazy system with an init method", function(){
+    var loaded = false;
+    var sys =  {
+        init: function() { loaded = true; }
+    };
+    Crafty.s("Loader", sys, true);
+    equal(loaded, false, "System not loaded on creation");
+    var s = Crafty.s("Loader");
+    equal(loaded, true, "System loaded on first reference");
+    s.destroy();
+  });
+
+  test("Create a system with a remove method", function(){
+    var destroyed = false;
+    var sys =  {
+        remove: function() { destroyed = true; }
+    };
+    Crafty.s("Loader", sys);
+    var s = Crafty.s("Loader");
+    equal(destroyed, false, "remove not called on creation");
+    s.destroy();
+    equal(destroyed, true, "remove called on destruction");
+  });
+
+  test("Bind an event to a system, trigger directly", function() {
+    var sys =  {
+        n: 0,
+        add: function(m) { this.n+=m; }
+    };
+    Crafty.s("Adder", sys);
+    var s = Crafty.s("Adder");
+    s.bind("Add", sys.add);
+    s.trigger("Add", 1);
+    equal(s.n, 1, "Direct trigger works");
+
+    s.destroy();
+  });
+
+  test("Bind an event to a system, then unbind", function() {
+    var sys =  {
+        n: 0,
+        add: function(m) { this.n+=m; }
+    };
+    Crafty.s("Adder", sys);
+    var s = Crafty.s("Adder");
+    s.bind("Add", sys.add);
+    s.trigger("Add", 1);
+    equal(s.n, 1, "Direct trigger works");
+
+    s.unbind("Add", sys.add);
+    s.trigger("Add", 1);
+    equal(s.n, 1, "No trigger after unbind");
+
+    s.destroy();
+  });
+
+
+  test("Bind an event to a system, trigger globally", function() {
+    var sys =  {
+        n: 0,
+        add: function(m) { this.n+=m; }
+    };
+    Crafty.s("Adder", sys);
+    var s = Crafty.s("Adder");
+    s.bind("Add", sys.add);
+    Crafty.trigger("Add", 1);
+    equal(s.n, 1, "Global trigger works");
+
+    s.destroy();
+  });
+
+  test("Bind an event to a system, then destroy it and trigger globally", function() {
+    var sys =  {
+        n: 0,
+        add: function(m) { this.n+=m; }
+    };
+    Crafty.s("Adder", sys);
+    var s = Crafty.s("Adder");
+    s.bind("Add", sys.add);
+    Crafty.trigger("Add", 1);
+    equal(s.n, 1, "Direct trigger works");
+
+    s.destroy();
+    Crafty.trigger("Add", 1);
+    equal(s.n, 1, "No trigger after unbind");
+
+  });
+
+  test("system.uniqueBind()", function(){
+    var sys =  {
+        n: 0,
+        add: function(m) { this.n+=m; }
+    };
+    Crafty.s("Adder", sys);
+    var s = Crafty.s("Adder");
+    s.bind("Add", s.add);
+    s.uniqueBind("Add", s.add);
+    s.trigger("Add", 1);
+    equal(s.n, 1, "Only one event handler called");
+
+  });
+
+  test("system.one()", function(){
+    var sys =  {
+        n: 0,
+        add: function(m) { this.n+=m; }
+    };
+    Crafty.s("Adder", sys);
+    var s = Crafty.s("Adder");
+    s.one("Add", s.add);
+    s.trigger("Add", 1);
+    s.trigger("Add", 1);
+    s.destroy();
+    equal(s.n, 1, "Only one event handler called");
+
+  });
+
+  test("Special property `events`", function() {
+    var sys =  {
+        n: 0,
+        events:{
+            "Add": function(m) { this.n+=m; }
+        }
+    };
+    Crafty.s("Adder", sys);
+    var s = Crafty.s("Adder");
+    s.trigger("Add", 1);
+    equal(s.n, 1, "Method listed in .events property triggers correctly.");
+    s.destroy();
+  });
+
+
+
+})();
+


### PR DESCRIPTION
It's very natural to want a non-entity object that can participate in the event system.  Currently when objects like the viewport or the graphical layers want to listen to an event, they have to refer to themselves via hardcoded references, since those event handlers get run with `Crafty` as the context.

This introduces the idea of systems which have a set of methods for participating in events.  These methods parallel those that Crafty and each entity implement.

When a system is created, a new object is created with these methods, and then it is extended with the methods/properties of a provided template object.  An `init` method and an `events` property can be provided that fill the same role as for components.  By default the system will be lazily created -- that is, it will only be created when referred to for the first time.  (This is what we do now with Crafty.canvasLayer and the like.)

In the future, we'll probably want to extend the capability of systems.  In particular, I envision that components and systems with the same name would have some connection -- perhaps the system could have methods for operating on all such entities at once.

I tested moving canvasLayer, domLayer, and webgl to this new paradigm and it seemed to work ok, but the actual switchover will happen in a new PR.

There were some small updates to the callbackMethods mixin required to implement this properly.
