### PR TITLE
Improve release workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /crafty.js
-/crafty-min.js
 build/api/*
 build/api.json
 build/parseNodes.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,16 +1,13 @@
 require("coffee-script");
-var fs = require('fs');
 var open = require("open");
 
 module.exports = function (grunt) {
-    var pkg = grunt.file.readJSON('package.json');
-    var version = pkg.version;
-    var banner =    '/**\n' +
-                    ' * <%= pkg.name %> <%= pkg.version %>\n' +
-                    ' * <%= pkg.author.url %>\n *\n' +
-                    ' * Copyright <%= grunt.template.today("yyyy") %>, <%= pkg.author.name %>\n' +
-                    ' * Dual licensed under the MIT or GPL licenses.\n' +
-                    ' */\n\n';
+    var banner = '/**\n' +
+                ' * <%= pkg.name %> <%= pkg.version %>\n' +
+                ' * <%= pkg.author.url %>\n *\n' +
+                ' * Copyright <%= grunt.template.today("yyyy") %>, <%= pkg.author.name %>\n' +
+                ' * Dual licensed under the MIT or GPL licenses.\n' +
+                ' */\n\n';
 
     var docGen = function() {
         var outputFile = "./build/api.json";
@@ -48,6 +45,15 @@ module.exports = function (grunt) {
                     banner: banner
                 },
                 files: {
+                    src: ['dist/crafty.js']
+                }
+            },
+            debug: {
+                options: {
+                    position: 'top',
+                    banner: banner
+                },
+                files: {
                     src: ['crafty.js']
                 }
             }
@@ -56,7 +62,7 @@ module.exports = function (grunt) {
         browserify: {
             dist: {
                 files: {
-                    'crafty.js': ['src/crafty.js']
+                    'dist/crafty.js': ['src/crafty.js']
                 },
                 options: {
                     transform: ['brfs']
@@ -75,7 +81,7 @@ module.exports = function (grunt) {
 
 
         watch: {
-            files: ['src/*.js'],
+            files: ['src/*.js', 'src/**/*.js'],
             tasks: ['build:dev']
         },
 
@@ -84,8 +90,8 @@ module.exports = function (grunt) {
                 banner: banner
             },
             build: {
-                src: 'crafty.js',
-                dest: 'crafty-min.js'
+                src: 'dist/crafty.js',
+                dest: 'dist/crafty-min.js'
             }
         },
 
@@ -176,15 +182,28 @@ module.exports = function (grunt) {
 
  
 
-    grunt.registerTask('version', 'Takes the version into src/version.js', function() {
-        fs.writeFileSync('src/version.js', 'module.exports = "' + version + '";');
+    grunt.registerTask('version', 'Propagates version changes', function() {
+        var pkg = grunt.config.get('pkg');
+        var version = grunt.option('crafty_version');
+        if (!version) {
+            grunt.warn("No command-line argument 'crafty_version' specified. Rerun the task with '--crafty_version=X.X.X'.");
+            version = pkg.version;
+        }
+        if (version === pkg.version) {
+            grunt.warn("Command-line argument 'crafty_version' is same as previous release version.");
+        }
+        pkg.version = version;
+        grunt.config.set('pkg', pkg);
+
+        grunt.file.write('package.json', JSON.stringify(pkg, null, 2));
+        grunt.file.write('src/core/version.js', 'module.exports = "' + version + '";');
     });
 
     // Build development
-    grunt.registerTask('build:dev', ['browserify:debug', 'usebanner']);
+    grunt.registerTask('build:dev', ['browserify:debug', 'usebanner:debug']);
 
     // Build release
-    grunt.registerTask('build:release', ['browserify:dist', 'usebanner']);
+    grunt.registerTask('build:release', ['browserify:dist', 'usebanner:dist']);
 
     // Building the documentation
     grunt.registerTask('api', "Generate api documentation", docGen);

--- a/bower.json
+++ b/bower.json
@@ -1,15 +1,20 @@
 {
   "name": "crafty",
+  "description": "Crafty is a modern component and event based framework for developing games in JavaScript that targets DOM, Canvas and WebGL.",
+  "keywords": [
+    "framework",
+    "javascript",
+    "game",
+    "engine"
+  ],
+  "license": ["GPL", "MIT"],
   "main": "dist/crafty.js",
-  "license": "MIT",
   "ignore": [
-    "**/.*",
-    "build",
-    "playgrounds",
-    "test",
-    "*.md",
-    "changelog.txt",
-    "Gruntfile.js",
-    "package.json"
+    "**",
+    "!bower.json",
+    "!README.md",
+    "!dist",
+    "!dist/crafty.js",
+    "!dist/crafty-min.js"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "url": "https://github.com/craftyjs/Crafty.git"
   },
   "licenses": "(GPL OR MIT)",
-  "description": "Crafty is a modern component and event based framework for javascript games that targets DOM and canvas. Check out the DEV version if you want to play with the latest and greatest.",
+  "description": "Crafty is a modern component and event based framework for developing games in JavaScript that targets DOM, Canvas and WebGL.",
   "keywords": [
     "framework",
-    "javascript"
+    "javascript",
+    "game",
+    "engine"
   ],
   "scripts": {
     "test": "grunt check"


### PR DESCRIPTION
Collection of improvements that will reduce human error when releasing
crafty for download, npm and bower.
Grunt task 'release' demands a 'crafty_version' command line parameter
which will update the version in the relevant files.
Additional meta improvements.

Fixes [future bower release inconsistencies](https://github.com/craftyjs/Crafty/issues/914#issuecomment-156398827).
