### PR TITLE
Various improvements to Motion system

### DIFF
--- a/src/controls/controls.js
+++ b/src/controls/controls.js
@@ -1017,8 +1017,6 @@ Crafty.c("Keyboard", {
  * @see Motion
  */
 Crafty.c("Multiway", {
-    _speed: 3,
-
     init: function () {
         this.requires("Motion");
 
@@ -1249,7 +1247,7 @@ Crafty.c("Fourway", {
     /**@
      * #.fourway
      * @comp Fourway
-     * @sign public this .fourway(Number speed)
+     * @sign public this .fourway([Number speed])
      * @param speed - Amount of pixels to move the entity whilst a key is down
      *
      * Constructor to initialize the speed. Component will listen for key events and move the entity appropriately.
@@ -1260,7 +1258,7 @@ Crafty.c("Fourway", {
      * @see Multiway, Motion
      */
     fourway: function (speed) {
-        this.multiway(speed, {
+        this.multiway(speed || this._speed, {
             UP_ARROW: -90,
             DOWN_ARROW: 90,
             RIGHT_ARROW: 0,
@@ -1289,7 +1287,8 @@ Crafty.c("Fourway", {
  * @see Gravity, Multiway, Fourway, Motion
  */
 Crafty.c("Twoway", {
-    _speed: 3,
+    _jumpSpeed: 6,
+
     /**@
      * #.canJump
      * @comp Twoway
@@ -1315,10 +1314,27 @@ Crafty.c("Twoway", {
         this.requires("Fourway, Motion, Supportable");
     },
 
+    remove: function() {
+        this.unbind("KeyDown", this._keydown_twoway);
+    },
+
+    _keydown_twoway: function (e) {
+        if (this.disableControls) return;
+
+        if (e.key === Crafty.keys.UP_ARROW || e.key === Crafty.keys.W || e.key === Crafty.keys.Z) {
+            var ground = this.ground();
+            this.canJump = !!ground;
+            this.trigger("CheckJumping", ground);
+            if (this.canJump) {
+                this.vy = -this._jumpSpeed;
+            }
+        }
+    },
+
     /**@
      * #.twoway
      * @comp Twoway
-     * @sign public this .twoway(Number speed[, Number jump])
+     * @sign public this .twoway([Number speed[, Number jump]])
      * @param speed - Amount of pixels to move left or right
      * @param jump - Vertical jump speed
      *
@@ -1334,7 +1350,7 @@ Crafty.c("Twoway", {
      */
     twoway: function (speed, jump) {
 
-        this.multiway(speed, {
+        this.multiway(speed || this._speed, {
             RIGHT_ARROW: 0,
             LEFT_ARROW: 180,
             D: 0,
@@ -1342,25 +1358,12 @@ Crafty.c("Twoway", {
             Q: 180
         });
 
-        if (speed) this._speed = speed;
         if (arguments.length < 2) {
-          this._jumpSpeed = this._speed * 2;
+          this._jumpSpeed = this._speed.y * 2;
         } else {
           this._jumpSpeed = jump;
         }
-
-        var ground;
-        this.bind("KeyDown", function (e) {
-            if (this.disableControls) return;
-            if (e.key === Crafty.keys.UP_ARROW || e.key === Crafty.keys.W || e.key === Crafty.keys.Z) {
-                ground = this.ground();
-                this.canJump = !!ground;
-                this.trigger("CheckJumping", ground);
-                if (this.canJump) {
-                    this.vy = -this._jumpSpeed;
-                }
-            }
-        });
+        this.uniqueBind("KeyDown", this._keydown_twoway);
 
         return this;
     }

--- a/src/controls/controls.js
+++ b/src/controls/controls.js
@@ -1300,11 +1300,15 @@ Crafty.c("Twoway", {
      * @example
      * ~~~
      * var player = Crafty.e("2D, Twoway");
+     * player.hasDoubleJumpPowerUp = true; // allow player to double jump by granting him a powerup
      * player.bind("CheckJumping", function(ground) {
-     *    if (!ground && player.hasDoubleJumpPowerUp) { // custom behaviour
-     *       player.hasDoubleJumpPowerUp = false;
-     *       player.canJump = true;
-     *    }
+     *     if (!ground && player.hasDoubleJumpPowerUp) { // allow player to double jump by using up his double jump powerup
+     *         player.canJump = true;
+     *         player.hasDoubleJumpPowerUp = false;
+     *     }
+     * });
+     * player.bind("LandedOnGround", function(ground) {
+     *     player.hasDoubleJumpPowerUp = true; // give player new double jump powerup upon landing
      * });
      * ~~~
      */

--- a/src/controls/controls.js
+++ b/src/controls/controls.js
@@ -1326,7 +1326,7 @@ Crafty.c("Twoway", {
         if (this.disableControls) return;
 
         if (e.key === Crafty.keys.UP_ARROW || e.key === Crafty.keys.W || e.key === Crafty.keys.Z) {
-            var ground = this.ground();
+            var ground = this.ground;
             this.canJump = !!ground;
             this.trigger("CheckJumping", ground);
             if (this.canJump) {

--- a/src/controls/controls.js
+++ b/src/controls/controls.js
@@ -1161,8 +1161,8 @@ Crafty.c("Multiway", {
             direction = this._keyDirection[keyCode];
             // add new data
             this._directionSpeed[direction] = {
-                x: this.__convertPixelsToMeters(Math.round(Math.cos(direction * (Math.PI / 180)) * 1000 * speed.x) / 1000),
-                y: this.__convertPixelsToMeters(Math.round(Math.sin(direction * (Math.PI / 180)) * 1000 * speed.y) / 1000)
+                x: Math.round(Math.cos(direction * (Math.PI / 180)) * 1000 * speed.x) / 1000,
+                y: Math.round(Math.sin(direction * (Math.PI / 180)) * 1000 * speed.y) / 1000
             };
         }
     },
@@ -1344,9 +1344,9 @@ Crafty.c("Twoway", {
 
         if (speed) this._speed = speed;
         if (arguments.length < 2) {
-          this._jumpSpeed = this.__convertPixelsToMeters(this._speed * 2);
+          this._jumpSpeed = this._speed * 2;
         } else {
-          this._jumpSpeed = this.__convertPixelsToMeters(jump);
+          this._jumpSpeed = jump;
         }
 
         var ground;

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -1412,6 +1412,7 @@ Crafty.extend({
              * Returns the target frames per second. This is not an actual frame rate.
              * @sign public void Crafty.timer.FPS(Number value)
              * @param value - the target rate
+             * @trigger FPSChange - Triggered when the target FPS is changed by user - Number - new target FPS
              * Sets the target frames per second. This is not an actual frame rate.
              * The default rate is 50.
              */
@@ -1421,6 +1422,7 @@ Crafty.extend({
                 else {
                     FPS = value;
                     milliSecPerFrame = 1000 / FPS;
+                    Crafty.trigger("FPSChange", value);
                 }
             },
 

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -944,8 +944,9 @@ Crafty.c("Supportable", {
      * ~~~
      * var player = Crafty.e("2D, Gravity");
      * player.bind("CheckLanding", function(ground) {
-     *     if (player.isAirplane) // custom behaviour
+     *     if (player.y + player.h > ground.y + player.vy) { // forbid landing, if player's feet are not above ground
      *         player.canLand = false;
+     *     }
      * });
      * ~~~
      */

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -1179,7 +1179,7 @@ Crafty.c("Gravity", {
      * ~~~
      */
     gravityConst: function (g) {
-        if (!this.ground()) { // gravity active, change acceleration
+        if (this._gravityActive) { // gravity active, change acceleration
             this.ay -= this._gravityConst;
             this.ay += g;
         }
@@ -1188,11 +1188,13 @@ Crafty.c("Gravity", {
         return this;
     },
     _startGravity: function() {
+        this._gravityActive = true;
         this.ay += this._gravityConst;
     },
     _stopGravity: function() {
         this.ay = 0;
         this.vy = 0;
+        this._gravityActive = false;
     }
 });
 

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -735,6 +735,7 @@
     var newDirectionEvents = 0,
         newRevolutionEvents = 0,
         movedEvents = 0,
+        rotatedEvents = 0,
         motionEvents = 0;
     e.bind("NewDirection", function(evt) {
       newDirectionEvents++;
@@ -744,6 +745,9 @@
     });
     e.bind("Moved", function(evt) {
       movedEvents++;
+    });
+    e.bind("Rotated", function(evt) {
+      rotatedEvents++;
     });
     e.bind("MotionChange", function(evt) {
       motionEvents++;
@@ -824,6 +828,7 @@
     e.one("NewRevolution", function(evt) {
       equal(evt, 1);
     });
+    e.one("Rotated", function(oldValue) { strictEqual(oldValue, 0); });
     e.one("MotionChange", function(evt) { strictEqual(evt.key, "vrotation"); strictEqual(evt.oldValue, 0); });
     e.vrotation = 1;
     Crafty.trigger('EnterFrame', {dt: 1000});
@@ -831,6 +836,7 @@
     e.one("NewRevolution", function(evt) {
       equal(evt, -1);
     });
+    e.one("Rotated", function(oldValue) { strictEqual(oldValue, 1); });
     e.one("MotionChange", function(evt) { strictEqual(evt.key, "vrotation"); strictEqual(evt.oldValue, 1); });
     e.vrotation = -1;
     Crafty.trigger('EnterFrame', {dt: 1000});
@@ -845,6 +851,7 @@
     equal(newDirectionEvents, 4);
     equal(newRevolutionEvents, 3);
     equal(movedEvents, 6);
+    equal(rotatedEvents, 2);
     equal(motionEvents, 17);
     e.destroy();
   });

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -392,10 +392,8 @@
 
   test("disableControl and enableControl and speed", function() {
     var e = Crafty.e("2D, Twoway")
-      .attr({
-        x: 0
-      })
-      .twoway(2);
+      .attr({ x: 0 })
+      .twoway();
 
     equal(e._vx, 0);
     equal(e._x, 0);

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -932,6 +932,7 @@
 
     var player = Crafty.e("2D, Gravity")
           .attr({ x: 0, y: 100, w: 32, h: 16 })
+          .gravityConst(0.3)
           .gravity("platform");
    
     strictEqual(player.acceleration().y, player._gravityConst, "acceleration should match gravity constant");
@@ -960,8 +961,8 @@
           vel = -1;
 
           var oldVel = this.velocity().y;
-          this.gravityConst(0.1);
-          strictEqual(this._gravityConst, 0.1, "gravity constant should have changed");
+          this.gravityConst(0.2);
+          strictEqual(this._gravityConst, 0.2, "gravity constant should have changed");
           strictEqual(this.acceleration().y, this._gravityConst, "acceleration should match gravity constant");
           strictEqual(this.velocity().y, oldVel, "velocity shouldn't have been resetted");
         });

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -311,31 +311,31 @@
     });
     Crafty.keydown[Crafty.keys.W] = true;
     e.multiway(1, { W: -90 });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vy, e.__convertPixelsToMeters(-1));
-    equal(e._y, e.__convertPixelsToMeters(-1));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vy, -1);
+    equal(e._y, -1);
 
     e.multiway(2, { W: 90 });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vy, e.__convertPixelsToMeters(2));
-    equal(e._y, e.__convertPixelsToMeters(1));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vy, 2);
+    equal(e._y, 1);
 
     e.fourway(1);
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vy, e.__convertPixelsToMeters(-1));
-    equal(e._y, e.__convertPixelsToMeters(0));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vy, -1);
+    equal(e._y, 0);
 
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vy, e.__convertPixelsToMeters(-1));
-    equal(e._y, e.__convertPixelsToMeters(-1));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vy, -1);
+    equal(e._y, -1);
 
     
     Crafty.trigger('KeyDown', {
       key: Crafty.keys.UP_ARROW
     });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vy, e.__convertPixelsToMeters(-1));
-    equal(e._y, e.__convertPixelsToMeters(-2));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vy, -1);
+    equal(e._y, -2);
 
     Crafty.trigger('KeyUp', {
       key: Crafty.keys.W
@@ -344,9 +344,9 @@
     Crafty.trigger('KeyUp', {
       key: Crafty.keys.UP_ARROW
     });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vy, e.__convertPixelsToMeters(0));
-    equal(e._y, e.__convertPixelsToMeters(-2));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vy, 0);
+    equal(e._y, -2);
 
 
     Crafty.trigger('KeyDown', {
@@ -355,36 +355,36 @@
     Crafty.trigger('KeyDown', {
       key: Crafty.keys.LEFT_ARROW
     });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vy, e.__convertPixelsToMeters(1));
-    equal(e._y, e.__convertPixelsToMeters(-1));
-    equal(e._vx, e.__convertPixelsToMeters(-1));
-    equal(e._x, e.__convertPixelsToMeters(-1));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vy, 1);
+    equal(e._y, -1);
+    equal(e._vx, -1);
+    equal(e._x, -1);
 
     Crafty.trigger('KeyUp', {
       key: Crafty.keys.DOWN_ARROW
     });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vy, e.__convertPixelsToMeters(0));
-    equal(e._y, e.__convertPixelsToMeters(-1));
-    equal(e._vx, e.__convertPixelsToMeters(-1));
-    equal(e._x, e.__convertPixelsToMeters(-2));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vy, 0);
+    equal(e._y, -1);
+    equal(e._vx, -1);
+    equal(e._x, -2);
 
     e.removeComponent("Multiway");
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vy, e.__convertPixelsToMeters(0));
-    equal(e._y, e.__convertPixelsToMeters(-1));
-    equal(e._vx, e.__convertPixelsToMeters(0));
-    equal(e._x, e.__convertPixelsToMeters(-2));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vy, 0);
+    equal(e._y, -1);
+    equal(e._vx, 0);
+    equal(e._x, -2);
 
     Crafty.trigger('KeyUp', {
       key: Crafty.keys.LEFT_ARROW
     });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vy, e.__convertPixelsToMeters(0));
-    equal(e._y, e.__convertPixelsToMeters(-1));
-    equal(e._vx, e.__convertPixelsToMeters(0));
-    equal(e._x, e.__convertPixelsToMeters(-2));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vy, 0);
+    equal(e._y, -1);
+    equal(e._vx, 0);
+    equal(e._x, -2);
 
 
     e.destroy();
@@ -397,58 +397,58 @@
       })
       .twoway(2);
 
-    equal(e._vx, e.__convertPixelsToMeters(0));
-    equal(e._x, e.__convertPixelsToMeters(0));
+    equal(e._vx, 0);
+    equal(e._x, 0);
 
     e.enableControl();
     e.speed({ x: 1, y: 1 });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vx, e.__convertPixelsToMeters(0));
-    equal(e._x, e.__convertPixelsToMeters(0));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vx, 0);
+    equal(e._x, 0);
 
     Crafty.trigger('KeyDown', {
       key: Crafty.keys.D
     });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vx, e.__convertPixelsToMeters(1));
-    equal(e._x, e.__convertPixelsToMeters(1));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vx, 1);
+    equal(e._x, 1);
 
     e.disableControl();
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vx, e.__convertPixelsToMeters(0));
-    equal(e._x, e.__convertPixelsToMeters(1));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vx, 0);
+    equal(e._x, 1);
 
     Crafty.trigger('KeyUp', {
       key: Crafty.keys.D
     });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vx, e.__convertPixelsToMeters(0));
-    equal(e._x, e.__convertPixelsToMeters(1));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vx, 0);
+    equal(e._x, 1);
 
     e.disableControl();
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vx, e.__convertPixelsToMeters(0));
-    equal(e._x, e.__convertPixelsToMeters(1));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vx, 0);
+    equal(e._x, 1);
 
 
     e.enableControl();
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vx, e.__convertPixelsToMeters(0));
-    equal(e._x, e.__convertPixelsToMeters(1));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vx, 0);
+    equal(e._x, 1);
 
     Crafty.trigger('KeyDown', {
       key: Crafty.keys.D
     });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vx, e.__convertPixelsToMeters(1));
-    equal(e._x, e.__convertPixelsToMeters(2));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vx, 1);
+    equal(e._x, 2);
 
     Crafty.trigger('KeyUp', {
       key: Crafty.keys.D
     });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vx, e.__convertPixelsToMeters(0));
-    equal(e._x, e.__convertPixelsToMeters(2));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vx, 0);
+    equal(e._x, 2);
 
 
     Crafty.trigger('KeyDown', {
@@ -457,39 +457,39 @@
     Crafty.trigger('KeyDown', {
       key: Crafty.keys.RIGHT_ARROW
     });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vx, e.__convertPixelsToMeters(1));
-    equal(e._x, e.__convertPixelsToMeters(3));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vx, 1);
+    equal(e._x, 3);
 
     e.disableControl();
     e.speed({ x: 2, y: 2 });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vx, e.__convertPixelsToMeters(0));
