### PR TITLE
Make timer.stop work for implementations of setInterval returning object

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -1271,7 +1271,7 @@ Crafty.extend({
             stop: function () {
                 Crafty.trigger("CraftyStopTimer");
 
-                if (typeof tick === "number") clearInterval(tick);
+                if (typeof tick !== "function") clearInterval(tick);
 
                 var onFrame = window.cancelAnimationFrame ||
                     window.cancelRequestAnimationFrame ||


### PR DESCRIPTION
The `timer.stop` method is not working in node.js (when testing) and test tasks keep hanging after completion.
This is due to node's `setInterval` implementation returning an object token instead of a number.
Changing the check in `timer.stop` solves this issue.
I believe there should be no side effects to it.
