### PR TITLE
Add open sauce tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: node_js
 node_js:
-  - '0.10'
+- '0.10'
 before_script:
-  - npm install -g grunt-cli
-
-after_success: ./travis-nightly.sh
-
+- npm install -g grunt-cli
+after_success: "./travis-nightly.sh"
+sudo: false
 cache:
   directories:
-    - node_modules
+  - node_modules
 env:
   global:
-    secure: p6SeAGd+Gohr6XeDkb5JPSQBu88UxAjljSMK0BNLJQgr8GkoA3mSJWy4uX0YjNq93VX4UMFxr0D4MlkcWZpX+cdN8K9PpxOgTq8Ml1Ljs355zbX9U/CdY99okiwzHktY4qKXBPsHLiEuCBeJ6pxs/v7m9z88mkjwDSunJG7F1oo=
+  - secure: p6SeAGd+Gohr6XeDkb5JPSQBu88UxAjljSMK0BNLJQgr8GkoA3mSJWy4uX0YjNq93VX4UMFxr0D4MlkcWZpX+cdN8K9PpxOgTq8Ml1Ljs355zbX9U/CdY99okiwzHktY4qKXBPsHLiEuCBeJ6pxs/v7m9z88mkjwDSunJG7F1oo=
+  - secure: NO+7PK5P0XLGbnvdSDBlrlnzqM/hMTy3wxxAp8ZtzEuS2ZOXn8q0KjOO/cAs1NorG1SOl8+XfFZBTR5W504GrHYLP8fNkLJOAyKMfFeTojwQ+385ShVr/NejZFejsc+xJZymIeDsEzBZqosxPOi+8k7jljDK4mzLdKMpt8flWUw=
+  - secure: iGO+VCkCq/26Dqrc6+G1nX8Dk+tTqhcINuiIVhxGtMARcY+WIzcyEK/cfXRaLnvIzIxQ0xUoGGnM9xe4DQT8L+BGzo8AGnVbzxITzceWTlhsFepcbOTgqOg0ZGMxQVQ6VBh888Cdks8KsOgtTNhzd+oVgcStsyxZPCVD/7VgNTE=
+addons:
+  sauce_connect: true

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "node-jsx": "^0.13.3",
     "open": "0.0.5",
     "react": "^0.13.3",
-    "grunt-node-qunit": "^2.0.2"
+    "grunt-node-qunit": "^2.0.2",
+    "grunt-saucelabs": "~8.6.1"
   },
   "browserify": {
     "transform": [

--- a/tests/common.js
+++ b/tests/common.js
@@ -1,15 +1,45 @@
+var log = [];
+
+QUnit.testStart(function(testDetails){
+  // Open Sauce logging
+  QUnit.log(function(details){
+    if (!details.result) {
+      details.name = testDetails.name;
+      log.push(details);
+    }
+  });
+});
+
 QUnit.testDone(function() {
   // Clean all entities at the end of each test
   Crafty("*").destroy();
 });
 
-QUnit.done(function(details) {
+QUnit.config.hidepassed = true;
+
+QUnit.done(function (test_results) {
   // special characters give colors in node environment
   // see http://stackoverflow.com/a/27111061/3041008 and http://stackoverflow.com/a/20344886/3041008
   if (typeof console !== "undefined" && typeof console.log !== "undefined" && typeof console.error !== "undefined") {
-      if (details.failed > 0)
+      if (test_results.failed > 0)
         console.error('\n', '\x1b[31m', 'Some tests failed!' ,'\x1b[0m', '\n');
       else
         console.log('\n', '\x1b[32m', 'All tests passed!' ,'\x1b[0m', '\n');
   }
+
+  // Open Sauce logging
+  var tests = [];
+  for(var i = 0, len = log.length; i < len; i++) {
+    var details = log[i];
+    tests.push({
+      name: details.name,
+      result: details.result,
+      expected: details.expected,
+      actual: details.actual,
+      source: details.source
+    });
+  }
+  test_results.tests = tests;
+  if (typeof window !== "undefined")
+    window.global_test_results = test_results;
 });


### PR DESCRIPTION
Solves cross-browser compatibility tests as described in #581 .
- Every time one of the branches of this original repository gets updated, the travis build is augmented with cross-browser compatibility tests. The cross-browser compatibility tests are **not** run when someone submits a pull request, unless the contributor also has an open sauce account (this is a known limitation I haven't found a fix for unfortunately)
- I included the minimal supported versions for now (to the best of my knowledge)
  - Firefox 4 for all available platforms
  - Opera 12 for all available platforms
  - Chrome 26 (should be version 6; unfortunately the test suite doesn't support prior versions) for all available platforms
  - Safari 5.1 for all available platforms
  - iOS 4.3.2 for iPad & iPhone
  - Android 4.0 (should be [version 2.3.3](https://github.com/AlloyTeam/Mars/blob/master/tools/es5-mobile-compat-table.md), unfortunately the test suite doesn't support prior versions)

@starwed If we agree on using this, then:
- you or another owner needs to create a free Sauce Labs account (it's called [OpenSauce](https://saucelabs.com/opensauce/))
- after that you can [encrypt your OpenSause username and password](https://docs.saucelabs.com/ci-integrations/travis-ci/#adding-credentials-for-a-public-github-repo) and put it in the `travis.yml` file
- from now on all changes on repo branches are automatically tested for cross-browser compatibility
- after we merge this we should include a [browser-compatibility badge](https://docs.saucelabs.com/reference/status-images/) in our readme
- update [supported browsers wiki page](https://github.com/craftyjs/Crafty/wiki/Supported-Browsers)
