### PR TITLE
Add debug displays of AreaMap

### DIFF
--- a/src/controls/inputs.js
+++ b/src/controls/inputs.js
@@ -729,6 +729,8 @@ Crafty.c("AreaMap", {
      * #.areaMap
      * @comp AreaMap
      *
+     * @trigger NewAreaMap - when a new areaMap is assigned - Crafty.polygon
+     *
      * @sign public this .areaMap(Crafty.polygon polygon)
      * @param polygon - Instance of Crafty.polygon used to check if the mouse coordinates are inside this region
      *
@@ -772,10 +774,9 @@ Crafty.c("AreaMap", {
         }
 
         poly.shift(this._x, this._y);
-        //this.map = poly;
         this.mapArea = poly;
-
         this.attach(this.mapArea);
+        this.trigger("NewAreaMap", poly);
         return this;
     }
 });

--- a/src/debug/debug-layer.js
+++ b/src/debug/debug-layer.js
@@ -295,6 +295,50 @@ Crafty.c("SolidHitBox", {
     }
 });
 
+/**@
+ * #WiredAreaMap
+ * @category Debug
+ *
+ * Adding this component to an entity with an AreaMap component will cause its click polygon to be drawn to the debug canvas as an outline.
+ * Following click areas exist for an entity (in decreasing order of priority): AreaMap, Hitbox, MBR. Use the appropriate debug components to display them.
+ *
+ * The methods of DebugCanvas can be used to control this component's appearance.
+ * @see DebugPolygon, DebugCanvas
+ */
+Crafty.c("WiredAreaMap", {
+    init: function () {
+        this.requires("DebugPolygon")
+            .debugStroke("green")
+            .matchAreaMap();
+        this.bind("NewAreaMap", this.matchAreaMap);
+    },
+    matchAreaMap: function () {
+        this.debugPolygon(this.mapArea);
+    }
+});
+
+/**@
+ * #SolidAreaMap
+ * @category Debug
+ *
+ * Adding this component to an entity with an AreaMap component will cause its click polygon to be drawn to the debug canvas, with a default alpha level of 0.7.
+ * Following click areas exist for an entity (in decreasing order of priority): AreaMap, Hitbox, MBR. Use the appropriate debug components to display them.
+ *
+ * The methods of DebugCanvas can be used to control this component's appearance.
+ * @see DebugPolygon, DebugCanvas
+ */
+Crafty.c("SolidAreaMap", {
+    init: function () {
+        this.requires("DebugPolygon")
+            .debugFill("lime").debugAlpha(0.7)
+            .matchAreaMap();
+        this.bind("NewAreaMap", this.matchAreaMap);
+    },
+    matchAreaMap: function () {
+        this.debugPolygon(this.mapArea);
+    }
+});
+
 Crafty.DebugCanvas = {
     context: null,
     entities: [],

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -254,18 +254,26 @@
   module("Collision");
 
   test("Collision constructors", function() {
+    var newHitboxEvents = 0;
+    var e = Crafty.e("2D, Collision")
+              .bind("NewHitbox", function(newHitbox) {
+                newHitboxEvents++;
+              });
+
     var poly = new Crafty.polygon([50, 0, 100, 100, 0, 100]);
-    var ent1 = Crafty.e("2D, Collision").collision(poly);
-    ok(ent1.map instanceof Crafty.polygon, "Hitbox is a polygon");
-    ok(ent1.map !== poly, "Hitbox is a clone of passed polygon");
+    e.collision(poly);
+    ok(e.map instanceof Crafty.polygon, "Hitbox is a polygon");
+    ok(e.map !== poly, "Hitbox is a clone of passed polygon");
 
     var arr = [50, 0, 100, 100, 0, 100];
-    var ent2 = Crafty.e("2D, Collision").collision(arr);
-    ok(ent2.map instanceof Crafty.polygon, "Hitbox is a polygon");
-    ok(ent2.map.points && ent2.map.points !== arr, "Array used in hitbox is a clone of passed array");
+    e.collision(arr);
+    ok(e.map instanceof Crafty.polygon, "Hitbox is a polygon");
+    ok(e.map.points && e.map.points !== arr, "Array used in hitbox is a clone of passed array");
 
-    var ent3 = Crafty.e("2D, Collision").collision(50, 0, 100, 100, 0, 100);
-    ok(ent3.map instanceof Crafty.polygon, "Hitbox is a polygon");
+    e.collision(50, 0, 100, 100, 0, 100);
+    ok(e.map instanceof Crafty.polygon, "Hitbox is a polygon");
+
+    strictEqual(newHitboxEvents, 3, "NewHitBox event triggered 3 times");
   });
 
   // This test assumes that the "circles" are really octagons, as per Crafty.circle.

--- a/tests/debug.js
+++ b/tests/debug.js
@@ -58,7 +58,6 @@
       w: 10,
       h: 20
     }).collision();
