### PR TITLE
Streamline intersect checks

### DIFF
--- a/src/graphics/sprite-animation.js
+++ b/src/graphics/sprite-animation.js
@@ -1,5 +1,4 @@
-var Crafty = require('../core/core.js'),
-	Animation = require('../core/animation.js');
+var Crafty = require('../core/core.js');
 
 
 /**@

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -488,7 +488,8 @@ Crafty.c("2D", {
             };
         }
 
-        return Crafty.rectManager.overlap(mbr, rect);
+        return mbr._x < rect._x + rect._w && mbr._x + mbr._w > rect._x &&
+            mbr._y < rect._y + rect._h && mbr._y + mbr._h > rect._y;
     },
 
     /**@

--- a/src/spatial/rect-manager.js
+++ b/src/spatial/rect-manager.js
@@ -37,7 +37,7 @@ Crafty.extend({
        */
       overlap: function (rectA, rectB) {
         return (rectA._x < rectB._x + rectB._w && rectA._x + rectA._w > rectB._x &&
-                rectA._y < rectB._y + rectB._h && rectA._h + rectA._y > rectB._y);
+                rectA._y < rectB._y + rectB._h && rectA._y + rectA._h > rectB._y);
       },
 
       /**@

--- a/src/spatial/spatial-grid.js
+++ b/src/spatial/spatial-grid.js
@@ -75,7 +75,6 @@ var Crafty = require('../core/core.js');
         search: function (rect, filter) {
             var keys = HashMap.key(rect, keyHolder),
                 i, j, k, l, cell,
-                overlap = Crafty.rectManager.overlap,
                 results = [];
 
             if (filter === undefined) filter = true; //default filter to true
@@ -102,7 +101,8 @@ var Crafty = require('../core/core.js');
                     id = obj[0]; //unique ID
                     obj = obj._mbr || obj;
                     //check if not added to hash and that actually intersects
-                    if (!found[id] && overlap(obj, rect))
+                    if (!found[id] && obj._x < rect._x + rect._w && obj._x + obj._w > rect._x &&
+                                      obj._y < rect._y + rect._h && obj._y + obj._h > rect._y)
                         found[id] = results[i];
                 }
 


### PR DESCRIPTION
Remove unneeded dependency on animation.js in sprite-animation.js.
Revert HashMap's intersect check to use hardcoded intersection in order to avoid dependency on Crafty.
Revert 2d.intersect to hardcoded intersection (to be streamlined with rest of 2d rect methods, fixes #874).
