### PR TITLE
Build & test crafty for nodejs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/api-gen.js
 .project
 .idea
 node_modules/
+localStorage/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,9 +100,7 @@ module.exports = function (grunt) {
         },
 
         qunit: {
-            all: [
-                'tests/index.html'
-            ]
+            all: ['tests/index.html'] // TODO add headless tests here
         },
 
         jsvalidate: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,7 +100,47 @@ module.exports = function (grunt) {
         },
 
         qunit: {
-            all: ['tests/index.html'] // TODO add headless tests here
+            all: ['tests/index.html']
+        },
+
+        'node-qunit': {
+            all: {
+                deps: 'tests/lib/helperFunctions.js',
+                code: 'tests/index_headless.js',
+                tests: [
+                    'tests/common.js',
+                    'tests/core.js',
+                    'tests/2d.js',
+                    'tests/logging.js',
+                    'tests/controls.js',
+                    'tests/events.js',
+                    //TODO add these once isometric adapted:
+                    //'tests/isometric.js',
+                    'tests/math.js',
+                    'tests/model.js',
+                    'tests/storage.js',
+                    'tests/systems.js',
+                    'tests/time.js',
+                    'tests/tween.js',
+                    'tests/issue746/mbr.js',
+                    'tests/issue746/pos.js',
+                    'tests/2D/collision/collision.js',
+                    'tests/2D/collision/sat.js'
+                ],
+                setup: {
+                    log: {
+                        errors: true,
+                        //tests: true,
+                        globalSummary: true
+                    }
+                },
+                done: function(err, res) {
+                    if (!err)
+                        grunt.log.ok("NODE TESTS SUCCESSFUL");
+                    else
+                        grunt.log.error("NODE TESTS FAILED");
+                }
+            }
         },
 
         jsvalidate: {
@@ -132,6 +172,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-jsvalidate');
     grunt.loadNpmTasks('grunt-browserify');
     grunt.loadNpmTasks('grunt-banner');
+    grunt.loadNpmTasks('grunt-node-qunit');
 
  
 
@@ -152,13 +193,13 @@ module.exports = function (grunt) {
     grunt.registerTask('default', ['build:dev', 'jsvalidate']);
 
     // Run the test suite
-    grunt.registerTask('check', ['build:dev', 'jsvalidate', 'qunit', 'jshint']);
+    grunt.registerTask('check', ['build:dev', 'jsvalidate', 'qunit', 'node-qunit', 'jshint']);
 
     // Make crafty.js ready for release - minified version
     grunt.registerTask('release', ['version', 'build:release', 'uglify', 'api']);
 
     // Run only tests
-    grunt.registerTask('validate', ['qunit']);
+    grunt.registerTask('validate', ['qunit', 'node-qunit']);
 
     grunt.registerTask('api-server', "View dynamically generated docs", runApiServer);
     grunt.registerTask('view-api', ['api', 'api-server'] );

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "homepage": "https://github.com/craftyjs/Crafty",
   "dependencies": {
-    "brfs": "1.0.1"
+    "brfs": "1.0.1",
+    "node-localstorage": "^0.5.0"
   },
   "devDependencies": {
     "coffee-script": "1.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "marked": "^0.3.3",
     "node-jsx": "^0.13.3",
     "open": "0.0.5",
-    "react": "^0.13.3"
+    "react": "^0.13.3",
+    "grunt-node-qunit": "^2.0.2"
   },
   "browserify": {
     "transform": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "branches": {
     "develop": true
   },
-  "main": "src/crafty.js",
+  "main": "src/crafty_headless.js",
+  "browser": "src/crafty.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/craftyjs/Crafty.git"
@@ -25,7 +26,8 @@
   "homepage": "https://github.com/craftyjs/Crafty",
   "dependencies": {
     "brfs": "1.0.1",
-    "node-localstorage": "^0.5.0"
+    "node-localstorage": "^0.5.0",
+    "require-nocache": "1.0.0"
   },
   "devDependencies": {
     "coffee-script": "1.7.1",

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -1279,12 +1279,15 @@ Crafty.extend({
                 // When first called, set the  gametime one frame before now!
                 if (typeof gameTime === "undefined")
                     gameTime = (new Date().getTime()) - milliSecPerFrame;
-                var onFrame = window.requestAnimationFrame ||
+
+                var onFrame = (typeof window !== "undefined") && (
+                    window.requestAnimationFrame ||
                     window.webkitRequestAnimationFrame ||
                     window.mozRequestAnimationFrame ||
                     window.oRequestAnimationFrame ||
                     window.msRequestAnimationFrame ||
-                    null;
+                    null
+                );
 
                 if (onFrame) {
                     tick = function () {
@@ -1308,13 +1311,15 @@ Crafty.extend({
 
                 if (typeof tick !== "function") clearInterval(tick);
 
-                var onFrame = window.cancelAnimationFrame ||
+                var onFrame = (typeof window !== "undefined") && (
+                    window.cancelAnimationFrame ||
                     window.cancelRequestAnimationFrame ||
                     window.webkitCancelRequestAnimationFrame ||
                     window.mozCancelRequestAnimationFrame ||
                     window.oCancelRequestAnimationFrame ||
                     window.msCancelRequestAnimationFrame ||
-                    null;
+                    null
+                );
 
                 if (onFrame) onFrame(requestID);
                 tick = null;

--- a/src/core/extensions.js
+++ b/src/core/extensions.js
@@ -1,5 +1,5 @@
 var Crafty = require('./core');
-var document = window.document;
+var document = (typeof window !== "undefined") && window.document;
 
 /**@
  * #Crafty.support
@@ -8,11 +8,12 @@ var document = window.document;
  */
 (function testSupport() {
     var support = Crafty.support = {},
-        ua = navigator.userAgent.toLowerCase(),
+        ua = (typeof navigator !== "undefined" && navigator.userAgent.toLowerCase()) || (typeof process !== "undefined" && process.version),
         match = /(webkit)[ \/]([\w.]+)/.exec(ua) ||
             /(o)pera(?:.*version)?[ \/]([\w.]+)/.exec(ua) ||
             /(ms)ie ([\w.]+)/.exec(ua) ||
-            /(moz)illa(?:.*? rv:([\w.]+))?/.exec(ua) || [],
+            /(moz)illa(?:.*? rv:([\w.]+))?/.exec(ua) ||
+            /(v)\d+\.(\d+)/.exec(ua) || [],
         mobile = /iPad|iPod|iPhone|Android|webOS|IEMobile/i.exec(ua);
 
     /**@
@@ -52,18 +53,19 @@ var document = window.document;
      * @comp Crafty.support
      * Is HTML5 `Audio` supported?
      */
-    support.audio = ('canPlayType' in document.createElement('audio'));
+    support.audio = (typeof window !== "undefined") && ('canPlayType' in document.createElement('audio'));
 
     /**@
      * #Crafty.support.prefix
      * @comp Crafty.support
-     * Returns the browser specific prefix (`Moz`, `O`, `ms`, `webkit`).
+     * Returns the browser specific prefix (`Moz`, `O`, `ms`, `webkit`, `node`).
      */
     support.prefix = (match[1] || match[0]);
 
     //browser specific quirks
     if (support.prefix === "moz") support.prefix = "Moz";
     if (support.prefix === "o") support.prefix = "O";
+    if (support.prefix === "v") support.prefix = "node";
 
     if (match[2]) {
         /**@
@@ -86,7 +88,7 @@ var document = window.document;
      * @comp Crafty.support
      * Is the `canvas` element supported?
      */
-    support.canvas = ('getContext' in document.createElement("canvas"));
+    support.canvas = (typeof window !== "undefined") && ('getContext' in document.createElement("canvas"));
 
     /**@
      * #Crafty.support.webgl
@@ -111,21 +113,21 @@ var document = window.document;
      * @comp Crafty.support
      * Is css3Dtransform supported by browser.
      */
-    support.css3dtransform = (typeof document.createElement("div").style.Perspective !== "undefined") || (typeof document.createElement("div").style[support.prefix + "Perspective"] !== "undefined");
+    support.css3dtransform = (typeof window !== "undefined") && ((typeof document.createElement("div").style.Perspective !== "undefined") || (typeof document.createElement("div").style[support.prefix + "Perspective"] !== "undefined"));
 
     /**@
      * #Crafty.support.deviceorientation
      * @comp Crafty.support
      * Is deviceorientation event supported by browser.
      */
-    support.deviceorientation = (typeof window.DeviceOrientationEvent !== "undefined") || (typeof window.OrientationEvent !== "undefined");
+    support.deviceorientation = (typeof window !== "undefined") && ((typeof window.DeviceOrientationEvent !== "undefined") || (typeof window.OrientationEvent !== "undefined"));
 
     /**@
      * #Crafty.support.devicemotion
      * @comp Crafty.support
      * Is devicemotion event supported by browser.
      */
-    support.devicemotion = (typeof window.DeviceMotionEvent !== "undefined");
+    support.devicemotion = (typeof window !== "undefined") && (typeof window.DeviceMotionEvent !== "undefined");
 
 })();
 

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -1,9 +1,12 @@
+
+var storage = (typeof window !== "undefined" && window.localStorage) || (new require('node-localstorage').LocalStorage('./localStorage'));
+
 /**@
  * #Storage
  * @category Utilities
- *
- *
- * Very simple way to get and set values, which will persist when the browser is closed also. Storage wraps around HTML5 Web Storage, which is well-supported across browsers and platforms, but limited to 5MB total storage per domain.
+ * Very simple way to get and set values, which will persist when the browser is closed also.
+ * Storage wraps around HTML5 Web Storage, which is well-supported across browsers and platforms, but limited to 5MB total storage per domain.
+ * Storage is also available for node, which is permanently persisted to the `./localStorage` folder - take care of removing entries. Note that multiple Crafty instances use the same storage, so care has to be taken not to overwrite existing entries.
  */
 /**@
  * #Crafty.storage
@@ -52,9 +55,8 @@
  * ~~~
  */
 
-var storage = function(key, value) {
-  var storage = window.localStorage,
-      _value = value;
+var store = function(key, value){
+  var _value = value;
 
   if(!storage){
     return false;
@@ -94,8 +96,8 @@ var storage = function(key, value) {
  * ~~~
  *
  */
-storage.remove = function(key){
-  window.localStorage.removeItem(key);
+store.remove = function(key){
+  storage.removeItem(key);
 };
 
-module.exports = storage;
+module.exports = store;

--- a/src/crafty_headless.js
+++ b/src/crafty_headless.js
@@ -1,0 +1,49 @@
+var requireNew = require('require-nocache')(module);
+
+module.exports = function() {
+    var Crafty = requireNew('./core/core');
+
+    Crafty.easing = requireNew('./core/animation');
+    requireNew('./core/extensions');
+    Crafty.c('Model', requireNew('./core/model'));
+    Crafty.extend(requireNew('./core/scenes'));
+    Crafty.storage = requireNew('./core/storage');
+    Crafty.c('Delay', requireNew('./core/time'));
+    Crafty.c('Tween', requireNew('./core/tween'));
+
+    requireNew('./core/systems');
+    requireNew('./core/version');
+
+
+    requireNew('./spatial/2d');
+    requireNew('./spatial/collision');
+    requireNew('./spatial/spatial-grid');
+    requireNew('./spatial/rect-manager');
+    requireNew('./spatial/math');
+
+    //TODO needs adaptation to work in nodejs
+    //requireNew('./isometric/diamond-iso');
+    //requireNew('./isometric/isometric');
+
+    requireNew('./controls/controls');
+    requireNew('./controls/keycodes');
+
+    requireNew('./debug/logging');
+
+    // add dummys - TODO remove this in future
+    Crafty.viewport = {
+        _x: 0,
+        _y: 0,
+        width: 0,
+        height: 0,
+        init: function() {},
+        reset: function() {}
+    };
+    Crafty.c("Keyboard", {
+        isDown: function (key) {
+            return false;
+        }
+    });
+
+    return Crafty;
+};

--- a/tests/common.js
+++ b/tests/common.js
@@ -1,11 +1,13 @@
-var resetStage = function() {
-  Crafty.viewport.reset();
-  Crafty.viewport.scroll('_x', 0);
-  Crafty.viewport.scroll('_y', 0);
-  Crafty.viewport.clampToEntities = true;
-};
-
 QUnit.testDone(function() {
   // Clean all entities at the end of each test
   Crafty("*").destroy();
+});
+
+QUnit.done(function(details) {
+  // special characters give colors in node environment
+  // see http://stackoverflow.com/a/27111061/3041008 and http://stackoverflow.com/a/20344886/3041008
+  if (details.failed > 0)
+    console.error('\n', '\x1b[31m', 'Some tests failed!' ,'\x1b[0m', '\n');
+  else
+    console.log('\n', '\x1b[32m', 'All tests passed!' ,'\x1b[0m', '\n');
 });

--- a/tests/debug.js
+++ b/tests/debug.js
@@ -1,31 +1,6 @@
 (function() {
   var module = QUnit.module;
 
-  module("Crafty.log");
-
-  test("Logging works when console.log is enabled", function(){
-    var original_log = console.log;
-    var logged_message = "";
-    console.log = function(msg) { logged_message = msg; };
-    var test_message = "test message";
-    
-    Crafty.log(test_message);
-    equal(logged_message, test_message, "Crafty.log correctly passes through to console.log");
-    
-    Crafty.loggingEnabled = false;
-    logged_message = "";
-    Crafty.log(test_message);
-    equal(logged_message, "", "Crafty.log does nothing when logging is disabled.");
-    Crafty.loggingEnabled = true;
-
-    console.log = undefined;
-    Crafty.log(test_message);
-    equal(logged_message, "", "Crafty.log does not crash when console.log is undefined.");
-
-
-    console.log = original_log;
-  });
-
   module("DebugLayer");
 
   test("DebugCanvas", function() {

--- a/tests/index.html
+++ b/tests/index.html
@@ -50,6 +50,7 @@
     <script type="text/javascript" src="./color.js"></script>
     <script type="text/javascript" src="./core.js"></script>
     <script type="text/javascript" src="./debug.js"></script>
+    <script type="text/javascript" src="./logging.js"></script>
     <script type="text/javascript" src="./2d.js"></script>
     <script type="text/javascript" src="./audio.js"></script>
     <script type="text/javascript" src="./inputs.js"></script>

--- a/tests/index_headless.js
+++ b/tests/index_headless.js
@@ -1,0 +1,2 @@
+Crafty = require('../src/crafty_headless.js')();
+Crafty.init();

--- a/tests/lib/helperFunctions.js
+++ b/tests/lib/helperFunctions.js
@@ -1,3 +1,10 @@
+resetStage = function() {
+  Crafty.viewport.reset();
+  Crafty.viewport.scroll('_x', 0);
+  Crafty.viewport.scroll('_y', 0);
+  Crafty.viewport.clampToEntities = true;
+};
+
 Round = function(x){
   return Math.round(x*100)/100;
 };

--- a/tests/logging.js
+++ b/tests/logging.js
@@ -1,0 +1,29 @@
+(function() {
+  var module = QUnit.module;
+
+  module("Crafty.log");
+
+  test("Logging works when console.log is enabled", function(){
+    var original_log = console.log;
+    var logged_message = "";
+    console.log = function(msg) { logged_message = msg; };
+    var test_message = "test message";
+    
+    Crafty.log(test_message);
+    equal(logged_message, test_message, "Crafty.log correctly passes through to console.log");
+    
+    Crafty.loggingEnabled = false;
+    logged_message = "";
+    Crafty.log(test_message);
+    equal(logged_message, "", "Crafty.log does nothing when logging is disabled.");
+    Crafty.loggingEnabled = true;
+
+    console.log = undefined;
+    Crafty.log(test_message);
+    equal(logged_message, "", "Crafty.log does not crash when console.log is undefined.");
+
+
+    console.log = original_log;
+  });
+
+})();


### PR DESCRIPTION
Behold! The time of running crafty on node is nigh! :) #440, #603
### Implemented thus far:
- `grunt-node-qunit` can be used to run the existing QUnit tests on node. caveat is that there is a name conflict between node's module and QUnit's module (hence c1c3301)
- encapsulated some test files in anonymous function (like rest of the tests) - 15c33f6
- some moving of tests is necessary, so that we can run whole test files on node (016f27e, 6a97e55)
- mock `Keyboard.isDown` in Multiway tests (703f039)
- build crafty for server (8e5d33e) - this is easily achieved with a bit of trickery using `require-nocache`. Users can go ahead and add `craftyjs` to their dependencies in their `package.json` of their node project. After that they can construct a new instance of crafty by calling `var Crafty = require('craftyjs')()`.
- perform tests on crafty for server instance (cc893ad). essentially the tests are run for the functionalities that are included in the headless build
### Outstanding issues:
- ~~`grunt-node-qunit` doesn't like async tests. haven't been able to solve this problem yet (may need to convert all async tests into sequential tests in worst case)~~ **forgot to `Crafty.init()` - all ok regarding async tests**
- still need to adapt the ~~`Crafty.support`, `Crafty.storage`~~(**adapted**) `isometric` functionalities so that they can run on node
- still need to find cleaner way of providing dummy/mocked methods ([crafty_headless.js](https://github.com/craftyjs/Crafty/compare/develop...mucaho:build_headless_new?expand=1#diff-10816ad19b11adbf7c4cd4ce895202e8); without those crafty doesn't work
### Notes

Would appreciate any pointers!
Preliminary plan is to include the commits gradually - first 6 commits are pretty straightforward and "finished".
