### PR TITLE
Add a server for viewing the documentation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,6 @@
 require("coffee-script");
 var fs = require('fs');
+var open = require("open");
 
 module.exports = function (grunt) {
     var pkg = grunt.file.readJSON('package.json');
@@ -24,6 +25,16 @@ module.exports = function (grunt) {
         grunt.file.write(outputFile, apiJSON);
         grunt.log.writeln("Wrote api data to " + outputFile);
     };
+
+    var apiServer = require("./build/api-gen/dynamic-server.js");
+    function runApiServer() {
+      var done = this.async();
+      apiServer(grunt, "./build/api.json");
+      setTimeout(function(){
+        open("http://localhost:8080");
+      }, 100);
+    }
+
 
     // Project configuration.
     grunt.initConfig({
@@ -104,6 +115,12 @@ module.exports = function (grunt) {
                     keepalive: true
                 }
             }
+        },
+
+        open: {
+            api : {
+              path: 'http://localhost:8080/',
+            },
         }
 
     });
@@ -144,5 +161,8 @@ module.exports = function (grunt) {
 
     // Run only tests
     grunt.registerTask('validate', ['qunit']);
+
+    grunt.registerTask('api-server', "View dynamically generated docs", runApiServer);
+    grunt.registerTask('view-api', ['api', 'api-server'] );
 
 };

--- a/build/api-gen/clean-name.js
+++ b/build/api-gen/clean-name.js
@@ -1,0 +1,5 @@
+var re = /[\.-]/g
+
+module.exports = function cleanName(raw) {
+  return raw.replace(re, "-");
+}

