### PR TITLE
Refactor how components are associated with specific draw layers

### DIFF
--- a/src/crafty.js
+++ b/src/crafty.js
@@ -31,6 +31,7 @@ require('./graphics/gl-textures');
 require('./graphics/renderable');
 require('./graphics/html');
 require('./graphics/image');
+require('./graphics/layers');
 require('./graphics/particles');
 require('./graphics/sprite-animation');
 require('./graphics/sprite');

--- a/src/graphics/canvas.js
+++ b/src/graphics/canvas.js
@@ -22,33 +22,19 @@ Crafty.c("Canvas", {
 
     init: function () {
         this.requires("Renderable");
-        var canvasLayer = Crafty.s("CanvasLayer");
-
-        this._drawLayer = canvasLayer;
-        this._drawContext = canvasLayer.context;
-
-        //increment the amount of canvas objs
-        canvasLayer.layerCount++;
+        
         //Allocate an object to hold this components current region
         this.currentRect = {};
-        this._changed = true;
-        canvasLayer.add(this);
+        
+        // Add the default canvas layer if we aren't attached to a custom one
+        if (!this._customLayer){
+            this._attachToLayer( Crafty.s("CanvasLayer"));
+        }
+        
+    },
 
-        this.bind("Invalidate", function (e) {
-            //flag if changed
-            if (this._changed === false) {
-                this._changed = true;
-                canvasLayer.add(this);
-            }
-
-        });
-
-
-        this.bind("Remove", function () {
-            this._drawLayer.layerCount--;
-            this._changed = true;
-            this._drawLayer.add(this);
-        });
+    remove: function() {
+        this._detachFromLayer();
     },
 
     /**@
@@ -76,8 +62,6 @@ Crafty.c("Canvas", {
             w: 0,
             h: 0
         }
-
-
     },
 
     draw: function (ctx, x, y, w, h) {
@@ -97,8 +81,8 @@ Crafty.c("Canvas", {
         pos._h = (h || this._h);
 
 
-        context = ctx || this._drawContext;
-        coord = this.__coord || [0, 0, 0, 0];
+        var context = ctx || this._drawContext;
+        var coord = this.__coord || [0, 0, 0, 0];
         var co = this.drawVars.co;
         co.x = coord[0] + (x || 0);
         co.y = coord[1] + (y || 0);

--- a/src/graphics/color.js
+++ b/src/graphics/color.js
@@ -170,10 +170,14 @@ Crafty.c("Color", {
 
     init: function () {
         this.bind("Draw", this._drawColor);
-        if (this.has("WebGL")){
-            this._establishShader("Color", Crafty.defaultShader("Color"));
+        if (this._drawLayer) {
+            this._setupColor(this._drawLayer);
         }
         this.trigger("Invalidate");
+    },
+    
+    events: {
+        "LayerAttached": "_setupColor"
     },
 
     remove: function(){
@@ -182,6 +186,12 @@ Crafty.c("Color", {
             this._element.style.backgroundColor = "transparent";
         }
         this.trigger("Invalidate");
+    },
+
+    _setupColor: function(layer) {
+        if (layer.type === "WebGL") {
+            this._establishShader("Color", Crafty.defaultShader("Color"));
+        }
     },
 
     // draw function for "Color"

--- a/src/graphics/dom-layer.js
+++ b/src/graphics/dom-layer.js
@@ -9,6 +9,7 @@ var Crafty = require('../core/core.js'),
  * Collection of mostly private methods to represent entities using the DOM.
  */
 Crafty.domLayerObject = {
+    type: "DOM",
     _changedObjs: [],
     _dirtyViewport: false,
 
@@ -113,15 +114,44 @@ Crafty.domLayerObject = {
     },
 
     /**@
-     * #.add
+     * #.dirty
      * @comp DomLayer
-     * @sign public .add(ent)
-     * @param ent - The entity to add
+     * @sign public .dirty(ent)
+     * @param ent - The entity to mark as dirty
      *
      * Add an entity to the list of DOM object to draw
      */
-    add: function add(ent) {
+    dirty: function add(ent) {
         this._changedObjs.push(ent);
+    },
+
+    /**@
+     * #.attach
+     * @comp DomLayer
+     * @sign public .attach(ent)
+     * @param ent - The entity to add
+     *
+     * Add an entity to the layer
+     */
+    attach: function attach(ent) {
+        ent._drawContext = this.context;
+        // attach the entity's div element to the dom layer
+        this._div.appendChild(ent._element);
+        // set position style and entity id
+        ent._element.style.position = "absolute";
+        ent._element.id = "ent" + ent[0];
+    },
+    
+    /**@
+     * #.detach
+     * @comp DomLayer
+     * @sign public .detach(ent)
+     * @param ent - The entity to remove
+     *
+     * Removes an entity from the layer
+     */
+    detach: function detach(ent) {
+        this._div.removeChild(ent._element);
     },
 
     // Sets the viewport position and scale

--- a/src/graphics/layers.js
+++ b/src/graphics/layers.js
@@ -1,0 +1,38 @@
+var Crafty = require('../core/core.js');
+
+Crafty.extend({
+    /**@
+     * #Crafty.createLayer
+     * @category Graphics
+     *
+     * @sign public void Crafty.createLayer(string name, object layerTemplate)
+     * @param name - the name that will refer to the layer
+     * @param layerTemplate - an object that implements the necessary methods for a draw layer
+     * 
+     * Creates a new instance of the specified type of layer.
+     * 
+     * @example
+     * ```
+     * Crafty.s("MyCanvasLayer", Crafty.canvasLayerObject)
+     * Crafty.e("2D, MyCanvasLayer, Color");
+     * ```
+     * Define a custom canvas layer, then create an entity that uses the custom layer to render.
+     */
+    createLayer: function createLayer(name, layerTemplate) {
+        Crafty.s(name, layerTemplate);
+        Crafty.c(name, {
+            init: function() {
+                this.requires("Renderable");
+                
+                // Flag to indicate that the base component doesn't need to attach a layer
+                this._customLayer = true;
+                this.requires(layerTemplate.type);
+                this._attachToLayer(Crafty.s(name));
+            },
+            
+            remove: function() {
+                this._detachFromLayer();
+            }
+        });
+    }
+});

--- a/src/graphics/renderable.js
+++ b/src/graphics/renderable.js
@@ -9,7 +9,9 @@ var Crafty = require('../core/core.js');
  */
 Crafty.c("Renderable", {
 
-
+    // Flag for tracking whether the entity is dirty or not
+    _changed: false,
+    
     /**@
      * #.alpha
      * @comp Renderable
@@ -27,8 +29,6 @@ Crafty.c("Renderable", {
      */
     _visible: true,
 
-
-    
     _setterRenderable: function(name, value) {
         if (this[name] === value) {
             return;
@@ -66,7 +66,6 @@ Crafty.c("Renderable", {
             enumerable: true
         },
         _visible: {enumerable:false}
-
     },
 
     _defineRenderableProperites: function () {
@@ -78,6 +77,40 @@ Crafty.c("Renderable", {
     init: function () {
         // create setters and getters that associate properties such as alpha/_alpha
         this._defineRenderableProperites();
+    },
+
+    // Renderable assumes that a draw layer has 3 important methods: attach, detach, and dirty
+
+    // Dirty the entity when it's invalidated
+    _invalidateRenderable: function() {
+        //flag if changed
+        if (this._changed === false) {
+            this._changed = true;
+            this._drawLayer.dirty(this);
+        }
+    },
+
+    // Attach the entity to a layer to be rendered
+    _attachToLayer: function(layer) {
+        if (this._drawLayer) {
+            this._detachFromLayer();
+        }
+        this._drawLayer = layer;
+        layer.attach(this);
+        this.bind("Invalidate", this._invalidateRenderable);
+        this.trigger("LayerAttached", layer);
+        this.trigger("Invalidate");
+    },
+
+    // Detach the entity from a layer
+    _detachFromLayer: function() {
+        if (!this._drawLayer) {
+            return;
+        }
+        this._drawLayer.detach(this);
+        this.unbind("Invalidate", this._invalidateRenderable);
+        this.trigger("LayerDetached", this._drawLayer);
+        delete this._drawLayer;
     },
 
     /**@

--- a/src/graphics/sprite.js
+++ b/src/graphics/sprite.js
@@ -144,11 +144,7 @@ Crafty.extend({
             //set the width and height to the sprite size
             this.w = this.__coord[2];
             this.h = this.__coord[3];
-
-            if (this.has("WebGL")){
-                this._establishShader(this.__image, Crafty.defaultShader("Sprite"));
-                this.program.setTexture( this.webgl.makeTexture(this.__image, this.img, false) );
-            }
+            this._setupSpriteImage(this._drawLayer);
         };
 
         for (spriteName in map) {
@@ -206,10 +202,20 @@ Crafty.c("Sprite", {
     init: function () {
         this.__trim = [0, 0, 0, 0];
         this.bind("Draw", this._drawSprite);
+        this.bind("LayerAttached", this._setupSpriteImage);
     },
 
     remove: function(){
         this.unbind("Draw", this._drawSprite);
+        this.unbind("LayerAttached", this._setupSpriteImage);
+    },
+    
+    _setupSpriteImage: function(layer) {
+        if (!this.__image || !this.img || !layer) return;
+        if (layer.type === "WebGL"){
+            this._establishShader(this.__image, Crafty.defaultShader("Sprite"));
+            this.program.setTexture( layer.makeTexture(this.__image, this.img, false) );
+        }
     },
 
     _drawSprite: function(e){

--- a/src/graphics/webgl.js
+++ b/src/graphics/webgl.js
@@ -165,28 +165,14 @@ Crafty.c("WebGL", {
      */
     init: function () {
         this.requires("Renderable");
-        var webgl = this.webgl = Crafty.s("WebGLLayer");
-        var gl = webgl.context;
-
-        //increment the amount of canvas objs
-        this._changed = true;
-        this.bind("Change", this._glChange);
+        // Attach to webgl layer
+        if (!this._customLayer){
+            this._attachToLayer( Crafty.s("WebGLLayer") );
+        }
     },
-
+ 
     remove: function(){
-        this._changed = true;
-        this.unbind(this._glChange);
-        // Webgl components need to be removed from their gl program
-        if (this.program) {
-            this.program.unregisterEntity(this);
-        }
-    },
-
-    _glChange: function(){
-        //flag if changed
-        if (this._changed === false) {
-            this._changed = true;
-        }
+        this._detachFromLayer();
     },
 
     // Cache the various objects and arrays used in draw
@@ -224,7 +210,7 @@ Crafty.c("WebGL", {
             w = y;
             y = x;
             x = ctx;
-            ctx = this.webgl.context;
+            ctx = this._drawLayer.context;
         }
 
         var pos = this.drawVars.pos;
@@ -252,12 +238,13 @@ Crafty.c("WebGL", {
         }
 
         //Draw entity
-        var gl = this.webgl.context;
+        var gl = this._drawContext;
         this.drawVars.gl = gl;
         var prog = this.drawVars.program = this.program;
 
         // The program might need to refer to the current element's index
         prog.setCurrentEntity(this);
+
         // Write position; x, y, w, h
         prog.writeVector("aPosition",
             this._x, this._y,
@@ -290,7 +277,7 @@ Crafty.c("WebGL", {
 
     // v_src is optional, there's a default vertex shader that works for regular rectangular entities
     _establishShader: function(compName, shader){
-        this.program = this.webgl.getProgramWrapper(compName, shader);
+        this.program = this._drawLayer.getProgramWrapper(compName, shader);
 
         // Needs to know where in the big array we are!
         this.program.registerEntity(this);

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -119,9 +119,7 @@ Crafty.c("2D", {
     _entry: null,
     _children: null,
     _parent: null,
-    _changed: false,
 
-    
     // Setup   all the properties that we need to define
     _2D_property_definitions: {
         x: {


### PR DESCRIPTION
- Abstract out the concept of attaching and detaching from a layer into a set of methods on Renderable.
- Also abstract out the concept of a renderable entity being marked as dirty.
- Minimal support for creating custom layers

This is an enhanced version of #995.  AFAICT the code is now fairly solid, but there are probably some documentation changes that need to be made.