-    equal(e._x, e.__convertPixelsToMeters(3));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vx, 0);
+    equal(e._x, 3);
 
     e.enableControl();
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vx, e.__convertPixelsToMeters(2));
-    equal(e._x, e.__convertPixelsToMeters(5));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vx, 2);
+    equal(e._x, 5);
 
     e.speed({ x: 3, y: 3 });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vx, e.__convertPixelsToMeters(3));
-    equal(e._x, e.__convertPixelsToMeters(8));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vx, 3);
+    equal(e._x, 8);
 
     Crafty.trigger('KeyUp', {
       key: Crafty.keys.D
     });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vx, e.__convertPixelsToMeters(3));
-    equal(e._x, e.__convertPixelsToMeters(11));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vx, 3);
+    equal(e._x, 11);
 
     Crafty.trigger('KeyUp', {
       key: Crafty.keys.RIGHT_ARROW
     });
-    Crafty.trigger('EnterFrame', {dt: 1000});
-    equal(e._vx, e.__convertPixelsToMeters(0));
-    equal(e._x, e.__convertPixelsToMeters(11));
+    Crafty.timer.simulateFrames(1);
+    equal(e._vx, 0);
+    equal(e._x, 11);
 
 
     e.destroy();
@@ -683,11 +683,10 @@
     strictEqual(ent.drotation, 0, "angular delta should be zero");
 
 
