### PR TITLE
Unregister webGL entity on destroy.

### DIFF
--- a/src/graphics/sprite.js
+++ b/src/graphics/sprite.js
@@ -198,10 +198,6 @@ Crafty.c("Sprite", {
 
     remove: function(){
         this.unbind("Draw", this._drawSprite);
-        // Webgl components need to be removed from their gl program
-        if (this.program) {
-            this.program.unregisterEntity(this);
-        }
     },
 
     _drawSprite: function(e){

--- a/src/graphics/webgl.js
+++ b/src/graphics/webgl.js
@@ -216,6 +216,10 @@ Crafty.c("WebGL", {
     remove: function(){
         this._changed = true;
         this.unbind(this._glChange);
+        // Webgl components need to be removed from their gl program
+        if (this.program) {
+            this.program.unregisterEntity(this);
+        }
     },
 
     _glChange: function(){


### PR DESCRIPTION
Fixes #977 

Too bad I could not write a test for it though, no webGL in phantomJS. 
