### PR TITLE
Remove event callback object when empty

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -1063,6 +1063,11 @@ Crafty._callbackMethods = {
                     callbacks.splice(i, 1);
                     i--;
                     l--;
+                    // Delete callbacks object if there are no remaining bound events
+                    if (callbacks.length === 0) {
+                        delete this._callbacks[event];
+                        delete handlers[event][this[0]];
+                    }
                 }
             } else {
                 callbacks[i].call(this, data);


### PR DESCRIPTION
When there are no callbacks left attached to a system or entity, that array should be removed from the global handlers object.

Failing to do so can cause an unnecessary performance hit when a large number of extant entities have previously bound to that event.

Fixes #957.
