### PR TITLE
Per-texture pixelart setting

### DIFF
--- a/src/graphics/canvas-layer.js
+++ b/src/graphics/canvas-layer.js
@@ -89,6 +89,10 @@ Crafty.extend({
             // Set pixelart to current status, and listen for changes
             this._setPixelart(Crafty._pixelartEnabled);
             Crafty.uniqueBind("PixelartSet", this._setPixelart);
+            
+            // Listen for pixelart overrides during drawing
+            // (caused by individual entities)
+            Crafty.uniqueBind("PixelartSetDraw", this._setPixelart);
 
             //Bind rendering of canvas context (see drawing.js)
             Crafty.uniqueBind("RenderScene", this._render);

--- a/src/graphics/canvas.js
+++ b/src/graphics/canvas.js
@@ -138,6 +138,7 @@ Crafty.c("Canvas", {
             context.globalAlpha = this._alpha;
         }
 
+        this.trigger("PreDraw");
         this.drawVars.ctx = context;
         this.trigger("Draw", this.drawVars);
 
@@ -148,6 +149,7 @@ Crafty.c("Canvas", {
         if (globalpha) {
             context.globalAlpha = globalpha;
         }
+        this.trigger("PostDraw");
         return this;
     }
 });

--- a/src/graphics/drawing.js
+++ b/src/graphics/drawing.js
@@ -40,3 +40,26 @@ Crafty.extend({
         Crafty.trigger("PixelartSet", enabled);
     }
 });
+
+Crafty.c("Pixelart", {
+    init: function () {
+        this._pixelartEnabled = Crafty._pixelartEnabled;
+        this.bind("PreDraw", this._setPixelart);
+        this.bind("PostDraw", this._resetPixelart);
+    },
+    
+    pixelart: function(enabled) {
+        this._pixelartEnabled = enabled;
+        this.trigger("PixelartSet", enabled);
+    },
+    
+    _setPixelart: function() {
+        // Trigger global event for engines that need it (Canvas).
+        // Should be ignored by others (WebGL,DOM).
+        Crafty.trigger("PixelartSetDraw", this._pixelartEnabled);
+    },
+    
+    _resetPixelart: function() {
+        Crafty.trigger("PixelartSetDraw", Crafty._pixelartEnabled);
+    }
+});

--- a/src/graphics/gl-textures.js
+++ b/src/graphics/gl-textures.js
@@ -30,7 +30,7 @@ TextureManager.prototype = {
 
 	// creates a texture out of the given image and repeating state
 	// The url is just used to generate a unique id for the texture
-	makeTexture: function(url, image, repeating) {
+	makeTexture: function(url, image, repeating, filter) {
 		// gl is the context, webgl the Crafty object containing prefs/etc
         var gl = this.gl, webgl = this.webgl;
 
@@ -45,8 +45,8 @@ TextureManager.prototype = {
         this.bindTexture(t);
 
         // Set the properties of the texture 
-        t.setImage(image);
-        t.setFilter(webgl.texture_filter);
+        t.setImage(image);        
+        t.setFilter(filter);
         t.setRepeat(repeating);
 
         return t;

--- a/src/graphics/image.js
+++ b/src/graphics/image.js
@@ -96,7 +96,7 @@ Crafty.c("Image", {
             this._pattern = this._drawContext.createPattern(this.img, this._repeat);
         } else if (this.has("WebGL")) {
             this._establishShader("image:" + this.__image, IMAGE_FRAGMENT_SHADER, IMAGE_VERTEX_SHADER, IMAGE_ATTRIBUTE_LIST);
-            this.program.setTexture( this.webgl.makeTexture(this.__image, this.img, (this._repeat!=="no-repeat")));
+            this.program.setTexture( this.webgl.makeTexture(this.__image, this.img, (this._repeat!=="no-repeat")), this._pixelartEnabled);
         }
 
         if (this._repeat === "no-repeat") {

--- a/src/graphics/sprite.js
+++ b/src/graphics/sprite.js
@@ -65,7 +65,7 @@ Crafty.extend({
      *
      * @see Sprite
      */
-    sprite: function (tile, tileh, url, map, paddingX, paddingY, paddingAroundBorder) {
+    sprite: function (tile, tileh, url, map, paddingX, paddingY, paddingAroundBorder, pixelart) {
         var spriteName, temp, x, y, w, h, img;
 
         //if no tile value, default to 1.
@@ -121,6 +121,11 @@ Crafty.extend({
             this.__padBorder = paddingAroundBorder;
             this.sprite(this.__coord[0], this.__coord[1], this.__coord[2], this.__coord[3]);
             
+            if (typeof pixelart == "boolean") {
+                this.requires("Pixelart");
+                this.pixelart(pixelart);
+            }
+            
             this.img = img;
             //draw now
             if (this.img.complete && this.img.width > 0) {
@@ -134,7 +139,7 @@ Crafty.extend({
 
             if (this.has("WebGL")){
                 this._establishShader(this.__image, SPRITE_FRAGMENT_SHADER, SPRITE_VERTEX_SHADER, SPRITE_ATTRIBUTE_LIST);
-                this.program.setTexture( this.webgl.makeTexture(this.__image, this.img, false) );
+                this.program.setTexture( this.webgl.makeTexture(this.__image, this.img, false, pixelart) );
             }
         };
 

--- a/src/graphics/webgl.js
+++ b/src/graphics/webgl.js
@@ -412,9 +412,14 @@ Crafty.extend({
 
         // Make a texture out of the given image element
         // The url is just used as a unique ID
-        makeTexture: function(url, image, repeating){
+        makeTexture: function(url, image, repeating, pixelart){
             var webgl = this;
-            return webgl.texture_manager.makeTexture(url, image, repeating);
+            var filter = webgl.texture_filter;
+            if (typeof pixelart == "boolean") {
+                var gl = webgl.context;
+                filter = pixelart ? gl.NEAREST : gl.LINEAR;
+            }
+            return webgl.texture_manager.makeTexture(url, image, repeating, filter);
         },
 
         /**@


### PR DESCRIPTION
This partly implements #882.

Canvas fully works. WebGL works, but it doesn't listen for pixelart change events from an entity. DOM is not implemented yet, but should be easy.

Main use case is probably via the Crafty.sprite() function, where I added another parameter. Looking at the code is probably the best to understand it. Due to the different ways things are rendered in Canvas, WebGL, DOM I had to make it quite flexible, but I think the design is not bad.

This pull request should not be merged yet but serve for discussion. It probably needs changes, and the DOM implementation.
