### PR TITLE
Entity name accessor

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -193,18 +193,40 @@ Crafty.fn = Crafty.prototype = {
      * @sign public this .setName(String name)
      * @param name - A human readable name for debugging purposes.
      *
+     * Set a human readable name for debugging purposes.
+     *
      * @example
      * ~~~
-     * this.setName("Player");
+     * var ent = Crafty.e().setName("Player");
      * ~~~
+     *
+     * @see Crafty Core#.getName
      */
     setName: function (name) {
         var entityName = String(name);
-
         this._entityName = entityName;
-
         this.trigger("NewEntityName", entityName);
         return this;
+    },
+
+    /**@
+     * #.getName
+     * @comp Crafty Core
+     * @sign public this .getName(String name)
+     * @returns A human readable name for debugging purposes.
+     *
+     * Get the human readable name for debugging purposes.
+     *
+     * @example
+     * ~~~
+     * var ent = Crafty.e().setName("Player");
+     * var name = ent.getName();
+     * ~~~
+     *
+     * @see Crafty Core#.setName
+     */
+    getName: function (name) {
+        return this._entityName;
     },
 
     /**@

--- a/tests/core.js
+++ b/tests/core.js
@@ -76,6 +76,37 @@
     strictEqual(destroyFlag, true, "Destroy flag true on destruction");
   });
 
+  test("name", function() {
+    var counter = 0;
+    var player = Crafty.e().bind("NewEntityName", function() {
+      counter++;
+    });
+
+    player.one("NewEntityName", function(name) {
+      strictEqual(name, "Player");
+    });
+    player.setName("Player");
+    strictEqual(player.getName(), "Player");
+
+    player.one("NewEntityName", function(name) {
+      strictEqual(name, "Player2");
+    });
+    player.setName("Player2");
+    strictEqual(player.getName(), "Player2");
+
+
+    var player3 = Crafty.e().one("NewEntityName", function(name) {
+      counter++;
+      strictEqual(name, "Player3");
+    });
+    player3.setName("Player3");
+    strictEqual(player3.getName(), "Player3");
+
+
+    strictEqual(player.getName(), "Player2", "other entity's name didn't change after changing another entity's name");
+    strictEqual(counter, 3, "correct number of events fired");
+  });
+
   test("attr", function() {
     var first = Crafty.e("test");
     first.attr("single", true);


### PR DESCRIPTION
Currently the entity name can only be set, but not queried using public methods.
EDIT: Initially I introduced property-like access (`.name`), however since this may break user code (since it's such a common property name) and it won't be used as often as e.g. `.x`, I decided against it and propose to use `.getName()` instead.