-
-
+    Crafty.timer.FPS(25);
     ent.velocity().setValues(v0);
     ent.vrotation = v0_r;
-    Crafty.trigger('EnterFrame', {dt: 1000});
+    Crafty.timer.simulateFrames(1);
     ok(ent.velocity().equals(v0), "velocity should be <2,5>");
     strictEqual(ent.vrotation, v0_r, "angular velocity should be 10");
     ok(ent.motionDelta().equals(v0), "delta should be <2,5>");
@@ -699,7 +698,7 @@
     var dPos = new Vector2D(a).scale(0.5).add(v0), dPos_r = v0_r + 0.5*a_r;
     ent.acceleration().setValues(a);
     ent.arotation = a_r;
-    Crafty.trigger('EnterFrame', {dt: 1000});
+    Crafty.timer.simulateFrames(1);
     ok(dPos.equals(new Vector2D(4,6)), "should be <4,6>");
     strictEqual(dPos_r, 2.5, "should be 2.5");
     ok(ent.motionDelta().equals(dPos), "delta should be <4,6>");
@@ -712,14 +711,14 @@
     strictEqual(ent.vrotation, v1_r, "angular velocity should be -5");
 
 
-
+    Crafty.timer.FPS(50);
     ent.attr({x: 0, y: 0})
        .resetMotion()
        .resetAngularMotion();
 
     ent.velocity().x = 10;
     ent.acceleration().x = 5;
