### PR TITLE
Fix rotation direction bug and simplify

### DIFF
--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -1343,7 +1343,7 @@ Crafty.c("AngularMotion", {
         __motionProp(this, "a", "rotation", true);
         __motionProp(this, "d", "rotation", false);
 
-        this.__oldRevolution = 0;
+        this.__oldRotationDirection = 0;
 
         this.bind("EnterFrame", this._angularMotionTick);
     },
@@ -1381,16 +1381,16 @@ Crafty.c("AngularMotion", {
         // v += a * Δt
         this.vrotation = vr + ar * dt;
 
-        var _vr = this._vrotation,
-            dvr = _vr ? (vr<0 ? -1:1):0; // Quick implementation of Math.sign
-        if (this.__oldRevolution !== dvr) {
-            this.__oldRevolution = dvr;
+        // Check if direction of velocity has changed
+        var _vr = this._vrotation, dvr = _vr ? (_vr<0 ? -1:1):0; // Quick implementation of Math.sign
+        if (this.__oldRotationDirection !== dvr) {
+            this.__oldRotationDirection = dvr;
             this.trigger('NewRotationDirection', dvr);
         }
 
+        // Check if velocity has changed
         // Δs = s[t] - s[t-1]
         this._drotation = newR - oldR;
-
         if (this._drotation !== 0) {
             this.rotation = newR;
             this.trigger('Rotated', oldR);
@@ -1527,7 +1527,6 @@ Crafty.c("Motion", {
         this._motionDelta = __motionVector(this, "d", false, new Crafty.math.Vector2D());
 
         this.__movedEvent = {axis: '', oldValue: 0};
-        this.__directionEvent = {x: 0, y: 0};
         this.__oldDirection = {x: 0, y: 0};
 
         this.bind("EnterFrame", this._linearMotionTick);
@@ -1631,9 +1630,6 @@ Crafty.c("Motion", {
      */
     _linearMotionTick: function(frameData) {
         var dt = frameData.dt / 1000; // time in s
-
-        var oldDirection = this.__oldDirection;
-
         var oldX = this._x, vx = this._vx, ax = this._ax,
             oldY = this._y, vy = this._vy, ay = this._ay;
 
@@ -1644,23 +1640,21 @@ Crafty.c("Motion", {
         this.vx = vx + ax * dt;
         this.vy = vy + ay * dt;
 
-
-        // Check to see if the velocity has changed
-        var _vx = this._vx, dvx = _vx ? (_vx<0 ? -1:1):0, // A quick implementation of Math.sign
+        // Check if direction of velocity has changed
+        var oldDirection = this.__oldDirection,
+            _vx = this._vx, dvx = _vx ? (_vx<0 ? -1:1):0, // A quick implementation of Math.sign
             _vy = this._vy, dvy = _vy ? (_vy<0 ? -1:1):0;
         if (oldDirection.x !== dvx || oldDirection.y !== dvy) {
-            var directionEvent = this.__directionEvent;
-            directionEvent.x = oldDirection.x = dvx;
-            directionEvent.y = oldDirection.y = dvy;
-            this.trigger('NewDirection', directionEvent);
+            oldDirection.x = dvx;
+            oldDirection.y = dvy;
+            this.trigger('NewDirection', oldDirection);
         }
 
-
+        // Check if velocity has changed
+        var movedEvent = this.__movedEvent;
         // Δs = s[t] - s[t-1]
         this._dx = newX - oldX;
         this._dy = newY - oldY;
-
-        var movedEvent = this.__movedEvent;
         if (this._dx !== 0) {
             this.x = newX;
             movedEvent.axis = 'x';

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -669,6 +669,7 @@
       strictEqual(evt.oldValue, 0, "[2] - old vy value was 0");
     });
     e.vy = -1;
+    e.vy = -1; // no MotionChange event was fired
     Crafty.timer.simulateFrames(1);
 
     // group 3 -- test newdireciton when we were previously moving
@@ -677,7 +678,6 @@
     e.one("NewDirection", function(evt) {
       equal(evt.x, 0, "[3] - not moving along x axis");
       equal(evt.y, 0, "[3] - not moving along y axis");
-      evt.x = 1; // bad boy!
     });
     e.vy = 0;
     Crafty.timer.simulateFrames(1);
@@ -685,7 +685,7 @@
 
     
     // Group 4, rotation tests
-    e.vrotation = 0;
+    e.vrotation = 0; // no MotionChange event was fired
     e.one("MotionChange", function(evt) {
       strictEqual(evt.key, "vrotation", "[4] - change of angular speed");
       strictEqual(evt.oldValue, 0, "[4] - old vr value was 0"); 
@@ -701,7 +701,7 @@
     e.one("NewRotationDirection", function(evt) {
       equal(evt, 1, "[5] - Rotating in the positive sense");
     });
-    e.one("Rotated", function(oldValue) { 
+    e.one("Rotated", function(oldValue) {
       strictEqual(oldValue, 0, "[5] - Rotated from 0 position");
     });
     e.vrotation = 1;
@@ -711,23 +711,34 @@
     e.one("NewRotationDirection", function(evt) {
       equal(evt, -1, "[6] - Rotating in the negative sense");
     });
-    e.one("Rotated", function(oldValue) { 
+    e.one("Rotated", function(oldValue) {
       strictEqual(oldValue, old_rotation, "[6] - Old rotation matches cached value");
     });
     e.vrotation = -1;
     Crafty.timer.simulateFrames(1);
 
+    old_rotation = e.rotation;
     e.one("NewRotationDirection", function(evt) {
-      equal(evt, 0, "[7] - No longer rotating");
+      equal(evt, 1, "[7] - Rotating in the positive sense");
+    });
+    e.one("Rotated", function(oldValue) {
+      strictEqual(oldValue, old_rotation, "[7] - Old rotation matches cached value");
+    });
+    e.vrotation = 1;
+    Crafty.timer.simulateFrames(1);
+
+    e.one("NewRotationDirection", function(evt) {
+      equal(evt, 0, "[8] - No longer rotating");
     });
     e.vrotation = 0;
     Crafty.timer.simulateFrames(1);
 
     // TODO: break these up into separate checks
-    equal(newDirectionEvents, 3, "NewDirection fired 4 times.");
-    equal(newRotationDirectionEvents, 3, "NewRotation fired 3 times.");
-    equal(motionEvents, 12, "Motion fired 12 times.");
-    equal(rotatedEvents, 2, "Rotated fired 2 times.");
+    equal(newDirectionEvents, 3, "NewDirection fired 3 times.");
+    equal(newRotationDirectionEvents, 4, "NewRotationDirection fired 4 times.");
+    equal(motionEvents, 13, "MotionChange fired 13 times.");
+    equal(movedEvents, 3, "Moved fired 3 times.");
+    equal(rotatedEvents, 3, "Rotated fired 3 times.");
     e.destroy();
   });
 


### PR DESCRIPTION
Small typo has caused bug that is not picked up by tests ([L1382](https://github.com/starwed/Crafty/blob/cafd964727b67b43e14cf0fb92b3258b5476c378/src/spatial/2d.js#L1382) of cafd964727b67b43e14cf0fb92b3258b5476c378)
Simplify direction event for velocity to increase performance.
