### PR TITLE
Allow creation of multiple Crafty instances

### DIFF
--- a/src/controls/controls.js
+++ b/src/controls/controls.js
@@ -1,5 +1,6 @@
-var Crafty = require('../core/core.js'),
-    document = window.document;
+module.exports = function(Crafty) {
+var document = window.document;
+
 
 Crafty.extend({
     over: null, //object mouseover, waiting for out
@@ -1312,3 +1313,5 @@ Crafty.c("Twoway", {
         return this;
     }
 });
+
+};

--- a/src/controls/device.js
+++ b/src/controls/device.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 Crafty.extend({
@@ -155,3 +155,5 @@ Crafty.extend({
         }
     }
 });
+
+};

--- a/src/controls/keycodes.js
+++ b/src/controls/keycodes.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 Crafty.extend({
@@ -214,3 +214,6 @@ Crafty.extend({
         RIGHT: 2
     }
 });
+
+
+};

--- a/src/core/animation.js
+++ b/src/core/animation.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 /**@
@@ -253,3 +253,5 @@ Crafty.c("Tween", {
 		this.trigger("TweenEnd", properties);
 	}
 });
+
+};

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -1,4 +1,4 @@
-var version = require('./version');
+module.exports = function(version) {
 
 /**@
  * #Crafty
@@ -1854,4 +1854,5 @@ if (typeof define === 'function') { // AMD
     });
 }
 
-module.exports = Crafty;
+return Crafty;
+};

--- a/src/core/extensions.js
+++ b/src/core/extensions.js
@@ -1,5 +1,6 @@
-var Crafty = require('../core/core.js'),
-    document = window.document;
+module.exports = function(Crafty) {
+var document = window.document;
+
 
 /**@
  * #Crafty.support
@@ -244,3 +245,5 @@ Crafty.extend({
         Crafty.stage.elem.style.background = style;
     }
 });
+
+};

--- a/src/core/loader.js
+++ b/src/core/loader.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 Crafty.extend({
@@ -435,3 +435,5 @@ Crafty.extend({
         }
     }
 });
+
+};

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 /**@
@@ -99,3 +99,5 @@ Crafty.c('Model', {
     }
   }
 });
+
+};

--- a/src/core/scenes.js
+++ b/src/core/scenes.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 Crafty.extend({
@@ -165,3 +165,5 @@ Crafty.extend({
 
     }
 });
+
+};

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 /**@
@@ -91,4 +91,6 @@ Crafty.storage = function(key, value){
  */
 Crafty.storage.remove = function(key){
   window.localStorage.removeItem(key);
+};
+
 };