-    e.matchHitBox(); // only necessary until collision works properly!
     equal(e.polygon.points[0], 10, "WiredHitBox -- correct x coord for upper right corner");
     equal(e.polygon.points[5], 30, "correct y coord for lower right corner");
     notEqual(typeof e._debug.strokeStyle, "undefined", "stroke style is assigned");
@@ -72,18 +71,47 @@
       w: 10,
       h: 20
     }).collision();
-    e2.matchHitBox(); // only necessary until collision works properly!
     equal(e2.polygon.points[0], 10, "SolidHitBox -- correct x coord for upper right corner");
     equal(e2.polygon.points[5], 30, "correct y coord for lower right corner");
     equal(typeof e2._debug.strokeStyle, "undefined", "stroke style is undefined");
     notEqual(typeof e2._debug.fillStyle, "undefined", "fill style is assigned");
 
     e2.collision(new Crafty.polygon([0, 0, 15, 0, 0, 15]));
-    e2.matchHitBox();
     equal(e2.polygon.points[5], 25, "After change -- correct y coord for third point");
 
     e2.destroy();
 
   });
 
+  test("AreaMap debugging", function() {
+    var e = Crafty.e("2D, AreaMap, WiredAreaMap").attr({
+      x: 10,
+      y: 10,
+      w: 10,
+      h: 20
+    }).areaMap(50, 0, 100, 100, 0, 100);
+    equal(e.polygon.points[0], 60, "WiredAreaMap -- correct x coord for upper right corner");
+    equal(e.polygon.points[5], 110, "correct y coord for lower right corner");
+    notEqual(typeof e._debug.strokeStyle, "undefined", "stroke style is assigned");
+    equal(typeof e._debug.fillStyle, "undefined", "fill style is undefined");
+
+    e.destroy();
+
+    var e2 = Crafty.e("2D, AreaMap, SolidAreaMap").attr({
+      x: 10,
+      y: 10,
+      w: 10,
+      h: 20
+    }).areaMap(50, 0, 100, 100, 0, 100);
+    equal(e2.polygon.points[0], 60, "SolidAreaMap -- correct x coord for upper right corner");
+    equal(e2.polygon.points[5], 110, "correct y coord for lower right corner");
+    equal(typeof e2._debug.strokeStyle, "undefined", "stroke style is undefined");
+    notEqual(typeof e2._debug.fillStyle, "undefined", "fill style is assigned");
+
+    e2.areaMap(new Crafty.polygon([0, 0, 15, 0, 0, 15]));
+    equal(e2.polygon.points[5], 25, "After change -- correct y coord for third point");
+
+    e2.destroy();
+
+  });
 })();

--- a/tests/inputs.js
+++ b/tests/inputs.js
@@ -3,19 +3,27 @@
 
   module('Inputs');
 
-  test("AreaMap constructors", function() {
+  test("AreaMap", function() {
+    var areaMapEvents = 0;
+    var e = Crafty.e("2D, AreaMap")
+              .bind("NewAreaMap", function(newAreaMap) {
+                areaMapEvents++;
+              });
+
     var poly = new Crafty.polygon([50, 0, 100, 100, 0, 100]);
-    var ent1 = Crafty.e("2D, AreaMap").areaMap(poly);
-    ok(ent1.mapArea instanceof Crafty.polygon, "Hitbox is a polygon");
-    ok(ent1.mapArea !== poly, "Hitbox is a clone of passed polygon");
+    e.areaMap(poly);
+    ok(e.mapArea instanceof Crafty.polygon, "Hitbox is a polygon");
+    ok(e.mapArea !== poly, "Hitbox is a clone of passed polygon");
 
     var arr = [50, 0, 100, 100, 0, 100];
-    var ent2 = Crafty.e("2D, AreaMap").areaMap(arr);
-    ok(ent2.mapArea instanceof Crafty.polygon, "Hitbox is a polygon");
-    ok(ent2.mapArea.points && ent2.mapArea.points !== arr, "Array used in hitbox is a clone of passed array");
+    e.areaMap(arr);
+    ok(e.mapArea instanceof Crafty.polygon, "Hitbox is a polygon");
+    ok(e.mapArea.points && e.mapArea.points !== arr, "Array used in hitbox is a clone of passed array");
 
-    var ent3 = Crafty.e("2D, AreaMap").areaMap(50, 0, 100, 100, 0, 100);
-    ok(ent3.mapArea instanceof Crafty.polygon, "Hitbox is a polygon");
+    e.areaMap(50, 0, 100, 100, 0, 100);
+    ok(e.mapArea instanceof Crafty.polygon, "Hitbox is a polygon");
+
+    strictEqual(areaMapEvents, 3, "NewAreaMap event triggered 3 times");
   });
 
   // mock-phantom-touch-events is a PhantomJS plugin, thus the test below is skipped if enviroment is not PhantomJS


### PR DESCRIPTION
The debug components are immensely useful, good job whoever added them! They are so well designed and implemented, it was very easy to add a new debug component.
This adds `WiredAreaMap` & `SolidAreaMap` to display custom click areas (+tests, +docs).
