### PR TITLE
Fix a bug with tick when Crafty.stop() has been called

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -1264,7 +1264,9 @@ Crafty.extend({
                 if (onFrame) {
                     tick = function () {
                         Crafty.timer.step();
-                        requestID = onFrame(tick);
+                        if (tick !== null) {
+                            requestID = onFrame(tick);
+                        }
                         //console.log(requestID + ', ' + frame)
                     };
 


### PR DESCRIPTION
Crafty.stop() will set tick = null, but if this happens _inside_ the game loop, then the currently executing tick function will still try to call onFrame, causing an error.

In some environments setInterval might be used instead -- because of the difference in logic, I don't believe a fix is needed in such a case.

Due to some unrelated issues with Crafty.stop() and how Crafty is setup, we can't run any tests involving stop() right now, so I didn't add one for this issue.

This fixes #887.
