### PR TITLE
Add jump keys parameter to TwoWay component

### DIFF
--- a/src/controls/controls.js
+++ b/src/controls/controls.js
@@ -1342,7 +1342,7 @@ Crafty.c("Twoway", {
      * @sign public this .twoway([Number speed[, Number jump, {Number|Array} jumpKeys]])
      * @param speed - Amount of pixels to move left or right
      * @param jump - Vertical jump speed
-     * @param jumpKeys - Defines one or more additional entity jump keys
+     * @param jumpKeys - Defines one or more entity jump keys
      *
      * Constructor to initialize the speed and power of jump. Component will
      * listen for key events and move the entity appropriately. This includes
@@ -1352,7 +1352,9 @@ Crafty.c("Twoway", {
      * The key presses will move the entity in that direction by the speed passed in
      * the argument. Pressing the `Up Arrow` or `W` will cause the entity to jump.
      *
-     * @see Gravity, Multiway, Fourway, Motion
+     * If jumpKeys is specified  the `Up Arrow` and `W` jump keys will be overridden.
+     *
+     * @see Gravity, Multiway, Fourway, Motion, Crafty.keys
      */
     twoway: function (speed, jump, jumpKeys) {
         this._jumpKeys = [Crafty.keys.UP_ARROW, Crafty.keys.W];
@@ -1366,16 +1368,17 @@ Crafty.c("Twoway", {
         });
 
         if (arguments.length < 2) {
-          this._jumpSpeed = this._speed.y * 2;
+            this._jumpSpeed = this._speed.y * 2;
         } else {
-          this._jumpSpeed = jump;
-          if (typeof jumpKeys === 'number') {
-            this._jumpKeys.push(jumpKeys);
-          } else if (jumpKeys) {
-            // Assume an array, although this could bite us :(
-            // We do, however (probably), save some type check speed
-            this._jumpKeys = this._jumpKeys.concat(jumpKeys);
-          }
+            this._jumpSpeed = jump;
+            if (typeof jumpKeys === 'number') {
+                this._jumpKeys[0] = jumpKeys;
+                this._jumpKeys.length = 1;
+            } else if (jumpKeys) {
+                // Assume an array, although this could bite us :(
+                // We do, however (probably), save some type check speed
+                this._jumpKeys = jumpKeys;
+            }
         }
         this.uniqueBind("KeyDown", this._keydown_twoway);
 

--- a/src/controls/controls.js
+++ b/src/controls/controls.js
@@ -90,7 +90,7 @@ Crafty.extend({
                  });
              }
         }
-		
+        
         Crafty.keydown = {};
     },
     
@@ -1288,6 +1288,7 @@ Crafty.c("Fourway", {
  */
 Crafty.c("Twoway", {
     _jumpSpeed: 6,
+    _jumpKeys: false,
 
     /**@
      * #.canJump
@@ -1325,7 +1326,7 @@ Crafty.c("Twoway", {
     _keydown_twoway: function (e) {
         if (this.disableControls) return;
 
-        if (e.key === Crafty.keys.UP_ARROW || e.key === Crafty.keys.W || e.key === Crafty.keys.Z) {
+        if (this._jumpKeys.indexOf(e.key) !== -1) {
             var ground = this.ground;
             this.canJump = !!ground;
             this.trigger("CheckJumping", ground);
@@ -1338,9 +1339,10 @@ Crafty.c("Twoway", {
     /**@
      * #.twoway
      * @comp Twoway
-     * @sign public this .twoway([Number speed[, Number jump]])
+     * @sign public this .twoway([Number speed[, Number jump, {Number|Array} jumpKeys]])
      * @param speed - Amount of pixels to move left or right
      * @param jump - Vertical jump speed
+     * @param jumpKeys - Defines one or more additional entity jump keys
      *
      * Constructor to initialize the speed and power of jump. Component will
      * listen for key events and move the entity appropriately. This includes
@@ -1352,7 +1354,8 @@ Crafty.c("Twoway", {
      *
      * @see Gravity, Multiway, Fourway, Motion
      */
-    twoway: function (speed, jump) {
+    twoway: function (speed, jump, jumpKeys) {
+        this._jumpKeys = [Crafty.keys.UP_ARROW, Crafty.keys.W];
 
         this.multiway(speed || this._speed, {
             RIGHT_ARROW: 0,
@@ -1366,6 +1369,13 @@ Crafty.c("Twoway", {
           this._jumpSpeed = this._speed.y * 2;
         } else {
           this._jumpSpeed = jump;
+          if (typeof jumpKeys === 'number') {
+            this._jumpKeys.push(jumpKeys);
+          } else if (jumpKeys) {
+            // Assume an array, although this could bite us :(
+            // We do, however (probably), save some type check speed
+            this._jumpKeys = this._jumpKeys.concat(jumpKeys);
+          }
         }
         this.uniqueBind("KeyDown", this._keydown_twoway);
 


### PR DESCRIPTION
Users may now configure a single (Number) or multiple (Array)
additional jump keys in the awesome Twoway component. :metal: 

Not sure, if I edited the docs header correctly. 
