### PR TITLE
Replace statements of console log with Crafty log

### DIFF
--- a/src/controls/device.js
+++ b/src/controls/device.js
@@ -100,7 +100,7 @@ Crafty.extend({
          * ~~~
          * // Get DeviceOrientation event normalized data.
          * Crafty.device.deviceOrientation(function(data){
-         *     console.log('data.tiltLR : '+Math.round(data.tiltLR)+', data.tiltFB : '+Math.round(data.tiltFB)+', data.dir : '+Math.round(data.dir)+', data.motUD : '+data.motUD+'');
+         *     Crafty.log('data.tiltLR : '+Math.round(data.tiltLR)+', data.tiltFB : '+Math.round(data.tiltFB)+', data.dir : '+Math.round(data.dir)+', data.motUD : '+data.motUD+'');
          * });
          * ~~~
          *
@@ -140,7 +140,7 @@ Crafty.extend({
          * ~~~
          * // Get DeviceMotion event normalized data.
          * Crafty.device.deviceMotion(function(data){
-         *     console.log('data.moAccel : '+data.rawAcceleration+', data.moCalcTiltLR : '+Math.round(data.tiltLR)+', data.moCalcTiltFB : '+Math.round(data.tiltFB)+'');
+         *     Crafty.log('data.moAccel : '+data.rawAcceleration+', data.moCalcTiltLR : '+Math.round(data.tiltLR)+', data.moCalcTiltFB : '+Math.round(data.tiltFB)+'');
          * });
          * ~~~
          *

--- a/src/controls/inputs.js
+++ b/src/controls/inputs.js
@@ -75,7 +75,7 @@ Crafty.extend({
      *    .color('green')
      *    .bind('TouchStart',function(e){ alert('big GREEN box was touched', e); });
      * 
-     * console.log("multitouch is "+Crafty.multitouch());
+     * Crafty.log("multitouch is "+Crafty.multitouch());
      * ~~~
      * @see Crafty.touchDispatch
      */
@@ -644,7 +644,7 @@ Crafty.bind("CraftyStop", function () {
  *
  * myEntity.bind('MouseUp', function(e) {
  *    if( e.mouseButton == Crafty.mouseButtons.RIGHT )
- *        console.log("Clicked right button");
+ *        Crafty.log("Clicked right button");
  * })
  * ~~~
  * @see Crafty.mouseDispatch
@@ -688,11 +688,11 @@ Crafty.c("Mouse", {
  * .attr({x: 10, y: 10, w: 40, h: 40})
  * .color('green')
  * .bind('TouchStart', function(TouchPoint){
- *   console.log('myEntity has been touched', TouchPoint);
+ *   Crafty.log('myEntity has been touched', TouchPoint);
  * }).bind('TouchMove', function(TouchPoint) {
- *   console.log('Finger moved over myEntity at the { x: ' + TouchPoint.realX + ', y: ' + TouchPoint.realY + ' } coordinates.');
+ *   Crafty.log('Finger moved over myEntity at the { x: ' + TouchPoint.realX + ', y: ' + TouchPoint.realY + ' } coordinates.');
  * }).bind('TouchEnd', function() {
- *   console.log('Touch over myEntity has finished.');
+ *   Crafty.log('Touch over myEntity has finished.');
  * });
  * ~~~
  * @see Crafty.multitouch
@@ -741,7 +741,7 @@ Crafty.c("AreaMap", {
      * Crafty.e("2D, DOM, Color, Mouse")
      *     .color("red")
      *     .attr({ w: 100, h: 100 })
-     *     .bind('MouseOver', function() {console.log("over")})
+     *     .bind('MouseOver', function() {Crafty.log("over")})
      *     .areaMap([0, 0, 50, 0, 50, 50, 0, 50) 
      * ~~~
      *

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -937,7 +937,7 @@ Crafty.fn = Crafty.prototype = {
      * });
      *
      * ent.customData = "2" // set customData to 2
-     * console.log(ent.customData) // prints 2
+     * Crafty.log(ent.customData) // prints 2
      * ~~~
      */
     defineField: function (prop, getCallback, setCallback) {
@@ -1295,7 +1295,7 @@ Crafty.extend({
                         if (tick !== null) {
                             requestID = onFrame(tick);
                         }
-                        //console.log(requestID + ', ' + frame)
+                        //Crafty.log(requestID + ', ' + frame)
                     };
 
                     tick();
@@ -1838,7 +1838,7 @@ Crafty.extend({
      * });
      *
      * ent.customData = "2" // set customData to 2
-     * console.log(ent.customData) // prints 2
+     * Crafty.log(ent.customData) // prints 2
      * ~~~
      * @see Crafty Core#.defineField
      */

--- a/src/core/extensions.js
+++ b/src/core/extensions.js
@@ -162,7 +162,7 @@ module.exports = {
      * ~~~
      * var player = Crafty.e("2D");
      *     player.onMouseDown = function(e) {
-     *         console.log(e.mouseButton, e.realX, e.realY);
+     *         Crafty.log(e.mouseButton, e.realX, e.realY);
      *     };
      * Crafty.addEvent(player, Crafty.stage.elem, "mousedown", player.onMouseDown);
      * ~~~

--- a/src/core/loader.js
+++ b/src/core/loader.js
@@ -44,7 +44,7 @@ module.exports = {
      *     "ray": ['ray.mp3'] // This loads ray.mp3 from custom/audio/path/ray.mp3
      *   }
      * }, function() {
-     *   console.log('loaded');
+     *   Crafty.log('loaded');
      * });
      * ~~~
      *

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -25,7 +25,7 @@
  * });
  * person = Crafty.e('Person').attr({name: 'blaine'});
  * person.bind('Change[name]', function() {
- *   console.log('name changed!');
+ *   Crafty.log('name changed!');
  * });
  * person.attr('name', 'blainesch'); // Triggers event
  * person.is_dirty('name'); // true

--- a/src/core/scenes.js
+++ b/src/core/scenes.js
@@ -160,7 +160,7 @@ module.exports = {
         if (this._scenes.hasOwnProperty(name)) {
             this._scenes[name].initialize.call(this, data);
         } else {
-            console.error('The scene "' + name + '" does not exist');
+            Crafty.error('The scene "' + name + '" does not exist');
         }
 
         return;

--- a/src/core/time.js
+++ b/src/core/time.js
@@ -60,19 +60,19 @@ module.exports = {
      *
      * The simplest delay
      * ~~~
-     * console.log("start");
+     * Crafty.log("start");
      * Crafty.e("Delay").delay(function() {
-     *   console.log("100ms later");
+     *   Crafty.log("100ms later");
      * }, 100, 0);
      * ~~~
      *
      * Delay with callbackOff to be executed after all delay iterations
      * ~~~
-     * console.log("start");
+     * Crafty.log("start");
      * Crafty.e("Delay").delay(function() {
-     *   console.log("100ms later");
+     *   Crafty.log("100ms later");
      * }, 100, 3, function() {
-     *   console.log("delay finished");
+     *   Crafty.log("delay finished");
      * });
      * ~~~
      *
@@ -98,7 +98,7 @@ module.exports = {
      * @example
      * ~~~
      * var doSomething = function(){
-     *   console.log("doing something");
+     *   Crafty.log("doing something");
      * };
      *
      * // execute doSomething each 100 miliseconds indefinetely

--- a/src/debug/logging.js
+++ b/src/debug/logging.js
@@ -7,10 +7,20 @@ var Crafty = require('../core/core.js');
  *
  * @sign Crafty.log( arguments )
  * @param arguments - arguments which are passed to `console.log`
- * 
+ *
  * This is a simple wrapper for `console.log`.  You can disable logging messages by setting `Crafty.loggingEnabled` to false.
+ * It is recommended to use `Crafty.log`, as `console.log` can crash on IE9.
  */
-
+/**@
+ * #Crafty.error
+ * @category Debug
+ *
+ * @sign Crafty.error( arguments )
+ * @param arguments - arguments which are passed to `console.error`
+ *
+ * This is a simple wrapper for `console.error`.  You can disable logging messages by setting `Crafty.loggingEnabled` to false.
+ * It is recommended to use `Crafty.error`, as `console.error` can crash on IE9.
+ */
 Crafty.extend({
 	// Allow logging to be disabled
 	loggingEnabled: true,
@@ -18,6 +28,11 @@ Crafty.extend({
 	log: function() {
 		if (Crafty.loggingEnabled && console && console.log) {
 			console.log.apply(this, arguments);
+		}
+	},
+	error: function() {
+		if (Crafty.loggingEnabled && console && console.error) {
+			console.error.apply(this, arguments);
 		}
 	}
 });

--- a/src/graphics/canvas-layer.js
+++ b/src/graphics/canvas-layer.js
@@ -259,7 +259,7 @@ Crafty.extend({
         },
 
         debug: function() {
-            console.log(this._changedObjs);
+            Crafty.log(this._changedObjs);
         },
 
         /** cleans up current dirty state, stores stale state for future passes */

--- a/src/graphics/dom-layer.js
+++ b/src/graphics/dom-layer.js
@@ -63,7 +63,7 @@ Crafty.extend({
          * @sign public Crafty.domLayer.debug()
          */
         debug: function () {
-            console.log(this._changedObjs);
+            Crafty.log(this._changedObjs);
         },
 
 

--- a/src/isometric/isometric.js
+++ b/src/isometric/isometric.js
@@ -107,7 +107,7 @@ Crafty.extend({
          * ~~~
          * var iso = Crafty.isometric.size(128,96);
          * var px = iso.pos2px(12800,4800);
-         * console.log(px); //Object { x=100, y=100}
+         * Crafty.log(px); //Object { x=100, y=100}
          * ~~~
          */
         px2pos: function (left, top) {
@@ -133,7 +133,7 @@ Crafty.extend({
          * ~~~
          * var iso = Crafty.isometric.size(128,96).centerAt(10,10); //Viewport is now moved
          * //After moving the viewport by another event you can get the new center point
-         * console.log(iso.centerAt());
+         * Crafty.log(iso.centerAt());
          * ~~~
          */
         centerAt: function (x, y) {

--- a/src/spatial/collision.js
+++ b/src/spatial/collision.js
@@ -397,10 +397,10 @@ Crafty.c("Collision", {
      * Crafty.e("2D, Collision")
      *     .checkHits('Solid') // check for collisions with entities that have the Solid component in each frame
      *     .bind("HitOn", function(hitData) {
-     *         console.log("Collision with Solid entity occurred for the first time.");
+     *         Crafty.log("Collision with Solid entity occurred for the first time.");
      *     })
      *     .bind("HitOff", function(comp) {
-     *         console.log("Collision with Solid entity ended.");
+     *         Crafty.log("Collision with Solid entity ended.");
      *     });
      * ~~~
      *
@@ -521,7 +521,7 @@ Crafty.c("Collision", {
      * Crafty.e("2D, Collision")
      *     .checkHits('Solid')
      *     .bind("HitOn", function(hitData) {
-     *         console.log("Collision with Solid entity was reported in this frame again!");
+     *         Crafty.log("Collision with Solid entity was reported in this frame again!");
      *         this.resetHitChecks('Solid'); // fire the HitOn event in the next frame also, if the collision is still active.
      *     })
      * ~~~

--- a/tests/camera.html
+++ b/tests/camera.html
@@ -67,10 +67,10 @@
 		if (!isFinite(i)) continue;
 		lis[i].addEventListener('click', function(e) {
 			var self = e.target;
-			console.log(self);
+			Crafty.log(self);
 			imageEntities = self.getAttribute('data-image-entities');
 			hotspotEntities = self.getAttribute('data-hotspot-entities');
-			console.log('reloading scene: '+ self.innerHTML);
+			Crafty.log('reloading scene: '+ self.innerHTML);
 			Crafty.scene('main');
 		}, false);
 	}

--- a/tests/common.js
+++ b/tests/common.js
@@ -6,8 +6,10 @@ QUnit.testDone(function() {
 QUnit.done(function(details) {
   // special characters give colors in node environment
   // see http://stackoverflow.com/a/27111061/3041008 and http://stackoverflow.com/a/20344886/3041008
-  if (details.failed > 0)
-    console.error('\n', '\x1b[31m', 'Some tests failed!' ,'\x1b[0m', '\n');
-  else
-    console.log('\n', '\x1b[32m', 'All tests passed!' ,'\x1b[0m', '\n');
+  if (typeof console !== "undefined" && typeof console.log !== "undefined" && typeof console.error !== "undefined") {
+      if (details.failed > 0)
+        console.error('\n', '\x1b[31m', 'Some tests failed!' ,'\x1b[0m', '\n');
+      else
+        console.log('\n', '\x1b[32m', 'All tests passed!' ,'\x1b[0m', '\n');
+  }
 });

--- a/tests/loader.js
+++ b/tests/loader.js
@@ -54,7 +54,7 @@
       }, function(data) {
         items.push(data);
       }, function(error) {
-        console.log(error);
+        Crafty.log(error);
       }
     );
   });

--- a/tests/logging.js
+++ b/tests/logging.js
@@ -4,9 +4,12 @@
   module("Crafty.log");
 
   test("Logging works when console.log is enabled", function(){
-    var original_log = console.log;
+    // this makes sure we don't crash on IE9; handle with care!
+    var logger = (typeof window !== "undefined") ? (window.console = window.console || {}) : console;
+
+    var original_log = logger.log;
     var logged_message = "";
-    console.log = function(msg) { logged_message = msg; };
+    logger.log = function(msg) { logged_message = msg; };
     var test_message = "test message";
     
     Crafty.log(test_message);
@@ -18,12 +21,12 @@
     equal(logged_message, "", "Crafty.log does nothing when logging is disabled.");
     Crafty.loggingEnabled = true;
 
-    console.log = undefined;
+    logger.log = undefined;
     Crafty.log(test_message);
     equal(logged_message, "", "Crafty.log does not crash when console.log is undefined.");
 
 
-    console.log = original_log;
+    logger.log = original_log;
   });
 
 })();


### PR DESCRIPTION
console log fails on IE9, this PR replaces all `console.log` with `Crafty.log` statements, both in the documentation and source where applicable
fixes part of #926 