--- a/build/api-gen/doc-components.jsx
+++ b/build/api-gen/doc-components.jsx
@@ -1,0 +1,395 @@
+var marked = require("marked");
+var hljs = require("highlight.js");
+var cleanName = require("./clean-name");
+var githubRoot = "https://github.com/craftyjs/Crafty/blob/";
+
+
+// Assumes the marked.js renderer has been imported into a global variable `marked`
+var MarkdownBlock = React.createClass({
+  markedConfig: {
+      renderer: (function() {
+          var r = new marked.Renderer();
+          r.code = function(code, language){
+            return '<pre><code class="hljs ' + (language || "") + '">' + 
+                hljs.highlight("javascript", code).value +
+              '</code></pre>';
+          };
+          return r;
+      })()
+  },
+
+  convert: function(raw) {
+    var raw = marked(raw, this.markedConfig)
+    return raw;
+  },
+  
+  render: function() {
+    var raw = this.props.value;
+    var rawHtml = this.convert(raw);
+    var key = this.props.key;
+    return <span key={key} className="markdown" dangerouslySetInnerHTML={{__html: rawHtml}} />
+  }
+})
+
+
+var ToC = React.createClass({
+  render: function() {
+    var blocks = this.props.data;
+    var toc = this.props.index;
+    var primary = this.props.primary;
+
+    // Generate categories
+    catArray = [];
+    for (var cat in toc.categories) {
+      if (cat != primary) {
+        catArray.push(toc.categories[cat]);
+      }
+    }
+    catArray.sort(nameSort);
+    var catElements = catArray.map( function(cat, index){return <Category key={cat.name} catName = {cat.name} pages = {cat.pages}/>});
+    return (
+      <ul id = "doc-level-one">
+        <li><a href="events.html">List of Events</a></li>
+        <Category catName = {primary} pages = {toc.categories[primary].pages}/>
+        {catElements}
+      </ul>
+    )
+  }
+
+})
+
+var DocLink = React.createClass({
+  render: function() {
+    var target = this.props.target;
+    var linkText, href;
+    var parent = (this.props.parentPage) ? this.props.parentPage.main.name : undefined;
+    // If the link target starts with the name of the page, assume it is an internal link
+    // (This is about resolving links such as Crafty.viewport.centerOn)
+    // If the ref begins with # or ., also assume it is an internal link
+    if (parent && target.indexOf(parent + ".") === 0 ) {
+      linkText = target.replace(parent, "");
+      href = "#" + cleanName(target);
+    } else if (target[0] === "#") {
+      linkText = target.substr(1);
+      href = cleanName(target);
+    } else if (target[0] === ".") {
+      linkText = target;
+      href = "#" + cleanName(target);
+    } else {
+      linkText = target;
+      href = cleanName(target) + ".html";
+    }
+    return <a href={href}>{linkText}</a>
+  }
+})
+
+var Category = React.createClass({
+  render: function() {
+    this.props.pages.sort(stringSort);
+    var pages = this.props.pages.map(function(page, index){return <li key={page}><DocLink target={page}/></li>});
+    return ( 
+      <li className="category">
+        {this.props.catName}
+        <ul className="category-list">
+          {pages}
+        </ul>
+      </li>
+    )
+  }
+});
+
+var Node = React.createClass({
+  render: function() {
+    var node = this.props.node;
+    var page = this.props.page;
+    switch(node.type) {
+      case "method":
+        return <Method data={node} page={page}/>
+      case "param":
+        return <Parameter paramName={node.name} page={page} paramDescription={node.description} />
+      case "triggers":
+        return <Events triggers={node.events} page={page}/>
+      case "raw":
+        return <MarkdownBlock value={node.value} page={page}/>
+      case "return":
+        return <Returns value={node.value} page={page}/>
+      case "xref":
+        return <SeeAlso xrefs = {node.xrefs} page={page} />
+      case "example":
+        return <Example contents={node.contents} page={page} />
+      default:
+        return <p> Unsupported node type: <b style={{color:"red"}}>{node.type}</b></p>
+    }
+  }
+})
+
+function mapNodes(contents, page){
+  return contents.map( function(node, index){ 
+    return <Node key={index} node={node} page={page}/>
+  });
+}
+
+
+var SubSectionHeader = React.createClass({
+  render: function() {
+    return <h4>{this.props.children || ""}</h4>
+  }
+})
+
+// SeeAlso
+var SeeAlso = React.createClass({
+  render: function() {
+    var page = this.props.page;
+    xrefs = this.props.xrefs.map(function(xref, index){
+      // if ()
+      return <li key={xref}><DocLink parentPage={page} target={xref} /></li>
+    });
+    return <div>
+      <SubSectionHeader>See Also</SubSectionHeader>
+      <ul className="see-also-list">
+        {xrefs}
+      </ul>
+
+    </div>
+  }
+})
+
+// Example
+
+var Example = React.createClass({
+  render: function() {
+    var contents = this.props.contents;
+    var pieces = mapNodes(contents, this.props.page);
+    return (<div className = "example">
+      <SubSectionHeader>Example</SubSectionHeader>
+      {pieces}
+    </div>)
+
+  }
+})
+
+// Event & Trigger
+
+var Events = React.createClass({
+  render: function() {
+    if (!this.props.triggers)
+      return <div/>
+    triggers = this.props.triggers.map(function(trigger, index){
+      return <Trigger key={index} trigger = {trigger}/>
+    })
+    if (this.props.noHeading)
+      var heading = "";
+    else
+      var heading = <SubSectionHeader>Events</SubSectionHeader>;
+    return (
+      <div className="triggered-events">
+        {heading}
+        <div className = "trigger-list">
+          {triggers}
+        </div>
+      </div>
+    );
+  }
+})
+
+var Trigger = React.createClass({
+  render: function() {
+    var trigger = this.props.trigger;
+    var triggerData;
+    if (trigger.objName!=="Data" || trigger.objProp)
+      triggerData = <span className="trigger-data">[ {trigger.objName} {trigger.objProp ? "{ " + trigger.objProp + " }": ""}]</span>
+    else
+      triggerData = "";
+    return (
+      <dl className="trigger">
+          <dt>{trigger.event} {triggerData}</dt>
+          <dd>{trigger.description}</dd>
+      </dl>
+    )
+
+  }
+})
+
+
+// Objects for displaying methods: Method is the container, Signature is required, Parameter and Returns are optional
+
+var Method = React.createClass({
+  render: function() {
+    var contents = this.props.data.contents;
+    var pieces = mapNodes(contents, this.props.page);
+    return (
+      <div className="crafty-method">
+        <Signature  sign = {this.props.data.signature} />
+        {pieces}
+      </div>
+    )
+  }
+});
+
+var Parameter = React.createClass({
+  render: function() {
+    return (
+      <dl className = "parameter">
+        <dt> {this.props.paramName} </dt>
+        <dd><MarkdownBlock value={this.props.paramDescription} key={1} /></dd>
+      </dl>
+    )
+  }
+})
+
+var Signature = React.createClass({
+  render: function() {
+    return (
+        <code className="signature">{this.props.sign}</code>
+    )
+  }
+})
+
+var Returns = React.createClass({
+  render: function() {
+       return (
+      <dl className = "parameter returns"> 
+        <dt className="returns"> [Returns] </dt> 
+        <dd><MarkdownBlock value={this.props.value} key={2} /></dd> 
+      </dl>
+    )
+  }
+})
+
+
+// Base doclet component
+
+var Doclet = React.createClass({
+  render: function() {
+    var contents = this.props.data.contents;
+    var pieces =  mapNodes(contents, this.props.page);
+    if (!this.props.top) {
+      var link = <a href='#doc-nav' className='doc-top'>Back to top</a>
+      var header = <h2 className="doclet-header">{this.props.data.name}</h2>
+    } else {
+      var link = "";
+      var header = "";
+    }
+    return (
+      <div id={cleanName(this.props.data.name)}>
+        {link}
+        {header}
+        <div className="doc-source"><SourceLink data={this.props.data}/></div>
+        {pieces}
+      </div>
+    )
+  }
+});
+
+var SourceLink = React.createClass({
+  render: function() {
+    var file = this.props.data.file;
+    var start = this.props.data.startLine;
+    var end = this.props.data.endLine;
+    var commit = this.props.data.commit;
+    var fileLocation = file +"#L" + start + "-" + end;
+    var target = githubRoot + commit + "/" + fileLocation;
+    return <a href={target}>{fileLocation}</a>
+  }
+
+})
+
+
+
+function nameSort(a, b) {
+    return stringSort(a.name, b.name);
+}
+
+function stringSort(a, b) {
+    if (typeof a === "string" && typeof b==="string")
+      return a.toUpperCase().localeCompare(b.toUpperCase());
+    else
+      if (typeof b === "string")
+        return 1;
+      else
+        return -1;
+}
+
+
+// page, dict, 
+var DocPage = React.createClass({
+  render: function() {
+    var page = this.props.page;
+    if (!page) {
+      return <div/>
+    }
+    var parts = page.parts;
+    parts.sort(nameSort);
+    var partlets = parts.map(function(part, index){return <Doclet key={index} data={part} top={false} page={page}/>});
+    var page_toc = parts.map( function(part, index){ return <li key={index}><InternalLink parent={page.main.name} target={part.name} value={part.name}/></li>});
+    if (!page.main){
+      return <div/>
+    }
+    if (parts.length > 0) {
+      var bottomParts = 
+        <div>
+          <SubSectionHeader>Methods and Properties</SubSectionHeader>
+          <ul className = "page-toc">
+            {page_toc}
+          </ul>
+          {partlets}
+        </div>
+    } else {
+      var bottomParts = "";
+    }
+    return (
+      <div className="doc-page">
+        <h1>{page.main.name}</h1>
+        <Doclet data={page.main} page={page} top={true}/>
+        {bottomParts}
+      </div>
+    )
+  }
+})
+
+var EventPage = React.createClass({
+  render: function() {
+    var parts = this.props.data;
+    var events = [];
+    var index=0;
+    for (var p in parts) {
+      var part = parts[p];
+      var contents = part.contents;
+      for (var b in contents){
+        var block = contents[b];
+        if (block.type == "triggers") {
+          events.push( 
+            <div key={index++} className="eventPageBlock">
+              <SubSectionHeader>{part.name}</SubSectionHeader>
+              <Events  triggers={block.events} noHeading={true}/>
+            </div>
+
+          );
+        }
+      }
+    }
+    var retval =  <div className="events-page">
+      {events}
+    </div>
+    return retval;
+  }
+})
+
+
+var InternalLink = React.createClass({
+    render: function() {
+      var cleanTarget = cleanName(this.props.target);
+      var linkText = this.props.target.replace(this.props.parent, "");
+      return <a href={"#" + cleanTarget}>{linkText}</a>
+    }
+});
+
+
+
+if (module) {
+  module.exports = {
+    "DocPage":DocPage,
+    "ToC": ToC,
+    "EventPage": EventPage
+  }
+}