-    Crafty.trigger('EnterFrame', {dt: 500});
+    Crafty.timer.simulateFrames(1, (1000 / Crafty.timer.FPS()) / 2);
     equal(ent.velocity().x, 10+5*0.5, "velocity x should be 12.5");
     equal(ent.x, 10*0.5+0.5*5*0.5*0.5, "entity x should be 5.625");
 
@@ -761,7 +760,7 @@
     e.one("Moved", function(evt) { strictEqual(evt.axis, "y"); strictEqual(evt.oldValue, 0); });
     e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, 0); });
     e.vy = 1;
-    Crafty.trigger('EnterFrame', {dt: 1000});
+    Crafty.timer.simulateFrames(1);
 
     e.one("NewDirection", function(evt) {
       equal(evt.x, -1);
@@ -775,7 +774,7 @@
     e.vy = 0;
     e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, 0); });
     e.vy = -1;
-    Crafty.trigger('EnterFrame', {dt: 1000});
+    Crafty.timer.simulateFrames(1);
 
     e.one("Moved", function(evt) { strictEqual(evt.axis, "x"); strictEqual(evt.oldValue, -1); 
     e.one("Moved", function(evt) { strictEqual(evt.axis, "y"); strictEqual(evt.oldValue, 0); });});
@@ -784,7 +783,7 @@
     e.vy = 0;
     e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, 0); });
     e.vy = -1;
