### PR TITLE
Gravity terminal velocity

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -1379,32 +1379,45 @@ Crafty.extend({
             /**@
              * #Crafty.timer.steptype
              * @comp Crafty.timer
+             *
+             * @trigger NewSteptype - when the current steptype changes - { mode, maxTimeStep } - New steptype
+             *
+             * Can be called to set the type of timestep the game loop uses.
              * @sign public void Crafty.timer.steptype(mode [, maxTimeStep])
-             * Can be called to set the type of timestep the game loop uses
              * @param mode - the type of time loop.  Allowed values are "fixed", "semifixed", and "variable".  Crafty defaults to "fixed".
              * @param maxTimeStep - For "fixed", sets the max number of frames per step.   For "variable" and "semifixed", sets the maximum time step allowed.
+             *
+             * Can be called to get the type of timestep the game loop uses.
+             * @sign public Object Crafty.timer.steptype(void)
+             * @returns Object containing the current timestep's properties { mode, maxTimeStep }
              *
              * * In "fixed" mode, each frame is sent the same value of `dt`, and to achieve the target game speed, mulitiple frame events are triggered before each render.
              * * In "variable" mode, there is only one frame triggered per render.  This recieves a value of `dt` equal to the actual elapsed time since the last frame.
              * * In "semifixed" mode, multiple frames per render are processed, and the total time since the last frame is divided evenly between them.
              *
+             * @see Crafty.timer.FPS
              */
-
             steptype: function (newmode, option) {
+                // setters
                 if (newmode === "variable" || newmode === "semifixed") {
                     mode = newmode;
                     if (option)
                         maxTimestep = option;
-
+                    Crafty.trigger("NewSteptype", {mode: mode, maxTimeStep: maxTimestep});
                 } else if (newmode === "fixed") {
                     mode = "fixed";
                     if (option)
                         maxFramesPerStep = option;
-                } else {
+                    Crafty.trigger("NewSteptype", {mode: mode, maxTimeStep: maxFramesPerStep});
+                } else if (newmode !== undefined) {
                     throw "Invalid step type specified";
+                // getter
+                } else {
+                    return {
+                        mode: mode,
+                        maxTimeStep: (mode === "variable" || mode === "semifixed") ? maxTimestep : maxFramesPerStep
+                    };
                 }
-
-
             },
 
             /**@
@@ -1424,6 +1437,7 @@ Crafty.extend({
              * Specifically it triggers `EnterFrame` & `ExitFrame` events for each frame and `PreRender`, `RenderScene` & `PostRender` events for each render.
              *
              * @see Crafty.timer.steptype
+             * @see Crafty.timer.FPS
              */
             step: function () {
                 var drawTimeStart, dt, lastFrameTime, loops = 0;
@@ -1506,6 +1520,8 @@ Crafty.extend({
              *
              * Sets the target frames per second. This is not an actual frame rate.
              * The default rate is 50.
+             *
+             * @see Crafty.timer.steptype
              */
             FPS: function (value) {
                 if (typeof value == "undefined")

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -1040,6 +1040,7 @@ Crafty.c("Supportable", {
         // Decrease width by 1px from left and 1px from right, to fall more gracefully
         // area._x++; area._w--;
 
+        // check if we lift-off
         if (ground) {
             var garea = ground._cbr || ground._mbr || ground;
             if (!(ground.__c[groundComp] && overlap(garea, area))) {
@@ -1049,6 +1050,7 @@ Crafty.c("Supportable", {
             }
         }
 
+        // check if we land (also possible to land on other ground object in same frame after lift-off from current ground object)
         if (!ground) {
             var obj, oarea,
                 results = Crafty.map.search(area, false),
@@ -1197,7 +1199,7 @@ Crafty.c("Gravity", {
      * Crafty.e("2D, DOM, Color, Gravity")
      *   .color("red")
      *   .attr({ w: 100, h: 100 })
-     *   .gravityConst(5)
+     *   .gravityConst(750)
      *   .gravity("platform");
      * ~~~
      */
@@ -1210,6 +1212,7 @@ Crafty.c("Gravity", {
 
         return this;
     },
+
     _startGravity: function() {
         if (this._gravityActive) return;
         this._gravityActive = true;

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -1123,6 +1123,7 @@ Crafty.c("GroundAttacher", {
  */
 Crafty.c("Gravity", {
     _gravityConst: 500,
+    _gravityActive: false,
 
     init: function () {
         this.requires("2D, Supportable, Motion");
@@ -1163,7 +1164,7 @@ Crafty.c("Gravity", {
      * @see Supportable, Motion
      */
     gravity: function (comp) {
-        this.bind("CheckLanding", this._gravityCheckLanding);
+        this.uniqueBind("CheckLanding", this._gravityCheckLanding);
         this.startGroundDetection(comp);
         this._startGravity();
 
@@ -1210,13 +1211,15 @@ Crafty.c("Gravity", {
         return this;
     },
     _startGravity: function() {
+        if (this._gravityActive) return;
         this._gravityActive = true;
         this.ay += this._gravityConst;
     },
     _stopGravity: function() {
+        if (!this._gravityActive) return;
+        this._gravityActive = false;
         this.ay = 0;
         this.vy = 0;
-        this._gravityActive = false;
     }
 });
 

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -878,10 +878,15 @@
 
     var player = Crafty.e("2D, Gravity")
           .attr({ x: 0, y: 100, w: 32, h: 16 })
-          .gravityConst(0.3*50*50)
-          .gravity("platform");
+          .gravityConst(0.3*50*50) // setting gravity constant before activating gravity
+          .gravity("platform2");
    
     strictEqual(player.acceleration().y, player._gravityConst, "acceleration should match gravity constant");
+
+    player.gravity("platform");
+    strictEqual(player.acceleration().y, player._gravityConst, "acceleration should match gravity constant after calling gravity twice");
+    strictEqual(player._groundComp, "platform", "new ground component set");
+
 
     var vel = -1;
     player.bind("EnterFrame", function() {

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -869,6 +869,55 @@
     strictEqual(player.x, 10, "player did not move with ground");
   });
 
+  test("Gravity", function() {
+    var player = Crafty.e("2D, Gravity")
+        .attr({ x: 0, y: 100, w: 32, h: 10 });
+
+    strictEqual(player.velocity().y, 0, "velocity should be 0 before activating gravity");
+    strictEqual(player.acceleration().y, 0, "acceleration should be 0 before activating gravity");
+    strictEqual(player._gravityConst, 500, "gravityConst should match default value");
+    strictEqual(player._gravityActive, false, "gravity should not be active");
+
+    player.gravityConst(0.3*50*50);
+    strictEqual(player.velocity().y, 0, "velocity should be 0 before activating gravity");
+    strictEqual(player.acceleration().y, 0, "acceleration should be 0 before activating gravity");
+    strictEqual(player._gravityConst, 0.3*50*50, "gravityConst should match new value");
+    strictEqual(player._gravityActive, false, "gravity should not be active");
+
+    strictEqual(player._groundComp, null, "no ground component set before activating gravity");
+    player.gravity("platform2");
+    strictEqual(player._gravityActive, true, "gravity should be active");
+    strictEqual(player._groundComp, "platform2", "new ground component set after activating gravity");
+    strictEqual(player.velocity().y, 0, "velocity should be 0 before stepping a frame");
+    strictEqual(player.acceleration().y, player._gravityConst, "acceleration should match gravity constant after activating gravity");
+
+    player.gravity("platform");
+    strictEqual(player._gravityActive, true, "gravity should be active");
+    strictEqual(player._groundComp, "platform", "ground component changed after reactivating gravity");
+    strictEqual(player.velocity().y, 0, "velocity should be 0 before stepping a frame");
+    strictEqual(player.acceleration().y, player._gravityConst, "acceleration should match gravity constant after activating gravity twice");
+
+    player.gravityConst(100);
+    strictEqual(player.velocity().y, 0, "velocity should be 0 before stepping a frame");
+    strictEqual(player.acceleration().y, player._gravityConst, "acceleration should match gravity constant after changing gravity constant while gravity is active");
+    strictEqual(player._gravityActive, true, "gravity should still be active");
+
+    player.vy = 1000;
+    player.gravityConst(0.2*50*50);
+    strictEqual(player.velocity().y, 1000, "velocity should not have been reset after changing gravityConst");
+
+    player.antigravity();
+    strictEqual(player._gravityActive, false, "gravity should be inactive");
+    strictEqual(player.acceleration().y, 0, "acceleration should be zero after deactivating gravity");
+    strictEqual(player.velocity().y, 0, "velocity should be zero after deactivating gravity");
+
+    player.gravity();
+    strictEqual(player._gravityActive, true, "gravity should be active");
+    strictEqual(player._groundComp, "platform", "ground component didn't change after reactivating");
+    strictEqual(player.acceleration().y, player._gravityConst, "acceleration should match gravity constant after activating gravity");
+    strictEqual(player.velocity().y, 0, "velocity should be still be zero immediately after deactivating gravity");
+  });
+
 
   test("Integrationtest - Gravity", function() {
     var done = false;
@@ -878,14 +927,8 @@
 
     var player = Crafty.e("2D, Gravity")
           .attr({ x: 0, y: 100, w: 32, h: 16 })
-          .gravityConst(0.3*50*50) // setting gravity constant before activating gravity
-          .gravity("platform2");
-   
-    strictEqual(player.acceleration().y, player._gravityConst, "acceleration should match gravity constant");
-
-    player.gravity("platform");
-    strictEqual(player.acceleration().y, player._gravityConst, "acceleration should match gravity constant after calling gravity twice");
-    strictEqual(player._groundComp, "platform", "new ground component set");
+          .gravityConst(0.3*50*50)
+          .gravity("platform");
 
 
     var vel = -1;
@@ -910,12 +953,6 @@
 
           Crafty.timer.simulateFrames(3);
           vel = -1;
-
-          var oldVel = this.velocity().y;
-          this.gravityConst(0.2*50*50);
-          strictEqual(this._gravityConst, 0.2*50*50, "gravity constant should have changed");
-          strictEqual(this.acceleration().y, this._gravityConst, "acceleration should match gravity constant");
-          strictEqual(this.velocity().y, oldVel, "velocity should not have been reset");
         });
         this.attr({y: 100});
       } else {
@@ -930,7 +967,7 @@
     });
 
     Crafty.timer.simulateFrames(75);
-    ok(done, "Test completed");
+    ok(done, "Integrationtest completed");
   });
 
 
@@ -975,7 +1012,7 @@
     });
 
     Crafty.timer.simulateFrames(75);
-    ok(done, "Test completed");
+    ok(done, "Integrationtest completed");
   });
 
 })();

--- a/tests/core.js
+++ b/tests/core.js
@@ -615,6 +615,41 @@
     Crafty.unbind("PostRender", postRenderFunc);
   });
 
+  test('Crafty.timer.steptype', function() {
+    var originalSteptype = Crafty.timer.steptype(),
+        steptype,
+        counter = 0;
+    var increment = function() {
+      counter++;
+    };
+    Crafty.bind("NewSteptype", increment);
+
+
+    Crafty.one("NewSteptype", function(evt) {
+      strictEqual(evt.mode, "fixed");
+      strictEqual(evt.maxTimeStep, 100);
+    });
+    Crafty.timer.steptype("fixed", 100);
+    steptype = Crafty.timer.steptype();
+    strictEqual(steptype.mode, "fixed");
+    strictEqual(steptype.maxTimeStep, 100);
+
+
+    Crafty.one("NewSteptype", function(evt) {
+      strictEqual(evt.mode, "variable");
+      strictEqual(evt.maxTimeStep, 1000);
+    });
+    Crafty.timer.steptype("variable", 1000);
+    steptype = Crafty.timer.steptype();
+    strictEqual(steptype.mode, "variable");
+    strictEqual(steptype.maxTimeStep, 1000);
+
+
+    strictEqual(counter, 2);
+    Crafty.unbind("NewSteptype", increment);
+    Crafty.timer.steptype(originalSteptype.mode, originalSteptype.maxTimeStep);
+  });
+
   test('Crafty.timer.FPS', function() {
     var counter = 0;
     var increment = function() {


### PR DESCRIPTION
Should solve issue as described in 1st paragraph of [this comment](https://github.com/craftyjs/Crafty/issues/903#issuecomment-102638698).
Basically this PR limits downwards velocity of gravity so that it doesn't reach astronomical values.
So this prevents you from falling through floor automatically, if you leave the `terminalVelocity` to the default value (because it's based on entities `h` and maximum allowed frame delta time).
Also some documentation about the effect associated to it - tunneling.

Alternative thoughts:
- Should this be even changeable / documented to user? For player characters with `h = 32` that means maximum movement of `32 px` per frame, which is pretty fast imo. (I haven't noticed any limiting of downwards velocity in an example platformer I tested).
- Have velocity limits be part of Motion? So far we need it just for gravity internally, but could be useful for user created content.