--- a/build/api-gen/dynamic-server.js
+++ b/build/api-gen/dynamic-server.js
@@ -1,0 +1,57 @@
+var http = require('http'),
+    director = require('director');
+
+
+var React = require('react');
+require('node-jsx').install({extension: '.jsx'});
+var StaticPage = require('./server-side'); // React component
+
+var createIndex = require("./index-docs");
+var cleanName = require("./clean-name");
+
+function startServer(grunt, input){
+    var api = grunt.file.readJSON(input),
+      index = createIndex(api),
+      pages = index.pages,
+      props = {data: api, index: index};
+
+    function createPage(selector, filename) {
+      filename = filename || cleanName(selector) + ".html";
+      props.selector = selector;
+      var page = React.createElement(StaticPage, props);
+      var raw = React.renderToStaticMarkup(page);
+      if (pages[selector]) {
+        var title = pages[selector].main.name;
+      } else {
+        var title = selector || filename;
+      }
+      raw = "<head><title>" + title + "</title><link type='text/css' rel='stylesheet' href='http://craftyjs.com/craftyjs-site.css'/><link type='text/css' rel='stylesheet' href='http://craftyjs.com/github.css'/></head>"
+          + "<body><div id='main'><div id='content' class='container'>" + raw +  "</div></div></body>";
+
+      return raw;
+    }
+
+    var router = new director.http.Router();
+
+    var server = http.createServer(function (req, res) {
+      router.dispatch(req, res, function (err) {
+        if (err) {
+          // Return index when page is missing
+          this.res.writeHead(200, { 'Content-Type': 'text/html' })
+          this.res.end( createPage("index") );
+        }
+      });
+    });
+
+    router.path(/(.+)\.html/, function () {
+      this.get(function (id) {
+        this.res.writeHead(200, { 'Content-Type': 'text/html' })
+        this.res.end( createPage(id) );
+      });
+    });
+
+    console.log("Starting api server")
+    server.listen(8080);
+};
+
+module.exports = startServer;