-    Crafty.trigger('EnterFrame', {dt: 1000});
+    Crafty.timer.simulateFrames(1);
 
     e.one("NewDirection", function(evt) {
       equal(evt.x, 0);
@@ -797,7 +796,7 @@
     e.vy = 0;
     e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, 0); });
     e.vy = -1;
-    Crafty.trigger('EnterFrame', {dt: 1000});
+    Crafty.timer.simulateFrames(1);
 
     e.one("NewDirection", function(evt) {
       equal(evt.x, 0);
@@ -806,24 +805,24 @@
     });
     e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, -1); });
     e.vy = 0;
-    Crafty.trigger('EnterFrame', {dt: 1000});
+    Crafty.timer.simulateFrames(1);
 
     e.vx = 0;
     e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, 0); });
     e.vy = 1;
     e.one("MotionChange", function(evt) { strictEqual(evt.key, "vy"); strictEqual(evt.oldValue, 1); });
     e.vy = 0;
-    Crafty.trigger('EnterFrame', {dt: 1000});
+    Crafty.timer.simulateFrames(1);
 
 
     e.vrotation = 0;
-    Crafty.trigger('EnterFrame', {dt: 1000});
+    Crafty.timer.simulateFrames(1);
 
     e.one("MotionChange", function(evt) { strictEqual(evt.key, "vrotation"); strictEqual(evt.oldValue, 0); });
     e.vrotation = 1;
     e.one("MotionChange", function(evt) { strictEqual(evt.key, "vrotation"); strictEqual(evt.oldValue, 1); });
     e.vrotation = 0;
