### PR TITLE
 Warn when using old syntax in Crafty.load

### DIFF
--- a/src/core/loader.js
+++ b/src/core/loader.js
@@ -226,6 +226,10 @@ Crafty.extend({
      */
     load: function (data, oncomplete, onprogress, onerror) {
       
+        if (Array.isArray(data)) {
+            Crafty.log("Calling Crafty.load with an array of assets no longer works; see the docs for more details.");
+        }
+
         data = (typeof data === "string" ? JSON.parse(data) : data);
       
         var j = 0,

--- a/src/crafty.js
+++ b/src/crafty.js
@@ -45,6 +45,7 @@ require('./controls/keycodes');
 require('./sound/sound');
 
 require('./debug/debug-layer');
+require('./debug/logging');
 
 
 

--- a/src/debug/logging.js
+++ b/src/debug/logging.js
@@ -1,0 +1,23 @@
+var Crafty = require('../core/core.js');
+
+
+/**@
+ * #Crafty.log
+ * @category Debug
+ *
+ * @sign Crafty.log( arguments )
+ * @param arguments - arguments which are passed to `console.log`
+ * 
+ * This is a simple wrapper for `console.log`.  You can disable logging messages by setting `Crafty.loggingEnabled` to false.
+ */
+
+Crafty.extend({
+	// Allow logging to be disabled
+	loggingEnabled: true,
+	// In some cases console.log doesn't exist, so provide a wrapper for it
+	log: function() {
+		if (Crafty.loggingEnabled && console && console.log) {
+			console.log.apply(this, arguments);
+		}
+	}
+});

--- a/tests/debug.js
+++ b/tests/debug.js
@@ -1,6 +1,31 @@
 (function() {
   var module = QUnit.module;
 
+  module("Crafty.log");
+
+  test("Logging works when console.log is enabled", function(){
+    var original_log = console.log;
+    var logged_message = "";
+    console.log = function(msg) { logged_message = msg; };
+    var test_message = "test message";
+    
+    Crafty.log(test_message);
+    equal(logged_message, test_message, "Crafty.log correctly passes through to console.log");
+    
+    Crafty.loggingEnabled = false;
+    logged_message = "";
+    Crafty.log(test_message);
+    equal(logged_message, "", "Crafty.log does nothing when logging is disabled.");
+    Crafty.loggingEnabled = true;
+
+    console.log = undefined;
+    Crafty.log(test_message);
+    equal(logged_message, "", "Crafty.log does not crash when console.log is undefined.");
+
+
+    console.log = original_log;
+  });
+
   module("DebugLayer");
 
   test("DebugCanvas", function() {

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -3,6 +3,16 @@
 
   module('Loader');
 
+  test("Warning on old syntax", function(){
+    var original_log = Crafty.log;
+    var logged_message = "";
+    Crafty.log = function(msg) { logged_message = msg; };
+    Crafty.load(["falsey.png"], function(){ logged_message = "nope"; });
+    ok(logged_message.indexOf("no longer works") >=0, "Correctly logged warning.");
+    Crafty.log = original_log;
+  });
+
+
   asyncTest('assets loading', function() {
     expect(1);
 
@@ -39,13 +49,13 @@
 
     Crafty.load(assets_to_load, function() {
         Crafty.removeAssets(assets_to_load);
-	ok(checkItems() == 2 && wereItemsRemoved(),
-          'all assets have been successfully loaded, and then successfully removed');
+        ok(checkItems() == 2 && wereItemsRemoved(), 'all assets have been successfully loaded, and then successfully removed');
         start();
-    }, function(data) {
-      items.push(data);
-    }, function(error) {
-      console.log(error);
-    });
+      }, function(data) {
+        items.push(data);
+      }, function(error) {
+        console.log(error);
+      }
+    );
   });
 })();


### PR DESCRIPTION
Since we changed the method signature of Crafty.load, we should warn when people try to use the old syntax.

This PR also adds a very simple wrapper (`Crafty.log`), so that the game doesn't simply crash in IE9 when logging is disabled.

This fixes #910.
