### PR TITLE
Refactor how components are associated with specific draw layers

### DIFF
--- a/src/graphics/canvas-layer.js
+++ b/src/graphics/canvas-layer.js
@@ -10,6 +10,7 @@ var Crafty = require('../core/core.js');
  * Mostly contains private methods to draw entities on a canvas element.
  */
 Crafty.canvasLayerObject = {
+    type: "Canvas",
     _dirtyRects: [],
     _changedObjs: [],
     layerCount: 0,
@@ -21,16 +22,46 @@ Crafty.canvasLayerObject = {
     },
 
     /**@
-     * #.add
+     * #.dirty
      * @comp CanvasLayer
-     * @sign public .add(ent)
+     * @sign public .dirty(ent)
      * @param ent - The entity to add
      *
      * Add an entity to the list of Canvas objects to draw
      */
-    add: function add(ent) {
+    dirty: function dirty(ent) {
         this._changedObjs.push(ent);
     },
+    
+    /**@
+     * #.attach
+     * @comp CanvasLayer
+     * @sign public .attach(ent)
+     * @param ent - The entity to add
+     *
+     * Add an entity to the list of Canvas objects to draw
+     */
+    attach: function attach(ent) {
+        ent._drawContext = this.context;
+        //increment the amount of canvas objs
+        this.layerCount++;
+    },
+    
+    /**@
+     * #.detach
+     * @comp CanvasLayer
+     * @sign public .detach(ent)
+     * @param ent - The entity to add
+     *
+     * Add an entity to the list of Canvas objects to draw
+     */
+    detach: function detach(ent) {
+        this.dirty(ent);
+        ent._drawContext = null;
+        //decrement the amount of canvas objs
+        this.layerCount--;
+    },
+    
 
     /**@
      * #.context
@@ -70,8 +101,6 @@ Crafty.canvasLayerObject = {
         c.style.position = 'absolute';
         c.style.left = "0px";
         c.style.top = "0px";
-
-        var canvas = Crafty.s("Canvas");
 
         Crafty.stage.elem.appendChild(c);
         this.context = c.getContext('2d');
@@ -141,7 +170,7 @@ Crafty.canvasLayerObject = {
      */
     _drawDirty: function () {
 
-        var i, j, q, rect,len, obj, ent,
+        var i, j, q, rect,len, obj,
             changed = this._changedObjs,
             l = changed.length,
             dirty = this._dirtyRects,

--- a/src/graphics/canvas.js
+++ b/src/graphics/canvas.js
@@ -22,39 +22,21 @@ Crafty.c("Canvas", {
 
     init: function () {
         this.requires("Renderable");
-        var canvasLayer = Crafty.s("CanvasLayer");
-
-        this._drawLayer = canvasLayer;
-        this._drawContext = canvasLayer.context;
-
-        //increment the amount of canvas objs
-        canvasLayer.layerCount++;
+        
         //Allocate an object to hold this components current region
         this.currentRect = {};
-        this._changed = true;
-        canvasLayer.add(this);
+        
+        this._attachToLayer( Crafty.s("CanvasLayer"));
+    },
 
-        this.bind("Invalidate", function (e) {
-            //flag if changed
-            if (this._changed === false) {
-                this._changed = true;
-                canvasLayer.add(this);
-            }
-
-        });
-
-
-        this.bind("Remove", function () {
-            this._drawLayer.layerCount--;
-            this._changed = true;
-            this._drawLayer.add(this);
-        });
+    remove: function() {
+        this._detachFromLayer();
     },
 
     /**@
      * #.draw
      * @comp Canvas
-     * @sign public this .draw([[Context ctx, ]Number x, Number y, Number w, Number h])
+     * @sign public this .draw([[Context ctx, ]Number x, Nwumber y, Number w, Number h])
      * @param ctx - Canvas 2D context if drawing on another canvas is required
      * @param x - X offset for drawing a segment
      * @param y - Y offset for drawing a segment
@@ -76,8 +58,6 @@ Crafty.c("Canvas", {
             w: 0,
             h: 0
         }
-
-
     },
 
     draw: function (ctx, x, y, w, h) {
@@ -97,8 +77,8 @@ Crafty.c("Canvas", {
         pos._h = (h || this._h);
 
 
-        context = ctx || this._drawContext;
-        coord = this.__coord || [0, 0, 0, 0];
+        var context = ctx || this._drawContext;
+        var coord = this.__coord || [0, 0, 0, 0];
         var co = this.drawVars.co;
         co.x = coord[0] + (x || 0);
         co.y = coord[1] + (y || 0);

--- a/src/graphics/color.js
+++ b/src/graphics/color.js
@@ -161,10 +161,14 @@ Crafty.c("Color", {
 
     init: function () {
         this.bind("Draw", this._drawColor);
-        if (this.has("WebGL")){
-            this._establishShader("Color", COLOR_FRAGMENT_SHADER, COLOR_VERTEX_SHADER, COLOR_ATTRIBUTE_LIST);
+        if (this._drawLayer) {
+            this._setupColor(this._drawLayer);
         }
         this.trigger("Invalidate");
+    },
+    
+    events: {
+        "LayerAttached": "_setupColor"
     },
 
     remove: function(){
@@ -173,6 +177,12 @@ Crafty.c("Color", {
             this._element.style.backgroundColor = "transparent";
         }
         this.trigger("Invalidate");
+    },
+
+    _setupColor: function(layer) {
+        if (layer.type === "WebGL") {
+            this._establishShader("Color", COLOR_FRAGMENT_SHADER, COLOR_VERTEX_SHADER, COLOR_ATTRIBUTE_LIST);
+        }
     },
 
     // draw function for "Color"

--- a/src/graphics/dom-layer.js
+++ b/src/graphics/dom-layer.js
@@ -9,6 +9,7 @@ var Crafty = require('../core/core.js'),
  * Collection of mostly private methods to represent entities using the DOM.
  */
 Crafty.domLayerObject = {
+    type: "DOM",
     _changedObjs: [],
     _dirtyViewport: false,
 
@@ -113,15 +114,44 @@ Crafty.domLayerObject = {
     },
 
     /**@
-     * #.add
+     * #.dirty
      * @comp DomLayer
-     * @sign public .add(ent)
-     * @param ent - The entity to add
+     * @sign public .dirty(ent)
+     * @param ent - The entity to mark as dirty
      *
      * Add an entity to the list of DOM object to draw
      */
-    add: function add(ent) {
+    dirty: function add(ent) {
         this._changedObjs.push(ent);
+    },
+
+    /**@
+     * #.attach
+     * @comp DomLayer
+     * @sign public .attach(ent)
+     * @param ent - The entity to add
+     *
+     * Add an entity to the layer
+     */
+    attach: function attach(ent) {
+        ent._drawContext = this.context;
+        // attach the entity's div element to the dom layer
+        this._div.appendChild(ent._element);
+        // set position style and entity id
+        ent._element.style.position = "absolute";
+        ent._element.id = "ent" + this[0];
+    },
+    
+    /**@
+     * #.detach
+     * @comp DomLayer
+     * @sign public .detach(ent)
+     * @param ent - The entity to remove
+     *
+     * Removes an entity from the layer
+     */
+    detach: function detach(ent) {
+        this._div.removeChild(ent._element);
     },
 
     // Sets the viewport position and scale

--- a/src/graphics/dom.js
+++ b/src/graphics/dom.js
@@ -26,12 +26,7 @@ Crafty.c("DOM", {
 
     init: function () {
         this.requires("Renderable");
-        var domLayer = Crafty.s("DomLayer");
-        if (!domLayer._div) {
-            domLayer.init();
-        }
-        this._drawLayer = domLayer;
-
+        
         this._cssStyles = {
             visibility: '',
             left: '',
@@ -44,23 +39,18 @@ Crafty.c("DOM", {
             transform: ''
         };
         this._element = document.createElement("div");
-        domLayer._div.appendChild(this._element);
-        this._element.style.position = "absolute";
-        this._element.id = "ent" + this[0];
 
-        this.bind("Invalidate", this._invalidateDOM);
+        // Attach the entity to the dom layer
+        this._attachToLayer( Crafty.s("DomLayer") );
+
         this.bind("NewComponent", this._updateClass);
         this.bind("RemoveComponent", this._removeClass);
-
-        this._invalidateDOM();
-
     },
 
     remove: function(){
-        this.undraw();
+        this._detachFromLayer();
         this.unbind("NewComponent", this._updateClass);
         this.unbind("RemoveComponent", this._removeClass);
-        this.unbind("Invalidate", this._invalidateDOM);
     },
 
     /**@
@@ -76,12 +66,12 @@ Crafty.c("DOM", {
 
     // removes a component on RemoveComponent events
     _removeClass: function(removedComponent) {
-        var i = 0,
+        var comp,
             c = this.__c,
             str = "";
-        for (i in c) {
-          if(i != removedComponent) {
-            str += ' ' + i;
+        for (comp in c) {
+          if(comp != removedComponent) {
+            str += ' ' + comp;
           }
         }
         str = str.substr(1);
@@ -90,21 +80,14 @@ Crafty.c("DOM", {
 
     // adds a class on NewComponent events
     _updateClass: function() {
-        var i = 0,
+        var comp,
             c = this.__c,
             str = "";
-        for (i in c) {
-            str += ' ' + i;
+        for (comp in c) {
+            str += ' ' + comp;
         }
         str = str.substr(1);
         this._element.className = str;
-    },
-
-    _invalidateDOM: function(){
-        if (!this._changed) {
-                this._changed = true;
-                this._drawLayer.add(this);
-            }
     },
 
     /**@
@@ -115,12 +98,15 @@ Crafty.c("DOM", {
      * @param elem - HTML element that will replace the dynamically created one
      *
      * Pass a DOM element to use rather than one created. Will set `._element` to this value. Removes the old element.
+     * 
+     * Will reattach the entity to the current draw layer
      */
     DOM: function (elem) {
         if (elem && elem.nodeType) {
-            this.undraw();
+            var layer = this._drawLayer;
+            this._detachFromLayer();
             this._element = elem;
-            this._element.style.position = 'absolute';
+            this.attachToLayer(layer);
         }
         return this;
     },
@@ -214,21 +200,6 @@ Crafty.c("DOM", {
             co: co
         });
 
-        return this;
-    },
-
-    /**@
-     * #.undraw
-     * @comp DOM
-     * @sign public this .undraw(void)
-     *
-     * Removes the element from the stage.
-     */
-    undraw: function () {
-        var el = this._element;
-        if (el && el.parentNode !== null) {
-            el.parentNode.removeChild(el);
-        }
         return this;
     },
 

--- a/src/graphics/image.js
+++ b/src/graphics/image.js
@@ -24,6 +24,7 @@ Crafty.c("Image", {
 
     init: function () {
         this.bind("Draw", this._drawImage);
+        this.bind("LayerAttached", this._setupImage);
     },
 
     remove: function() {
@@ -75,33 +76,32 @@ Crafty.c("Image", {
             var self = this;
 
             this.img.onload = function () {
-                self._onImageLoad();
+                self._setupImage(self._drawLayer);
             };
         } else {
-            this._onImageLoad();
+            this._setupImage(this._drawLayer);
         }
-
 
         this.trigger("Invalidate");
 
         return this;
     },
 
-    _onImageLoad: function(){
-
-        if (this.has("Canvas")) {
+    // called on image change or layer attachment
+    _setupImage: function(layer){
+        if (!this.img || !layer) return;
+        
+        if (layer.type === "Canvas") {
             this._pattern = this._drawContext.createPattern(this.img, this._repeat);
-        } else if (this.has("WebGL")) {
+        } else if (layer.type === "WebGL") {
             this._establishShader("image:" + this.__image, IMAGE_FRAGMENT_SHADER, IMAGE_VERTEX_SHADER, IMAGE_ATTRIBUTE_LIST);
-            this.program.setTexture( this.webgl.makeTexture(this.__image, this.img, (this._repeat!=="no-repeat")));
+            this.program.setTexture( layer.makeTexture(this.__image, this.img, (this._repeat!=="no-repeat")));
         }
 
         if (this._repeat === "no-repeat") {
             this.w = this.w || this.img.width;
             this.h = this.h || this.img.height;
         }
-
-
 
         this.ready = true;
         this.trigger("Invalidate");

--- a/src/graphics/sprite.js
+++ b/src/graphics/sprite.js
@@ -132,11 +132,8 @@ Crafty.extend({
             //set the width and height to the sprite size
             this.w = this.__coord[2];
             this.h = this.__coord[3];
-
-            if (this.has("WebGL")){
-                this._establishShader(this.__image, SPRITE_FRAGMENT_SHADER, SPRITE_VERTEX_SHADER, SPRITE_ATTRIBUTE_LIST);
-                this.program.setTexture( this.webgl.makeTexture(this.__image, this.img, false) );
-            }
+            
+            this._setupSpriteImage(this._drawLayer);
         };
 
         for (spriteName in map) {
@@ -194,10 +191,20 @@ Crafty.c("Sprite", {
     init: function () {
         this.__trim = [0, 0, 0, 0];
         this.bind("Draw", this._drawSprite);
+        this.bind("LayerAttached", this._setupSpriteImage);
     },
 
     remove: function(){
         this.unbind("Draw", this._drawSprite);
+        this.unbind("LayerAttached", this._setupSpriteImage);
+    },
+    
+    _setupSpriteImage: function(layer) {
+        if (!this.__image || !this.img || !layer) return;
+        if (layer.type === "WebGL"){
+            this._establishShader(this.__image, SPRITE_FRAGMENT_SHADER, SPRITE_VERTEX_SHADER, SPRITE_ATTRIBUTE_LIST);
+            this.program.setTexture( layer.makeTexture(this.__image, this.img, false) );
+        }
     },
 
     _drawSprite: function(e){

--- a/src/graphics/webgl-layer.js
+++ b/src/graphics/webgl-layer.js
@@ -179,6 +179,7 @@ RenderProgramWrapper.prototype = {
  * A collection of methods to handle webgl contexts.
  */
 Crafty.webglLayerObject = {
+    type: "WebGL",
     /**@
      * #.context
      * @comp WebGLLayer
@@ -215,7 +216,7 @@ Crafty.webglLayerObject = {
         if (!gl.getProgramParameter(shaderProgram, gl.LINK_STATUS)) {
           throw("Could not initialise shaders");
         }
-        
+
         shaderProgram.viewport = gl.getUniformLocation(shaderProgram, "uViewport");
         return shaderProgram;
     },
@@ -300,7 +301,6 @@ Crafty.webglLayerObject = {
         // This is necessary to match the blending of canvas/dom entities against the background color
         gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
         gl.enable(gl.BLEND);
-        
 
         //Bind rendering of canvas context (see drawing.js)
         this.uniqueBind("RenderScene", this.render);
@@ -311,8 +311,6 @@ Crafty.webglLayerObject = {
         this.dirtyViewport = true;
 
         this.texture_manager = new Crafty.TextureManager(gl, this);
-
-
     },
 
     // Cleanup the DOM when the system is destroyed
@@ -343,7 +341,7 @@ Crafty.webglLayerObject = {
 
     // convenicne to sort array by global Z
     zsort: function(a, b) {
-            return a._globalZ - b._globalZ;
+        return a._globalZ - b._globalZ;
     },
 
     // Hold an array ref to avoid garbage
@@ -391,7 +389,6 @@ Crafty.webglLayerObject = {
         // A batch is rendered whenever the next element needs to use a different type of program
         // Therefore, you get better performance by grouping programs by z-order if possible.
         // (Each sprite sheet will use a different program, but multiple sprites on the same sheet can be rendered in one batch)
-        var batchCount = 0;
         var shaderProgram = null;
         for (i=0; i < l; i++) {
             current = visible_gl[i];
@@ -412,6 +409,47 @@ Crafty.webglLayerObject = {
           shaderProgram.renderBatch();
         }
         
-    }
+    },
+    
+    /**@
+     * #.dirty
+     * @comp WebGLLayer
+     * @sign public .dirty(ent)
+     * @param ent - The entity to mark as dirty
+     *
+     * Add an entity to the list of DOM object to draw
+     */
+    dirty: function add(ent) {
+        // WebGL doens't need to do any special tracking of changed objects
+    },
+
+    /**@
+     * #.attach
+     * @comp WebGLLayer
+     * @sign public .attach(ent)
+     * @param ent - The entity to add
+     *
+     * Add an entity to the layer
+     */
+    attach: function attach(ent) {
+        // WebGL entities really need to be added to a specific program, which is handled in the LayerAttached event by components
+        ent._drawContext = this.context;
+    },
+
+    /**@
+     * #.detach
+     * @comp WebGLLayer
+     * @sign public .detach(ent)
+     * @param ent - The entity to remove
+     *
+     * Removes an entity from the layer
+     */
+    detach: function detach(ent) {
+        // This could, like attach, be handled by components
+        // We instead handle it in a central place for now
+        if (ent.program) {
+            ent.program.unregisterEntity(this);
+        }
+    },
 
 };

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -119,9 +119,7 @@ Crafty.c("2D", {
     _entry: null,
     _children: null,
     _parent: null,
-    _changed: false,
 
-    
     // Setup   all the properties that we need to define
     _2D_property_definitions: {
         x: {


### PR DESCRIPTION
Abstract out the concept of attaching and detaching from a layer into a set of methods on Renderable.

Also abstract out the concept of a renderable entity being marked as dirty.

The point of all this is to make it possible to have multiple layers of the same type -- for instance, a background and foreground canvas layer.

This probably needs some more polish and thought in terms of how components are added and removed from entities (I think we have some existing bugs/issues there that could be cleaned up as part of this work) but I thought I'd open the PR so folk could give feedback.