-    Crafty.trigger('EnterFrame', {dt: 1000});
+    Crafty.timer.simulateFrames(1);
 
     e.one("NewRevolution", function(evt) {
       equal(evt, 1);
@@ -831,7 +830,7 @@
     e.one("Rotated", function(oldValue) { strictEqual(oldValue, 0); });
     e.one("MotionChange", function(evt) { strictEqual(evt.key, "vrotation"); strictEqual(evt.oldValue, 0); });
     e.vrotation = 1;
-    Crafty.trigger('EnterFrame', {dt: 1000});
+    Crafty.timer.simulateFrames(1);
 
     e.one("NewRevolution", function(evt) {
       equal(evt, -1);
@@ -839,14 +838,14 @@
     e.one("Rotated", function(oldValue) { strictEqual(oldValue, 1); });
     e.one("MotionChange", function(evt) { strictEqual(evt.key, "vrotation"); strictEqual(evt.oldValue, 1); });
     e.vrotation = -1;
-    Crafty.trigger('EnterFrame', {dt: 1000});
+    Crafty.timer.simulateFrames(1);
 
     e.one("NewRevolution", function(evt) {
       equal(evt, 0);
     });
     e.one("MotionChange", function(evt) { strictEqual(evt.key, "vrotation"); strictEqual(evt.oldValue, -1); });
     e.vrotation = 0;
-    Crafty.trigger('EnterFrame', {dt: 1000});
+    Crafty.timer.simulateFrames(1);
 
     equal(newDirectionEvents, 4);
     equal(newRevolutionEvents, 3);
@@ -876,26 +875,26 @@
 
 
     ok(!ent.ground(), "entity should not be on ground");
-    Crafty.trigger("EnterFrame");
+    Crafty.timer.simulateFrames(1);
     ok(!ent.ground(), "entity should not be on ground");
 
     ent.y = 5;
-    Crafty.trigger("EnterFrame"); // 1 landed event should have occured
+    Crafty.timer.simulateFrames(1); // 1 landed event should have occured
     equal(ent.y, 5, "ent y should not have changed");
     ok(ent.ground(), "entity should be on ground");
 
     ent.y = 0;
-    Crafty.trigger("EnterFrame"); // 1 lifted event should have occured
+    Crafty.timer.simulateFrames(1); // 1 lifted event should have occured
     equal(ent.y, 0, "ent y should not have changed");
     ok(!ent.ground(), "entity should not be on ground");
 
     ent.y = 7;
-    Crafty.trigger("EnterFrame"); // 1 landed event should have occured
+    Crafty.timer.simulateFrames(1); // 1 landed event should have occured
     equal(ent.y, 5, "ent y should have been snapped to ground");
     ok(ent.ground(), "entity should be on ground");
 
     ent.y = 0;
-    Crafty.trigger("EnterFrame"); // 1 lifted event should have occured
+    Crafty.timer.simulateFrames(1); // 1 lifted event should have occured
     equal(ent.y, 0, "ent y should not have changed");
     ok(!ent.ground(), "entity should not be on ground");
 
@@ -903,7 +902,7 @@
       this.canLand = false;
     });
     ent.y = 7;
-    Crafty.trigger("EnterFrame"); // no event should have occured
+    Crafty.timer.simulateFrames(1); // no event should have occured
     equal(ent.y, 7, "ent y should not have changed");
     ok(!ent.ground(), "entity should not be on ground");
 
@@ -927,6 +926,7 @@
     ground.x = 20;
     strictEqual(player.x, 10, "player did not move with ground");
   });
