### PR TITLE
Have travis upload "nightly" builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: node_js
 node_js:
-  - "0.10"
+  - '0.10'
 before_script:
   - npm install -g grunt-cli
+
+after_success: ./travis-nightly.sh
+
 cache:
   directories:
     - node_modules
+env:
+  global:
+    secure: p6SeAGd+Gohr6XeDkb5JPSQBu88UxAjljSMK0BNLJQgr8GkoA3mSJWy4uX0YjNq93VX4UMFxr0D4MlkcWZpX+cdN8K9PpxOgTq8Ml1Ljs355zbX9U/CdY99okiwzHktY4qKXBPsHLiEuCBeJ6pxs/v7m9z88mkjwDSunJG7F1oo=

--- a/travis-nightly.sh
+++ b/travis-nightly.sh
@@ -1,0 +1,16 @@
+# If this isn't a PR, and occurs on the develop branch, push crafty.js to craftyjs/Crafty-Distro
+if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "develop" ]; then
+  echo -e "Uploading nightly build to craftyjs/Crafty-Distro\n" 
+  # Log some git info to the file commit_date
+  TZ=UTC git log -n 1 --format=format:"built from commit %h (%cd) of 'develop' branch" --date=local > commit_date
+  #Clone the nightlies branch into the nightlies directory
+  git clone -b nightlies https://${GH_TOKEN}@github.com/craftyjs/Crafty-Distro.git $HOME/nightlies
+  mv $TRAVIS_BUILD_DIR/crafty.js $HOME/nightlies
+  mv $TRAVIS_BUILD_DIR/commit_date $HOME/nightlies/README.md
+  cd $HOME/nightlies
+  git config user.name "Travis"
+  git config user.email "travis@travis-ci.org"
+  git add crafty.js README.md
+  git commit -m "automated commit of Travis build $TRAVIS_BUILD_NUMBER"
+  git push origin nightlies
+fi


### PR DESCRIPTION
When a travis build is triggered that is not part of a pull request, it will run a script to upload the build to Crafty-Distro
- It will upload using the OAuth token of the account @craftyjs-machine-user, which has write permissions only to Crafty-Distro and craftyjs.github.com
- The upload script is in the file `travis-nightly.sh`
- I've also tried to configure tron-ci to automatically run the travis build script once a night, but I'm not actually sure that's necessary -- I think it should just run the script after we merge a PR

Thanks to @neothemachine for providing the basis of the script (see #885)!  ~~This particular version hasn't been tested yet.~~
