### PR TITLE
Now tweening doesn't screw up if the components are changed.

### DIFF
--- a/src/core/tween.js
+++ b/src/core/tween.js
@@ -11,7 +11,7 @@ module.exports = {
     this.tweenGroup = {};
     this.tweenStart = {};
     this.tweens = [];
-    this.bind("EnterFrame", this._tweenTick);
+    this.uniqueBind("EnterFrame", this._tweenTick);
 
   },
 


### PR DESCRIPTION
BUGFIX: If the tweening component is added/removed multiple times from a component, it gets two copies of this, which makes tweens go too quickly.