--- a/build/api-gen/index-docs.js
+++ b/build/api-gen/index-docs.js
@@ -1,0 +1,44 @@
+var cleanName = require("./clean-name");
+
+function createIndex(blocks) {
+  var cats = {};
+  var pages = {};
+  var dictionary = {};
+  function comp(c) {
+    var clean = cleanName(c);
+    return pages[clean] || (pages[clean] = {name:c, cleanName: clean, main: null, parts:[]})
+  }
+  function cat(c) {
+    return cats[c] || (cats[c] = {name:c, pages:[]})
+  }
+  for (var i = 0; i < blocks.length; i++) {
+    var block = blocks[i];
+    // Add to any categories
+    if (block.categories) {
+      for (var j = 0; j < block.categories.length; j++) {
+        if (block.name) {
+          cat(block.categories[j]).pages.push(block.name)
+        }
+        comp(block.name).main = block;
+      }
+    }
+    // Add to any comps
+    if (block.comp && block.name) {
+      comp(block.comp).parts.push(block);
+    }
+
+    if (block.name) {
+      dictionary[block.name] = block;
+    }
+  }
+
+  // console.log("Cats", cats)
+  return {
+    pages: pages,
+    categories: cats,
+    dictionary: dictionary
+  }
+
+}
+
+module.exports = createIndex;

--- a/build/api-gen/server-side.jsx
+++ b/build/api-gen/server-side.jsx
@@ -1,0 +1,46 @@
+React = require("react");
+
+docComp = require("./doc-components");
+var ToC = docComp.ToC;
+var DocPage = docComp.DocPage;
+var EventPage = docComp.EventPage;
+
+
+// We create a StaticPage component for generating the page
+// Unlike in thre dynamic case, we assume we can just pass the necessary state directly
+var StaticPage = React.createClass({
+	render: function() {
+		var pages = this.props.index.pages;
+		var selector = this.props.selector;
+		var dict = this.props.index.dictionary;
+		
+		if (selector == "events") {
+			var content =  <EventPage data = {this.props.data} />
+		} else {
+			var page = pages[selector];
+			if (page) {
+				var content = <DocPage page={page} dict={dict} />
+			} else {
+				var content = <div/>
+			}
+		}
+
+		return <div id="docs">
+			<div className="toc-holder" id = "doc-nav">
+				<ToC data = {this.props.data} index = {this.props.index} primary = "Core"/>
+			</div>
+			<div id="doc-content" className="doc-page-holder">
+				{content}
+			</div>
+		</div>
+	}
+
+
+})
+
+var StaticFactory = React.createFactory(StaticPage);
+
+module.exports = StaticPage;
+
+
+

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "coffee-script": "1.7.1",
+    "director": "^1.2.8",
     "git-rev-sync": "^1.0.0",
     "grunt": "^0.4.5",
     "grunt-banner": "^0.2.3",
@@ -49,9 +50,15 @@
     "grunt-contrib-uglify": "^0.5.1",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-jsvalidate": "^0.2.2",
-    "marked": "^0.3.2"
+    "highlight.js": "^8.6.0",
+    "marked": "^0.3.3",
+    "node-jsx": "^0.13.3",
+    "open": "0.0.5",
+    "react": "^0.13.3"
   },
-  "browserify": { 
-    "transform": [ "brfs" ] 
+  "browserify": {
+    "transform": [
+      "brfs"
+    ]
   }
 }


### PR DESCRIPTION
This adds a new grunt task `grunt api-server` that will serve the api documentation directly from `api.json`.

Use `grunt view-api` to build the docs and then view them in your default browser.

This copies over some scripts from the craftyjs.com repo, but perhaps there's a better way to share them.