+
 
   test("Gravity", function() {
     var ground = Crafty.e("2D, platform")
@@ -958,14 +958,12 @@
         this.bind("LiftedOffGround", function() {
           liftCount++;
 
-          Crafty.trigger("EnterFrame", {dt: 50});
-          Crafty.trigger("EnterFrame", {dt: 50});
-          Crafty.trigger("EnterFrame", {dt: 50});
+          Crafty.timer.simulateFrames(3);
           vel = -1;
 
           var oldVel = this.velocity().y;
-          this.gravityConst(5);
-          strictEqual(this._gravityConst, this.__convertPixelsToMeters(5), "gravity constant should have changed");
+          this.gravityConst(0.1);
+          strictEqual(this._gravityConst, 0.1, "gravity constant should have changed");
           strictEqual(this.acceleration().y, this._gravityConst, "acceleration should match gravity constant");
           strictEqual(this.velocity().y, oldVel, "velocity shouldn't have been resetted");
         });

--- a/tests/core.js
+++ b/tests/core.js
@@ -698,4 +698,35 @@
     Crafty.unbind("PostRender", postRenderFunc);
   });
 
+  test('Crafty.timer.FPS', function() {
+    var counter = 0;
+    var increment = function() {
+      counter++;
+    };
+    Crafty.bind("FPSChange", increment);
+
+    Crafty.one("FPSChange", function(fps) {
+      strictEqual(fps, 25);
+      strictEqual(Crafty.timer.FPS(), 25);
+    });
+    Crafty.one("EnterFrame", function(frameData) {
+      strictEqual(frameData.dt, 1000/25);
+    });
+    Crafty.timer.FPS(25);
+    Crafty.timer.simulateFrames(1);
+
+    Crafty.one("FPSChange", function(fps) {
+      strictEqual(fps, 50);
+      strictEqual(Crafty.timer.FPS(), 50);
+    });
+    Crafty.one("EnterFrame", function(frameData) {
+      strictEqual(frameData.dt, 1000/50);
+    });
+    Crafty.timer.FPS(50);
+    Crafty.timer.simulateFrames(1);
+
+    Crafty.unbind("FPSChange", increment);
+    strictEqual(counter, 2);
+  });
+
 })();


### PR DESCRIPTION
Continuation of #876 
- Change units in motion system to use user intuitive pixels per frame and degrees per frame  
  Now when user sets `vx = 1`, the entity will move `1px` each frame, depending on the current target fps `Crafty.timer.FPS()`. Note that this should also work in the cases when user selects different `timer.stepMode` (e.g. `variable`), as the calculation is still done using `dt` and a `dtFactor` derived from the desired target FPS.
- Fixes bug that when setting `gravityConst` before activating `gravity()` leads to inconsistent state
- Fixes bug that leads to incosistent state when entity intersects with multiple ground entities
- Small improvements `Supportable`, `Twoway` and `Multiway`
- Add additional tests
### Future additions
- Allow Supportable to check for SAT collision (see [discussion](https://groups.google.com/forum/#!topic/craftyjs/2_PCJK8B6Ek)). However, what to do about entity snapping? `this.y = hit._y - this._h; // snap entity to ground object`. 
  As you can see, this won't snap correctly with the polygon hitbox being larger/smaller than the actual entity. Should the user be allowed to specify his own snap function?
- I think we should limit the downwards velocity when gravity is active (introduce settable `terminal velocity` that defaults to the velocity caused by gravity after 12 frames) and document for user that he should make his platforms at least `terminal velocity + 1` high - `max(entity._h, platform._h) > terminal velocity`
