### PR TITLE
Fix supportable ground detection bug

### DIFF
--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -958,7 +958,7 @@ Crafty.c("Supportable", {
      * ~~~
      * var player = Crafty.e("2D, Gravity");
      * player.bind("CheckLanding", function(ground) {
-     *     if (player.y + player.h > ground.y + player.vy) { // forbid landing, if player's feet are not above ground
+     *     if (player.y + player.h > ground.y + player.dy) { // forbid landing, if player's feet are not above ground
      *         player.canLand = false;
      *     }
      * });
@@ -1043,7 +1043,7 @@ Crafty.c("Supportable", {
         }
 
         if (!ground) {
-            var hit = false, obj, oarea,
+            var obj, oarea,
                 results = Crafty.map.search(area, false),
                 i = 0,
                 l = results.length;
@@ -1053,18 +1053,15 @@ Crafty.c("Supportable", {
                 oarea = obj._cbr || obj._mbr || obj;
                 // check for an intersection with the player
                 if (obj !== this && obj.__c[groundComp] && overlap(oarea, area)) {
-                    hit = obj;
-                    break;
-                }
-            }
+                    this.canLand = true;
+                    this.trigger("CheckLanding", obj); // is entity allowed to land?
+                    if (this.canLand) {
+                        this._ground = ground = obj;
+                        this.y = obj._y - this._h; // snap entity to ground object
+                        this.trigger("LandedOnGround", ground); // collision with ground was detected for first time
 
-            if (hit) {
-                this.canLand = true;
-                this.trigger("CheckLanding", hit); // is entity allowed to land?
-                if (this.canLand) {
-                    this._ground = ground = hit;
-                    this.y = hit._y - this._h; // snap entity to ground object
-                    this.trigger("LandedOnGround", ground); // collision with ground was detected for first time
+                        break;
+                    }
                 }
             }
         }

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -922,16 +922,21 @@
     strictEqual(ent.ground, null, "entity should not be on ground");
 
     ground.addComponent("Ground");
-    ent.bind("CheckLanding", function(ground) {
-      this.canLand = false;
+    ground2.addComponent("Ground");
+    ent.bind("CheckLanding", function(candidate) {
+      if (candidate === ground)
+        this.canLand = false;
     });
     ent.y = 7;
     Crafty.timer.simulateFrames(1); // no event should have occured
     equal(ent.y, 7, "ent y should not have changed");
     strictEqual(ent.ground, null, "entity should not be on ground");
+    ent.y = 12;
+    Crafty.timer.simulateFrames(1); // 1 landed event should have occured
+    equal(ent.y, ground2.y - ent.h, "ent y should have been snapped to ground");
+    strictEqual(ent.ground, ground2, "entity should be on ground2");
 
-
-    equal(landedCount, 3, "landed count mismatch");
+    equal(landedCount, 4, "landed count mismatch");
     equal(liftedCount, 3, "lifted count mismatch");
 
     ground.destroy();


### PR DESCRIPTION
Only one entity is chosen among all intersected ground entities;
however, if this entity does not pass "CheckLanding" requirement, the
player will not land on any ground entity, even if the other entities
satisfy the requirement.

Demonstrated in [this demo](https://github.com/craftyjs/demos/blob/master/devDemos/example_realisticJump.html) when trying to jump in the middle of the first two platforms.
