### PR TITLE
This code uses the first result for zero filling an integer on Google…

### DIFF
--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -16,15 +16,6 @@ var M = Math,
     PI = M.PI,
     DEG_TO_RAD = PI / 180;
 
-Crafty.extend({
-    zeroFill: function (number, width) {
-        width -= number.toString().length;
-        if (width > 0)
-            return new Array(width + (/\./.test(number) ? 2 : 1)).join('0') + number;
-        return number.toString();
-    }
-});
-
 /**@
  * #2D
  * @category 2D
@@ -874,7 +865,10 @@ Crafty.c("2D", {
             this._rotate(value); // _rotate triggers "Rotate"
             //set the global Z and trigger reorder just in case
         } else if (name === '_z') {
-            this._globalZ = parseInt(value + Crafty.zeroFill(this[0], 5), 10); //magic number 10^5 is the max num of entities
+            var intValue = value <<0;
+            value = value==intValue ? intValue : intValue+1;
+            this._globalZ = value*100000+this[0]; //magic number 10^5 is the max num of entities
+            this[name] = value;
             this.trigger("reorder");
             //if the rect bounds change, update the MBR and trigger move
         } else if (name === '_x' || name === '_y') {


### PR DESCRIPTION
… and then casts it immediately back to an integer.  Let's just use multiplication.  Also, using Crafty.tween fails for incomprehensible reasons so let's round float Z values up in the meantime while we figure out why.  (Tween correctly avoids calculating by stepping through values and instead interpolates based on the start and end values.  I can't think of any other legitimate usage for fractional z values up.)

A final problem was:  The code was triggering the reorder event before the new z value was assigned; this is bad because reordering doesn't happen until afterwards.  So, any reordering code still sees the old Z value and essentially does nothing.

In the face of all sanity it looks like setting the _globalZvalue here is either getting set again somewhere else, or there's some reason for the really weird reason that it's setup like it is.