--- a/src/core/time.js
+++ b/src/core/time.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 /**@
@@ -118,3 +118,5 @@ Crafty.c("Delay", {
         return this;
     }
 });
+
+};

--- a/src/crafty.js
+++ b/src/crafty.js
@@ -1,58 +1,53 @@
-var Crafty = require('./core/core');
+var createInstance = function() {
+    var version = require('./core/version');
+    var Crafty = require('./core/core')(version);
 
-require('./core/animation');
-require('./core/extensions');
-require('./core/loader');
-require('./core/model');
-require('./core/scenes');
-require('./core/storage');
-require('./core/time');
-require('./core/version');
+    require('./core/animation')(Crafty);
+    require('./core/extensions')(Crafty);
+    require('./core/loader')(Crafty);
+    require('./core/model')(Crafty);
+    require('./core/scenes')(Crafty);
+    require('./core/storage')(Crafty);
+    require('./core/time')(Crafty);
 
+    var HashMap = require('./spatial/spatial-grid.js');
+    require('./spatial/2d')(Crafty, HashMap);
+    require('./spatial/collision')(Crafty);
+    require('./spatial/rect-manager')(Crafty);
+    require('./spatial/math')(Crafty);
 
-require('./spatial/2d');
-require('./spatial/collision');
-require('./spatial/spatial-grid');
-require('./spatial/rect-manager');
-require('./spatial/math');
+    require('./graphics/canvas')(Crafty);
+    require('./graphics/canvas-layer')(Crafty);
+    require('./graphics/color')(Crafty);
+    require('./graphics/dom')(Crafty);
+    require('./graphics/dom-helper')(Crafty);
+    require('./graphics/dom-layer')(Crafty);
+    require('./graphics/drawing')(Crafty);
+    require('./graphics/gl-textures')(Crafty);
+    require('./graphics/html')(Crafty);
+    require('./graphics/image')(Crafty);
+    require('./graphics/particles')(Crafty);
+    require('./graphics/sprite-animation')(Crafty);
+    require('./graphics/sprite')(Crafty);
+    require('./graphics/text')(Crafty);
+    require('./graphics/viewport')(Crafty);
+    require('./graphics/webgl')(Crafty);
 
-require('./graphics/canvas');
-require('./graphics/canvas-layer');
-require('./graphics/color');
-require('./graphics/dom');
-require('./graphics/dom-helper');
-require('./graphics/dom-layer');
-require('./graphics/drawing');
-require('./graphics/gl-textures');
-require('./graphics/html');
-require('./graphics/image');
-require('./graphics/particles');
-require('./graphics/sprite-animation');
-require('./graphics/sprite');
-require('./graphics/text');
-require('./graphics/viewport');
-require('./graphics/webgl');
+    require('./isometric/diamond-iso')(Crafty);
+    require('./isometric/isometric')(Crafty);
 
-require('./isometric/diamond-iso');
-require('./isometric/isometric');
+    require('./controls/controls')(Crafty);
+    require('./controls/device')(Crafty);
+    require('./controls/keycodes')(Crafty);
 
-require('./controls/controls');
-require('./controls/device');
-require('./controls/keycodes');
+    require('./sound/sound')(Crafty);
 
-require('./sound/sound');
+    require('./debug/debug-layer')(Crafty);
 
-require('./debug/debug-layer');
+    return Crafty;
+};
 
-
-
-
-
-
-
-
-
-
+var Crafty = createInstance();
 if(window) window.Crafty = Crafty;
 
 module.exports = Crafty;

--- a/src/debug/debug-layer.js
+++ b/src/debug/debug-layer.js
@@ -1,5 +1,5 @@
-var Crafty = require('../core/core.js'),
-    document = window.document;
+module.exports = function(Crafty) {
+var document = window.document;
 
 /**@
  * #DebugCanvas
@@ -370,5 +370,7 @@ Crafty.DebugCanvas = {
         }
 
     }
+
+};
 
 };

--- a/src/graphics/canvas-layer.js
+++ b/src/graphics/canvas-layer.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 /**@
@@ -333,3 +333,5 @@ Crafty.extend({
 
     }
 });
+
+};

--- a/src/graphics/canvas.js
+++ b/src/graphics/canvas.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 /**@
@@ -151,3 +151,5 @@ Crafty.c("Canvas", {
         return this;
     }
 });
+
+};

--- a/src/graphics/color.js
+++ b/src/graphics/color.js
@@ -1,7 +1,5 @@
-var Crafty = require('../core/core.js'),
-    document = window.document;
-
-
+module.exports = function(Crafty) {
+var document = window.document;
 
 
 /**@
@@ -252,3 +250,4 @@ Crafty.c("Color", {
     }
 });
 
+};

--- a/src/graphics/dom-helper.js
+++ b/src/graphics/dom-helper.js
@@ -1,5 +1,6 @@
-var Crafty = require('../core/core.js'),
-    document = window.document;
+module.exports = function(Crafty) {
+var document = window.document;
+
 
 Crafty.extend({
     /**@
@@ -100,3 +101,5 @@ Crafty.extend({
         }
     }
 });
+
+};

--- a/src/graphics/dom-layer.js
+++ b/src/graphics/dom-layer.js
@@ -1,5 +1,5 @@
-var Crafty = require('../core/core.js'),
-    document = window.document;
+module.exports = function(Crafty) {
+var document = window.document;
 
 
 /**@
@@ -128,3 +128,5 @@ Crafty.extend({
 
     }
 });
+
+};

--- a/src/graphics/dom.js
+++ b/src/graphics/dom.js
@@ -1,5 +1,5 @@
-var Crafty = require('../core/core.js'),
-    document = window.document;
+module.exports = function(Crafty) {
+var document = window.document;
 
 /**@
  * #DOM
@@ -290,3 +290,5 @@ Crafty.c("DOM", {
         return this;
     }
 });
+
+};

--- a/src/graphics/drawing.js
+++ b/src/graphics/drawing.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 Crafty.extend({
     /**@
@@ -40,3 +40,5 @@ Crafty.extend({
         Crafty.trigger("PixelartSet", enabled);
     }
 });
+
+};

--- a/src/graphics/gl-textures.js
+++ b/src/graphics/gl-textures.js
@@ -1,4 +1,5 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
+
 
 // An object for wrangling textures
 // An assumption here is that doing anything with textures is fairly expensive, so the code should be expressive rather than performant
@@ -179,4 +180,6 @@ TextureWrapper.prototype = {
         // Set the image dimensions
         gl.uniform2f(gl.getUniformLocation(shader, dimension_name), this.width, this.height);
 	}
+};
+
 };

--- a/src/graphics/html.js
+++ b/src/graphics/html.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 /**@
@@ -79,3 +79,5 @@ Crafty.c("HTML", {
         return this;
     }
 });
+
+};

--- a/src/graphics/image.js
+++ b/src/graphics/image.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 // 
@@ -141,3 +141,5 @@ Crafty.c("Image", {
 
     }
 });
+
+};

--- a/src/graphics/particles.js
+++ b/src/graphics/particles.js
@@ -1,5 +1,5 @@
-var Crafty = require('../core/core.js'),    
-    document = window.document;
+module.exports = function(Crafty) {
+var document = window.document;
 
 /**@
  * #Particles
@@ -375,3 +375,5 @@ Crafty.c("Particles", {
         }
     }
 });
+
+};

--- a/src/graphics/sprite-animation.js
+++ b/src/graphics/sprite-animation.js
@@ -1,5 +1,4 @@
-var Crafty = require('../core/core.js'),
-	Animation = require('../core/animation.js');
+module.exports = function(Crafty) {
 
 
 /**@
@@ -475,3 +474,5 @@ Crafty.c("SpriteAnimation", {
 		return this._reels[reelId];
 	}
 });
+
+};

--- a/src/graphics/sprite.js
+++ b/src/graphics/sprite.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 // Define some variables required for webgl
@@ -324,3 +324,5 @@ Crafty.c("Sprite", {
         return this;
     }
 });
+
+};

--- a/src/graphics/text.js
+++ b/src/graphics/text.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 /**@
@@ -264,3 +264,5 @@ Crafty.c("Text", {
     }
 
 });
+
+};

--- a/src/graphics/viewport.js
+++ b/src/graphics/viewport.js
@@ -1,5 +1,6 @@
-var Crafty = require('../core/core.js'),
-    document = window.document;
+module.exports = function(Crafty) {
+var document = window.document;
+
 
 Crafty.extend({
     /**@
@@ -735,3 +736,5 @@ Crafty.extend({
         },
     }
 });
+
+};

--- a/src/graphics/webgl.js
+++ b/src/graphics/webgl.js
@@ -1,5 +1,6 @@
-var Crafty = require('../core/core.js'),
-    document = window.document;
+module.exports = function(Crafty) {
+var document = window.document;
+
 
 // Object for abstracting out all the gl calls to handle rendering entities with a particular program
 RenderProgramWrapper = function(context, shader){
@@ -585,3 +586,5 @@ Crafty.extend({
 
     }
 });
+
+};

--- a/src/isometric/diamond-iso.js
+++ b/src/isometric/diamond-iso.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 Crafty.extend({
@@ -160,3 +160,5 @@ Crafty.extend({
 
     }
 });
+
+};

--- a/src/isometric/isometric.js
+++ b/src/isometric/isometric.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 Crafty.extend({
@@ -179,3 +179,5 @@ Crafty.extend({
         }
     }
 });
+
+};

--- a/src/sound/sound.js
+++ b/src/sound/sound.js
@@ -1,5 +1,6 @@
-var Crafty = require('../core/core.js'),
-    document = window.document;
+module.exports = function(Crafty) {
+var document = window.document;
+
 
 Crafty.extend({
     /**@
@@ -550,3 +551,5 @@ Crafty.extend({
         }
     }
 });
+
+};

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -1,6 +1,4 @@
-var Crafty = require('../core/core.js'),
-    HashMap = require('./spatial-grid.js');
-
+module.exports = function(Crafty, HashMap) {
 
 
 /**@
@@ -1851,4 +1849,6 @@ Crafty.matrix.prototype = {
         if (row < 1 || row > this.mtx.length || col < 1 || col > this.mtx[0].length) return null;
         return this.mtx[row - 1][col - 1];
     }
+};
+
 };

--- a/src/spatial/collision.js
+++ b/src/spatial/collision.js
@@ -1,5 +1,5 @@
-var Crafty = require('../core/core.js'),
-    DEG_TO_RAD = Math.PI / 180;
+module.exports = function(Crafty) {
+var DEG_TO_RAD = Math.PI / 180;
 
 
 /**@
@@ -690,3 +690,5 @@ Crafty.c("Collision", {
         };
     }
 });
+
+};

--- a/src/spatial/math.js
+++ b/src/spatial/math.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 /**@
@@ -1094,3 +1094,5 @@ Crafty.math.Matrix2D = (function () {
 
     return Matrix2D;
 })();
+
+};

--- a/src/spatial/rect-manager.js
+++ b/src/spatial/rect-manager.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = function(Crafty) {
 
 
 /**@
@@ -156,3 +156,6 @@ Crafty.extend({
 
 
 });
+
+
+};

--- a/src/spatial/spatial-grid.js
+++ b/src/spatial/spatial-grid.js
@@ -1,4 +1,4 @@
-var Crafty = require('../core/core.js');
+module.exports = (function() {
 
 
 /**
@@ -102,7 +102,8 @@ var Crafty = require('../core/core.js');
                     id = obj[0]; //unique ID
                     obj = obj._mbr || obj;
                     //check if not added to hash and that actually intersects
-                    if (!found[id] && overlap(obj, rect))
+                    if (!found[id] && obj._x < rect._x + rect._w && obj._x + obj._w > rect._x &&
+                                      obj._y < rect._y + rect._h && obj._h + obj._y > rect._y)
                         found[id] = results[i];
                 }
 
@@ -356,4 +357,5 @@ var Crafty = require('../core/core.js');
         }
     };
 
-    module.exports = HashMap;
+return HashMap;
+})();


### PR DESCRIPTION
Continuation of #877 .

By wrapping each source file into a module.exports constructor,
mulitple instances can be constructed.
The initial crafty instance is constructed using the empty
constructor of `core.js`, which is then handed to the other source
modules.
Remove unneeded dependency on animation.js in sprite-animation.js.
Revert HashMap's intersect check to use hardcoded intersect
functionality in order to avoid dependency on Crafty.

Alternatively, to avoid polluting the generated Crafty source file with `module.exports` statements, [another approach](https://github.com/craftyjs/Crafty/pull/877#issuecomment-77738720) could be considered
