### PR TITLE
Add 2D raycast

### DIFF
--- a/playgrounds/2D/raycast/raycast.html
+++ b/playgrounds/2D/raycast/raycast.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML>
+<html>
+	<head>
+		<script type="text/javascript" src="../../../crafty.js"></script>
+	</head>
+	<body>
+		<h1>Raycast playground:</h1>
+
+		<p>
+		<h3>Input:</h3>
+			<ul>
+			<li>Drag on the background to initiate a raycast (up to the line length).<br/></li>
+			<li>Drag &amp; drop entities to move them.<br/></li>
+			<li>Hold shift while dragging entities up/down to rotate them.<br/></li>
+		</ul>
+		</p>
+
+		<p>
+		<h3>Output:</h3>
+			<ul>
+			<li>First object hit by ray will be given red outline.<br/></li>
+			<li>For all objects hit (up to the line length) the intersection point will be marked with a purple dot.<br/></li>
+		</ul>
+		</p>
+		<div id="cr-stage" style="border: solid black 8px;"></div>
+		<script type="text/javascript" src="raycast.js"></script>
+	</body>
+</html>

--- a/playgrounds/2D/raycast/raycast.js
+++ b/playgrounds/2D/raycast/raycast.js
@@ -1,0 +1,165 @@
+Crafty.init(640, 640);
+Crafty.background('white');
+
+
+var startPos = {};
+Crafty.e('Background, 2D, DOM, MouseDrag, DebugPolygon')
+      .setName('Background')
+      .attr({w: 640, h: 640})
+      .debugStroke('red')
+      .bind('StartDrag', function(e) {
+        this.debugPolygon(undefined);
+        startPos = {x: e.realX, y: e.realY};
+      })
+      .bind('Dragging', function(e) {
+        this.debugPolygon({points: [startPos.x, startPos.y, e.realX, e.realY]});
+      })
+      .bind('StopDrag', function(e) {
+        raycast(startPos, {x: e.realX, y: e.realY});
+      });
+
+for (var i = 0; i < 10; ++i)
+  for (var j = 0; j < 10; ++j)
+    Crafty.e('Cell, 2D, DOM, Color')
+          .setName('Cell['+i+']['+j+']')
+          .attr({ x: i * 64, y: j * 64, w: 64, h: 64, z: -1})
+          .color((i + j) % 2 ? "rgba(0, 255, 0, 0.1)" : "rgba(0, 0, 255, 0.1)");
+
+Crafty.c("MouseMovable", {
+  required: "Mouse, Draggable",
+
+  events: {
+    "KeyDown": function(e) {
+      if (e.key === Crafty.keys.SHIFT) {
+        this.disableDrag();
+        this.uniqueBind("Dragging", this._dragMouseDrag);
+        this.uniqueBind("StopDrag", this._stopMouseDrag);
+      }
+    },
+    "KeyUp": function(e) {
+      if (e.key === Crafty.keys.SHIFT) {
+        this.enableDrag();
+        this.unbind("Dragging", this._dragMouseDrag);
+        this.unbind("StopDrag", this._stopMouseDrag);
+      }
+    }
+  },
+
+  _stopMouseDrag: function() {
+    delete this._lastMousePos;
+  },
+  _dragMouseDrag: function(e) {
+    if (this._lastMousePos) {
+      var d = new Crafty.math.Vector2D(
+        e.realX - this._lastMousePos.x,
+        e.realY - this._lastMousePos.y
+      );
+
+      this.rotation += d.dotProduct({x: 0, y: 1});
+    }
+    this._lastMousePos = {x: e.realX, y: e.realY};
+  }
+});
+
+var trapezoid = Crafty.e('Trapezoid, 2D, DOM, Color, Collision, SolidHitBox, MouseMovable')
+      .setName('Trapezoid')
+      .attr({w: 200, h: 100})
+      .origin('center')
+      .collision(new Crafty.polygon([50, 0, 0, 100, 200, 100, 150, 0]))
+      .color("rgba(0, 127, 127, 0.25)");
+
+var yellow = Crafty.e('Yellow, 2D, DOM, Collision, SolidHitBox, MouseMovable')
+      .setName('Yellow')
+      .attr({w: 100, h: 100})
+      .origin('center')
+      .collision(new Crafty.polygon([0, 0, 0, 100, 100, 100, 100, 0]));
+
+var parallelogram = Crafty.e('Parallelogram, 2D, DOM, Color, Collision, SolidHitBox, MouseMovable')
+      .setName('Parallelogram')
+      .attr({w: 100, h: 100})
+      .origin('center')
+      .collision(new Crafty.polygon([0, 0, 25, 100, 100, 100, 75, 0]))
+      .color("rgba(0, 127, 127, 0.25)");
+
+var triangle = Crafty.e('Triangle, 2D, DOM, Color, Collision, SolidHitBox, MouseMovable')
+      .setName('Triangle')
+      .attr({w: 300, h: 100})
+      .origin('center')
+      .collision(new Crafty.polygon([25, 75, 250, 25, 275, 50]))
+      .color("rgba(0, 127, 127, 0.25)");
+
+var cbr = Crafty.e('CBR, 2D, DOM, Color, Collision, SolidHitBox, MouseMovable')
+      .setName('CBR')
+      .attr({w: 100, h: 100})
+      .origin('center')
+      .collision(new Crafty.polygon([75, -25, 125, -25, 125, 25, 75, 25]))
+      .color("rgba(0, 127, 127, 0.25)");
+
+var green = Crafty.e('Green, 2D, DOM, Collision, Color, MouseMovable')
+      .setName('Green')
+      .attr({w: 100, h: 100})
+      .origin('center')
+      .color('rgb(47, 233, 87)');
+
+var purple = Crafty.e('Purple, 2D, DOM, Collision, Color, MouseMovable')
+      .setName('Purple')
+      .attr({w: 100, h: 100})
+      .origin('center')
+      .color('rgb(147, 33, 187)');
+
+trapezoid.attr({x: 400, y: 150});
+yellow.attr({x: 50, y: 50});
+parallelogram.attr({x: 350, y: 350});
+green.attr({x: 100, y: 500});
+purple.attr({x: 500, y: 500});
+triangle.attr({x: 25, y: 222});
+cbr.attr({x: 256, y: 64});
+
+
+function raycast(start, end) {
+  Crafty("FirstHit").destroy();
+  Crafty("Hit").destroy();
+
+  var origin = {_x: start.x, _y: start.y},
+      direction = new Crafty.math.Vector2D(end.x - start.x, end.y - start.y),
+      magnitude = direction.magnitude(),
+      results;
+  direction.normalize();
+
+  if (magnitude < 5) return;
+  Crafty.log('Raycast',
+    'origin=[', origin._x.toFixed(2), origin._y.toFixed(2), ']',
+    'direction=[', direction.x.toFixed(2), direction.y.toFixed(2), ']',
+    'magnitude=', magnitude.toFixed(2));
+
+  // find first ray hit
+  results = Crafty.raycast(origin, direction, -Infinity);
+  if (results.length > 0) {
+    Crafty.log('FirstHit',
+      'name=', results[0].obj.getName(),
+      'distance=', results[0].distance.toFixed(2),
+      '@[', results[0].x.toFixed(2), results[0].y.toFixed(2), ']');
+
+    Crafty.e("FirstHit, 2D, DOM, DebugPolygon")
+          .setName("FirstHit")
+          .debugStroke('red')
+          .debugPolygon(results[0].obj.map);
+  }
+
+  // find all ray hits up to line length
+  results = Crafty.raycast(origin, direction, magnitude);
+  for (var i=0; i < results.length; ++i) {
+    Crafty.log('Hit'+i,
+      'name=', results[i].obj.getName(),
+      'distance=', results[i].distance.toFixed(2),
+      '@[', results[i].x.toFixed(2), results[i].y.toFixed(2), ']');
+
+    Crafty.e("Hit, 2D, DOM, VisibleMBR")
+          .setName("Hit"+i)
+          .attr({
+            x: results[i].x - 2, w: 4,
+            y: results[i].y - 2, h: 4
+          });
+  }
+  Crafty.log('');
+}

--- a/src/graphics/viewport.js
+++ b/src/graphics/viewport.js
@@ -503,7 +503,7 @@ Crafty.extend({
             // clamps the viewport to the viewable area
             // under no circumstances should the viewport see something outside the boundary of the 'world'
             if (!this.clampToEntities) return;
-            var bound = Crafty.clone(this.bounds) || Crafty.map.boundaries();
+            var bound = Crafty.clone(this.bounds) || Crafty.clone(Crafty.map.boundaries());
             bound.max.x *= this._scale;
             bound.min.x *= this._scale;
             bound.max.y *= this._scale;

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -266,7 +266,7 @@ Crafty.c("2D", {
                 this._parent.detach(this);
             }
 
-            Crafty.map.remove(this);
+            Crafty.map.remove(this._entry);
 
             this.detach();
         });

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -1799,6 +1799,127 @@ Crafty.polygon.prototype = {
             p[i] = x;
             p[i+1] = y;
         }
+    },
+
+    /**@
+     * #.intersectRay
+     * @comp Crafty.polygon
+     * @sign public Number .intersectRay(Object origin, Object direction)
+     * @param origin - the point of origin from which the ray will be cast. The object must contain the properties `_x` and `_y`.
+     * @param direction - the direction the ray will be cast. It must be normalized. The object must contain the properties `x` and `y`.
+     * @returns a Number indicating the distance from the ray's origin to the closest intersection point of the polygon.
+     *          Returns `Infinity` if there is no intersection.
+     *
+     * Find the distance to the closest intersection point of the supplied ray with any of this polygon's segments.
+     *
+     * @example
+     * ~~~
+     * var poly = new Crafty.polygon([0,0, 50,0, 50,50, 0,50]);
+     *
+     * var origin = {_x: -1, _y: 25};
+     * var direction = new Crafty.math.Vector2D(1, 0).normalize();;
+     *
+     * var distance = poly.intersectRay(origin, direction);
+     * Crafty.log('Distance from origin to closest intersection point', distance); // logs '1'
+     * ~~~
+     */
+
+    // Note that for the algorithm to work, the points of the polygon have to be defined
+    // either clock-wise or counter-clock-wise
+    //
+    // Segment-segment intersection is described here: http://stackoverflow.com/a/565282/3041008
+    // see dot projection: http://www.wildbunny.co.uk/blog/vector-maths-a-primer-for-games-programmers/vector/#Projection
+    //
+    // origin = {_x, _y}
+    // direction = {x, y}, must be normalized
+    // edge = end - start (of segment)
+    //
+    //
+    // # Segment - segment intersection equation
+    // origin + d * direction = start + e * edge
+    //
+    // ## Solving for d
+    // (origin + d * direction) x edge = (start + e * edge) x edge
+    // edge x edge == 0
+    // d = (start − origin) × edge / (direction × edge)
+    // d_nominator = (start - origin) x edge =
+    //      (start.x - origin.x, start.y - origin.y) x (edge.x, edge.y) =
+    //      (start.x - origin.x) * edge.y - (start.y - origin.y) * edge.x
+    // d_denominator = direction x edge =
+    //      (direction.x, direction.y) x (edge.x, edge.y) =
+    //      direction.x * edge.y - direction.y * edge.x
+    //
+    // ## Solving for e
+    // (origin + d * direction) x direction = (start + e * edge) x direction
+    // direction x direction == 0
+    // edge factor must be in interval [0, 1]
+    // e = (start − origin) × direction / (direction × edge)
+    // e_nominator = (start − origin) × direction =
+    //      (start.x - origin.x) * direction.y - (start.y - origin.y) * direction.x
+    // e_denominator = d_denominator
+    //
+    //
+    // # If segments are colinear (both nominator and denominator == 0),
+    //    then minDistance is min(d0, d1) >= 0,
+    //    get d0, d1 by doing dot projection onto normalized direction vector
+    //
+    // origin + d0*direction = start
+    // d0*direction = (start - origin)
+    // -> d0 = (start - origin) • direction =
+    //      (start.x - origin.x, start.y - origin.y) • (direction.x, direction.y) =
+    //      (start.x - origin.x) * direction.x + (start.y - origin.y) * direction.y
+    //
+    // origin + d1*direction = end
+    // d1*direction = end - origin
+    // -> d1 = (end - origin) • direction =
+    //      (end.x - origin.x, end.y - origin.y) • (direction.x, direction.y) =
+    //      (end.x - origin.x) * direction.x + (end.y - origin.y) * direction.y
+    intersectRay: function (origin, direction) {
+        var points = this.points,
+            minDistance = Infinity;
+        var d, d_nom,
+            e, e_nom,
+            denom;
+
+        var originX = origin._x, directionX = direction.x,
+            originY = origin._y, directionY = direction.y;
+
+        var i = 0, l = points.length;
+        var startX = points[l - 2], endX, edgeX,
+            startY = points[l - 1], endY, edgeY;
+        for (; i < l; i += 2) {
+            endX = points[i];
+            endY = points[i+1];
+            edgeX = endX - startX;
+            edgeY = endY - startY;
+
+            d_nom = (startX - originX) * edgeY      - (startY - originY) * edgeX;
+            e_nom = (startX - originX) * directionY - (startY - originY) * directionX;
+            denom = directionX * edgeY - directionY * edgeX;
+
+            if (denom !== 0) {
+                d = d_nom / denom;
+                e = e_nom / denom;
+
+                if (e >= 0 && e <= 1 && d >= 0 && d < minDistance)
+                    minDistance = d;
+
+            } else if (d_nom === 0 || e_nom === 0) {
+
+                d = (startX - originX) * directionX + (startY - originY) * directionY;
+                if (d >= 0 && d < minDistance)
+                    minDistance = d;
+
+                d = (endX - originX) * directionX + (endY - originY) * directionY;
+                if (d >= 0 && d < minDistance)
+                    minDistance = d;
+            }
+
+            startX = endX;
+            startY = endY;
+        }
+
+        return minDistance;
     }
 };
 

--- a/src/spatial/spatial-grid.js
+++ b/src/spatial/spatial-grid.js
@@ -135,26 +135,21 @@
         /**@
          * #Crafty.map.remove
          * @comp Crafty.map
-         * @sign public void Crafty.map.remove([Object keys, ]Object obj)
-         * @param keys - key region. If omitted, it will be derived from obj by `Crafty.HashMap.key`.
-         * @param obj - An object to remove from the hashmap
+         * @sign public void Crafty.map.remove(Entry entry)
+         * @param entry - An entry to remove from the hashmap
          *
-         * Remove an entity in a broad phase map.
-         * - The second form is only used in Crafty.HashMap to save time for computing keys again, where keys were computed previously from obj. End users should not call this form directly.
+         * Remove an entry from the broad phase map.
          *
          * @example
          * ~~~
          * Crafty.map.remove(e);
          * ~~~
          */
-        remove: function (keys, obj) {
+        remove: function (entry) {
+            var keys = entry.keys;
+            var obj = entry.obj;
             var i = 0,
                 j, hash;
-
-            if (arguments.length === 1) {
-                obj = keys;
-                keys = HashMap.key(obj, keyHolder);
-            }
 
             //search in all x buckets
             for (i = keys.x1; i <= keys.x2; i++) {
@@ -177,7 +172,7 @@
         /**@
          * #Crafty.map.refresh
          * @comp Crafty.map
-         * @sign public void Crafty.map.remove(Entry entry)
+         * @sign public void Crafty.map.refresh(Entry entry)
          * @param entry - An entry to update
          *
          * Update an entry's keys, and its position in the broad phrase map.

--- a/src/spatial/spatial-grid.js
+++ b/src/spatial/spatial-grid.js
@@ -141,7 +141,7 @@
                     obj = results[i];
                     if (!obj) continue; //skip if deleted
                     id = obj[0]; //unique ID
-                    obj = obj._mbr || obj;
+                    obj = obj._cbr || obj._mbr || obj;
                     //check if not added to hash and that actually intersects
                     if (!found[id] && obj._x < rect._x + rect._w && obj._x + obj._w > rect._x &&
                                       obj._y < rect._y + rect._h && obj._y + obj._h > rect._y)
@@ -395,12 +395,8 @@
      * @see Crafty.HashMap.constructor
      */
     HashMap.key = function (obj, keys) {
-        if (obj._mbr) {
-            obj = obj._mbr;
-        }
-        if (!keys) {
-            keys = {};
-        }
+        obj = obj._cbr || obj._mbr || obj;
+        keys = keys || {};
 
         keys.x1 = Math.floor(obj._x / cellsize);
         keys.y1 = Math.floor(obj._y / cellsize);

--- a/tests/2D/raycast.js
+++ b/tests/2D/raycast.js
@@ -1,0 +1,1264 @@
+(function() {
+  var module = QUnit.module;
+
+
+  var cellsize = 64;
+
+  var EAST = new Crafty.math.Vector2D(1, 0).normalize();
+  var WEST = new Crafty.math.Vector2D(-1, 0).normalize();
+  var SOUTH = new Crafty.math.Vector2D(0, 1).normalize();
+  var NORTH = new Crafty.math.Vector2D(0, -1).normalize();
+  var SOUTH_EAST = new Crafty.math.Vector2D(1, 1).normalize();
+  var NORTH_EAST = new Crafty.math.Vector2D(1, -1).normalize();
+  var SOUTH_WEST = new Crafty.math.Vector2D(-1, 1).normalize();
+  var NORTH_WEST = new Crafty.math.Vector2D(-1, -1).normalize();
+
+  var ANGLE_POS_41 = new Crafty.math.Vector2D(
+        Math.cos(41 * Math.PI / 180),
+        -Math.sin(41 * Math.PI / 180) // y-axis is inverted in Crafty
+      ).normalize();
+  var ANGLE_NEG_22_5 = new Crafty.math.Vector2D(
+        Math.cos(-22.5 * Math.PI / 180),
+        -Math.sin(-22.5 * Math.PI / 180) // y-axis is inverted in Crafty
+      ).normalize();
+  var ANGLE_NEG_1 = new Crafty.math.Vector2D(
+        Math.cos(-1 * Math.PI / 180),
+        -Math.sin(-1 * Math.PI / 180) // y-axis is inverted in Crafty
+      ).normalize();
+
+
+  //////////////////////
+  // UTILITY FUNCTIONS
+  //////////////////////
+
+  function createEntity (cellX, cellY, cellWidth, cellHeight) {
+    cellX = cellX || 0;
+    cellY = cellY || 0;
+    cellWidth = cellWidth || 1;
+    cellHeight = cellHeight || 1;
+
+    var e = Crafty.e("2D, Collision").attr({
+      x: cellX * cellsize + 1,
+      y: cellY * cellsize + 1,
+      w: cellWidth * cellsize - 2,
+      h: cellHeight * cellsize - 2,
+    });
+
+    return e;
+  }
+
+  function diagonalDistance (diffX, diffY) {
+    var dX = diffX * cellsize + 1,
+    dY = diffY * cellsize + 1;
+
+    return Math.sqrt(dX * dX + dY * dY);
+  }
+
+  function checkResults (origin, direction, raycastResults, expectedResults) {
+    strictEqual(raycastResults.length, Object.keys(expectedResults).length, "expected ids count must match");
+
+    var actualId, actualDistance, expectedDistance,
+        actualIntersectionX, expectedIntersectionX,
+        actualIntersectionY, expectedIntersectionY;
+    for (var i = 0, l = raycastResults.length; i < l; ++i) {
+      actualId = raycastResults[i].obj[0];
+      actualDistance = raycastResults[i].distance;
+      actualIntersectionX = raycastResults[i].x;
+      actualIntersectionY = raycastResults[i].y;
+      expectedDistance = expectedResults[actualId];
+      expectedIntersectionX = origin._x + expectedDistance * direction.x;
+      expectedIntersectionY = origin._y + expectedDistance * direction.y;
+
+      ok(typeof expectedResults[actualId] !== 'undefined', "actual id is among expected ids");
+      strictEqual(actualDistance.toFixed(2), expectedDistance.toFixed(2),  "actual distance matches expected distance");
+      strictEqual(actualIntersectionX.toFixed(2), expectedIntersectionX.toFixed(2), "actual intersection point x matches expected intersection point x");
+      strictEqual(actualIntersectionY.toFixed(2), expectedIntersectionY.toFixed(2), "actual intersection point y matches expected intersection point y");
+    }
+  }
+
+  //////////////////////
+  // TESTS
+  //////////////////////
+
+  module("Raycast");
+
+  var mapSize = 64 * 5;
+
+  var LEFT = {_x: 0, _y: mapSize / 2};
+  var RIGHT = {_x: mapSize, _y: mapSize / 2};
+  var TOP = {_x: mapSize/2, _y: 0};
+  var BOTTOM = {_x: mapSize / 2, _y: mapSize};
+  var TOP_LEFT = {_x: 0, _y: 0};
+  var TOP_RIGHT = {_x: mapSize, _y: 0};
+  var BOTTOM_LEFT = {_x: 0, _y: mapSize};
+  var BOTTOM_RIGHT = {_x: mapSize, _y: mapSize};
+
+  test("Check multiple hits", function() {
+    var origin, direction,
+        expectedResults = {},
+        e, f,
+        results;
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║E║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║F║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (0,0)
+    Direction = (1,1)
+    */
+    origin = TOP_LEFT;
+    direction = SOUTH_EAST;
+
+    expectedResults = {};
+    e = createEntity(0, 0); expectedResults[e[0]] = diagonalDistance(0, 0);
+    f = createEntity(4, 4); expectedResults[f[0]] = diagonalDistance(4, 4);
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+    f.destroy();
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║E║X║X║X║X║
+        ╠═╬═╬═╬═╬═╣
+        ║X║ ║X║X║X║
+        ╠═╬═╬═╬═╬═╣
+        ║X║X║ ║X║X║
+        ╠═╬═╬═╬═╬═╣
+        ║X║X║X║ ║X║
+        ╠═╬═╬═╬═╬═╣
+        ║X║X║X║X║F║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (0,0)
+    Direction = (1,1)
+    */
+    origin = TOP_LEFT;
+    direction = SOUTH_EAST;
+
+    expectedResults = {};
+    e = createEntity(0, 0); expectedResults[e[0]] = diagonalDistance(0, 0);
+    f = createEntity(4, 4); expectedResults[f[0]] = diagonalDistance(4, 4);
+    var temps = [];
+    for (var i = 0; i < 5; ++i)
+      for (var j = 0; j < 5; ++j)
+        if (i !== j)
+          temps.push(createEntity(i, j));
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+    f.destroy();
+    for (i = 0; i < temps.length; ++i) {
+      temps[i].destroy();
+    }
+
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║:║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (0,0)
+    Direction = (1,1)
+    */
+    origin = TOP_LEFT;
+    direction = SOUTH_EAST;
+
+    expectedResults = {};
+    e = createEntity(1,1); expectedResults[e[0]] = diagonalDistance(1, 1);
+    f = createEntity(1,1); expectedResults[f[0]] = diagonalDistance(1, 1);
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+    f.destroy();
+  });
+
+
+  test("Check big entity hits", function() {
+    var origin, direction,
+        expectedResults = {},
+        e, f,
+        results;
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║E║E║E║E║E║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (0,0)
+    Direction = (1,1)
+    */
+    origin = TOP_LEFT;
+    direction = SOUTH_EAST;
+
+    expectedResults = {};
+    e = createEntity(0, 4, 5, 1); expectedResults[e[0]] = diagonalDistance(4,4);
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║F║F║F║F║F║
+        ╠═╬═╬═╬═╬═╣
+        ║F║F║F║F║F║
+        ╠═╬═╬═╬═╬═╣
+        ║F║F║F║F║F║
+        ╠═╬═╬═╬═╬═╣
+        ║F║F║F║F║F║
+        ╠═╬═╬═╬═╬═╣
+        ║E║E║E║E║E║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (0,0)
+    Direction = (1,1)
+    */
+    origin = TOP_LEFT;
+    direction = SOUTH_EAST;
+
+    expectedResults = {};
+    e = createEntity(0, 4, 5, 1); expectedResults[e[0]] = diagonalDistance(4,4);
+    f = createEntity(0, 0, 4, 5); expectedResults[f[0]] = diagonalDistance(0,0);
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+    f.destroy();
+  });
+
+
+  test("Check diagonal hits", function() {
+    var origin, direction,
+        expectedResults = {},
+        e,
+        results;
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║E║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+    */
+    expectedResults = {};
+    e = createEntity(2, 2); expectedResults[e[0]] = diagonalDistance(2, 2);
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (0,0)
+    Direction = (1,1)
+    */
+    origin = TOP_LEFT;
+    direction = SOUTH_EAST;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (320,0)
+    Direction = (-1,1)
+    */
+    origin = TOP_RIGHT;
+    direction = SOUTH_WEST;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (0,320)
+    Direction = (1,-1)
+    */
+    origin = BOTTOM_LEFT;
+    direction = NORTH_EAST;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (320,320)
+    Direction = (-1,-1)
+    */
+    origin = BOTTOM_RIGHT;
+    direction = NORTH_WEST;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+
+    e.destroy();
+  });
+
+
+  test("Check vert/horiz hits", function() {
+    var origin, direction,
+        expectedResults = {},
+        e,
+        results;
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║E║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+    */
+    expectedResults = {};
+    e = createEntity(2, 2); expectedResults[e[0]] = diagonalDistance(2, 0);
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (0,160)
+    Direction = (1,0)
+    */
+    origin = LEFT;
+    direction = EAST;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (320,160)
+    Direction = (-1,0)
+    */
+    origin = RIGHT;
+    direction = WEST;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (160,0)
+    Direction = (0,1)
+    */
+    origin = TOP;
+    direction = SOUTH;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (160,320)
+    Direction = (0,-1)
+    */
+    origin = BOTTOM;
+    direction = NORTH;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+
+    e.destroy();
+  });
+
+
+  test("Check no hits", function() {
+    var origin, direction,
+        expectedResults = {},
+        e,
+        results;
+
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║E║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+    */
+    expectedResults = {};
+    e = createEntity(2, 2);
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (0,0)
+    Direction = (-1,-1)
+    */
+    origin = TOP_LEFT;
+    direction = NORTH_WEST;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (320,0)
+    Direction = (1,1)
+    */
+    origin = TOP_RIGHT;
+    direction = SOUTH_EAST;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (0,320)
+    Direction = (1,1)
+    */
+    origin = BOTTOM_LEFT;
+    direction = SOUTH_EAST;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (0,160)
+    Direction = (-1,0)
+    */
+    origin = LEFT;
+    direction = WEST;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (160,320)
+    Direction = (0,1)
+    */
+    origin = BOTTOM;
+    direction = SOUTH;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (-1000,-1000)
+    Direction = (0.75,-0.66)
+    */
+    origin = {_x: -1000, _y: -1000};
+    direction = ANGLE_POS_41;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+    */
+    e.destroy();
+    expectedResults = {};
+
+    /*
+     -----
+    | Ray |
+     -----
+    Origin = (0,0)
+    Direction = (1,1)
+    */
+    origin = TOP_LEFT;
+    direction = SOUTH_EAST;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+  });
+
+
+  test("Check colinear hits", function() {
+    var origin, direction,
+        expectedResults = {},
+        e,
+        results;
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║E║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (0,0)
+    Direction = (1,0)
+    */
+    origin = {_x: 0, _y: 1};
+    direction = {x: 1, y: 0};
+
+    expectedResults = {};
+    e = createEntity(2, 0); expectedResults[e[0]] = diagonalDistance(2, 0);
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+
+    /*
+     ------
+    | Grid |
+     ------
+    (-320,-320)  (0,-320)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║E║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║^║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (-320,0)     (0,0)
+
+     -----
+    | Ray |
+     -----
+    Origin = (-192+1, -96-1)
+    Direction = (0,1)
+    */
+    origin = {_x: -3 * cellsize + 1, _y: -1.5 * cellsize - 1};
+    direction = {x: 0, y: -1};
+
+    expectedResults = {};
+    e = createEntity(-3, -4); expectedResults[e[0]] = 1.5 * cellsize;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+  });
+
+
+  test("Check first hit", function() {
+    var origin, direction,
+        expectedResults = {},
+        e, f, g, h,
+        results;
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║ ║ ║h║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║g║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║f║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║E║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (0,320)
+    Direction = (1,-1)
+    */
+    origin = BOTTOM_LEFT;
+    direction = NORTH_EAST;
+
+    expectedResults = {};
+    e = createEntity(1, 3, 1, 1); expectedResults[e[0]] = diagonalDistance(1, 1);
+    f = createEntity(2, 2, 1, 1);
+    g = createEntity(3, 1, 1, 1);
+    h = createEntity(4, 0, 1, 1);
+
+    results = Crafty.raycast(origin, direction, -Infinity);
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+    f.destroy();
+    g.destroy();
+    h.destroy();
+  });
+
+
+  test("Check maxDistance hits", function() {
+    var origin, direction,
+        expectedResults = {},
+        e, f, g, h,
+        results;
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║ ║ ║h║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║g║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║F║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║E║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (0,320)
+    Direction = (1,-1)
+    */
+    origin = BOTTOM_LEFT;
+    direction = NORTH_EAST;
+
+    expectedResults = {};
+    e = createEntity(1, 3, 1, 1); expectedResults[e[0]] = diagonalDistance(1, 1);
+    f = createEntity(2, 2, 1, 1);
+    g = createEntity(3, 1, 1, 1);
+    h = createEntity(4, 0, 1, 1);
+
+    results = Crafty.raycast(origin, direction, diagonalDistance(2,2)-1);
+    checkResults(origin, direction, results, expectedResults);
+
+    expectedResults[f[0]] = diagonalDistance(2, 2);
+    results = Crafty.raycast(origin, direction, diagonalDistance(2,2));
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+    f.destroy();
+    g.destroy();
+    h.destroy();
+  });
+
+
+  test("Check component filter", function() {
+    var origin, direction,
+        expectedResults = {},
+        e, f, g, h,
+        results;
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║ ║ ║h║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║G║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║f║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║E║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (0,320)
+    Direction = (1,-1)
+    */
+    origin = BOTTOM_LEFT;
+    direction = NORTH_EAST;
+
+    expectedResults = {};
+    e = createEntity(1, 3, 1, 1); e.addComponent("RAY"); expectedResults[e[0]] = diagonalDistance(1, 1);
+    f = createEntity(2, 2, 1, 1);
+    g = createEntity(3, 1, 1, 1); g.addComponent("RAY"); expectedResults[g[0]] = diagonalDistance(3, 3);
+    h = createEntity(4, 0, 1, 1);
+
+    results = Crafty.raycast(origin, direction, "RAY");
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+    f.destroy();
+    g.destroy();
+    h.destroy();
+  });
+
+
+  test("Check origin within entity", function() {
+    var origin, direction,
+        expectedResults = {},
+        e, f,
+        results;
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║e║F║e║e║E║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (32,32)
+    Direction = (1,0)
+    */
+    origin = {_x: cellsize / 2, _y: cellsize / 2};
+    direction = EAST;
+
+    expectedResults = {};
+    e = createEntity(0, 0, 5, 5);
+    f = createEntity(1, 0, 1, 1);
+
+    expectedResults[f[0]] = 0.5 * cellsize + 1;
+    results = Crafty.raycast(origin, direction, -Infinity);
+    checkResults(origin, direction, results, expectedResults);
+
+    expectedResults[e[0]] = 4.5 * cellsize - 1;
+    results = Crafty.raycast(origin, direction, Infinity);
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+    f.destroy();
+  });
+
+
+  test("Check intersection at 0 distance", function() {
+    var origin, direction,
+        expectedResults = {},
+        e, f,
+        results;
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,-320)   (320,-320)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║F║F║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║F║:║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║\║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,0)      (320,0)
+
+     -----
+    | Ray |
+     -----
+    Origin = (192-1,-128-1)
+    Direction = (-1,-1)
+    */
+    origin = {_x: 3*cellsize - 1, _y: -2*cellsize - 1};
+    direction = NORTH_WEST;
+
+    expectedResults = {};
+    e = createEntity(2, -3, 1, 1); expectedResults[e[0]] = 0;
+
+    results = Crafty.raycast(origin, direction, -Infinity);
+    checkResults(origin, direction, results, expectedResults);
+
+    f = createEntity(1, -4, 2, 2); expectedResults[f[0]] = 0;
+    results = Crafty.raycast(origin, direction, Infinity);
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+    f.destroy();
+  });
+
+
+  test("Check result sorting", function() {
+    var origin, direction,
+        expectedResults = {},
+        e, f, g, h,
+        results;
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║-║F║G║H║E║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (32,32)
+    Direction = (0.99, 0.01)
+    */
+    origin = {_x: cellsize / 2, _y: cellsize / 2};
+    direction = ANGLE_NEG_1;
+
+    expectedResults = {};
+    e = createEntity(0, 0, 5, 1);
+    f = createEntity(0, 0, 2, 1);
+    g = createEntity(0, 0, 3, 1);
+    h = createEntity(3, 0, 1, 1);
+
+    // with sorting explicitly disabled
+    results = Crafty.raycast(origin, direction, false);
+    strictEqual(results.length, 4, "all entities found");
+
+    strictEqual(results[0].obj[0], e[0], "entity e reported first");
+    strictEqual(results[1].obj[0], f[0], "entity f reported second");
+    strictEqual(results[2].obj[0], g[0], "entity g reported third");
+    strictEqual(results[3].obj[0], h[0], "entity h reported fourth");
+
+    // with sorting enabled - this should be default case
+    results = Crafty.raycast(origin, direction);
+    strictEqual(results.length, 4, "all entities found");
+
+    strictEqual(results[0].obj[0], f[0], "entity f first hit with ray");
+    ok(results[0].distance > 0.5*cellsize, "entity f first hit with ray");
+    strictEqual(results[0].x, f.x + f.w, "entity f first hit with ray");
+    ok(results[0].y > cellsize/32, "entity f first hit with ray");
+
+    strictEqual(results[1].obj[0], g[0], "entity g second hit with ray");
+    ok(results[1].distance > results[0].distance, "entity g second hit with ray");
+    ok(results[1].distance > 1.5*cellsize, "entity g second hit with ray");
+    strictEqual(results[1].x, g.x + g.w, "entity g second hit with ray");
+    ok(results[1].y > results[0].y, "entity g second hit with ray");
+
+    strictEqual(results[2].obj[0], h[0], "entity h third hit with ray");
+    ok(results[2].distance > results[1].distance, "entity h third hit with ray");
+    ok(results[2].distance > 2.5*cellsize, "entity h third hit with ray");
+    strictEqual(results[2].x, h.x, "entity h third hit with ray");
+    ok(results[2].y > results[1].y, "entity h third hit with ray");
+
+    strictEqual(results[3].obj[0], e[0], "entity e fourth hit with ray");
+    ok(results[3].distance > results[2].distance, "entity e fourth hit with ray");
+    ok(results[3].distance > 3.5*cellsize, "entity e fourth hit with ray");
+    strictEqual(results[3].x, e.x + e.w, "entity e fourth hit with ray");
+    ok(results[3].y > results[2].y, "entity e fourth hit with ray");
+
+    e.destroy();
+    f.destroy();
+    g.destroy();
+    h.destroy();
+  });
+
+
+  test("Check intersection with hitbox outside entity (CBR)", function() {
+    var origin, direction,
+        expectedResults = {},
+        e, f, g,
+        results;
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║e║E║F║G║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║f║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (0,0)
+    Direction = (1,0)
+    */
+    origin = LEFT;
+    direction = EAST;
+
+    expectedResults = {};
+    e = createEntity(0, 2, 2, 1).collision([
+          cellsize, 0,
+          2*cellsize-2, 0,
+          2*cellsize-2, cellsize-2,
+          cellsize, cellsize-2
+        ]);
+    expectedResults[e[0]] = 1*cellsize + 1;
+
+    f = createEntity(2, 3, 1, 1).collision([
+      0, -cellsize,
+      cellsize-2, -cellsize,
+      cellsize-2, -2,
+      0, -2
+    ]);
+    //TODO remove this once new hitbox updates entry in map
+    f.x++;
+    f.x--;
+    expectedResults[f[0]] = 2*cellsize + 1;
+
+    g = createEntity(3, 2, 1, 1);
+    expectedResults[g[0]] = 3*cellsize + 1;
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+    f.destroy();
+    g.destroy();
+  });
+
+
+  test("Check more complex scenarios", function() {
+    var origin, direction,
+        expectedResults = {},
+        e, f,
+        dX, dY,
+        results;
+
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║ ║E║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║f║f║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║/║f║f║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (256,0)
+    Direction = (1,-1)
+    */
+    origin = {_x: 0, _y: 256};
+    direction = NORTH_EAST;
+
+    expectedResults = {};
+    e = createEntity(3, 0, 1, 1); expectedResults[e[0]] = diagonalDistance(3, 3);
+    f = Crafty.e("2D, Collision").attr({ x: 112, y: 176, w: 32, h: 32 });
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+    f.destroy();
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║ ║ ║ ║ ║E║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║f║f║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║/║ ║f║f║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╠═╬═╬═╬═╬═╣
+        ║ ║ ║ ║ ║ ║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (0,192)
+    Direction = (2,-1)
+    */
+    origin = {_x: 0, _y: 192};
+    direction = new Crafty.math.Vector2D(2, -1).normalize();
+
+    expectedResults = {};
+    e = createEntity(4, 0, 1, 1);
+    // intersection with e at (258, 63)
+    dX = 258 - 0;
+    dY = 63 - 192;
+    expectedResults[e[0]] = Math.sqrt(dX * dX + dY * dY);
+    f = Crafty.e("2D, Collision").attr({ x: 176, y: 112, w: 32, h: 32 });
+
+    results = Crafty.raycast(origin, direction);
+    checkResults(origin, direction, results, expectedResults);
+
+    e.destroy();
+    f.destroy();
+
+    /*
+     ------
+    | Grid |
+     ------
+    (0,0)        (320,0)
+        ╔═╦═╦═╦═╦═╗
+        ║\║F║e║e║e║
+        ╠═╬═╬═╬═╬═╣
+        ║e║e║e║e║e║
+        ╠═╬═╬═╬═╬═╣
+        ║e║e║e║e║e║
+        ╠═╬═╬═╬═╬═╣
+        ║e║e║e║e║e║
+        ╠═╬═╬═╬═╬═╣
+        ║e║e║e║e║e║
+        ╚═╩═╩═╩═╩═╝
+    (0,320)      (320,320)
+
+     -----
+    | Ray |
+     -----
+    Origin = (32,32)
+    Direction = (0.924, 0.3827)
+    */
+    origin = {_x: cellsize / 2, _y: cellsize / 2};
+    direction = ANGLE_NEG_22_5;
+
+    expectedResults = {};
+    e = createEntity(0, 0, 5, 5);
+    f = createEntity(1, 0, 1, 1);
+
+    results = Crafty.raycast(origin, direction, -Infinity);
+
+    strictEqual(results.length, 1, "only first entity found");
+    strictEqual(results[0].obj[0], f[0], "entity f hit with ray");
+    ok(results[0].distance > cellsize/2 + 1, "distance greater than x-difference");
+    ok(results[0].distance < diagonalDistance(0.5, 0.5), "distance less than diagonal distance");
+    strictEqual(results[0].x, f.x, "x intersection point same as f's left side");
+    ok(results[0].y > f.y + 0.5 *f.h, "y intersection point lower than f's center");
+    ok(results[0].y < f.y + 0.75*f.h, "y intersection point higher than 3/4 of f's height");
+
+    e.destroy();
+    f.destroy();
+  });
+
+
+  test("Check a complex scenario constructed in playground", function() {
+    var origin, direction, magnitude,
+        expectedResults = {},
+        results;
+
+
+    Crafty.e('2D, Collision')
+          .setName('Trapezoid')
+          .attr({w: 200, h: 100})
+          .origin('center')
+          .collision(new Crafty.polygon([50, 0, 0, 100, 200, 100, 150, 0]))
+          .attr({x: 53, y: -177, rotation: -175});
+
+    Crafty.e('2D, Collision')
+          .setName('Parallelogram')
+          .attr({w: 100, h: 100})
+          .origin('center')
+          .collision(new Crafty.polygon([0, 0, 25, 100, 100, 100, 75, 0]))
+          .attr({x: -44, y: -206, rotation: 0});
+
+    Crafty.e('2D, Collision')
+          .setName('Triangle')
+          .attr({w: 300, h: 100})
+          .origin('center')
+          .collision(new Crafty.polygon([25, 75, 250, 25, 275, 50]))
+          .attr({x: -96, y: -130, rotation: -107});
+
+    Crafty.e('2D, Collision')
+          .setName('CBR')
+          .attr({w: 100, h: 100})
+          .origin('center')
+          .collision(new Crafty.polygon([75, -25, 125, -25, 125, 25, 75, 25]))
+          .attr({x: -23, y: -204, rotation: 14});
+
+    origin = {_x: 161, _y: 60.98333740234375};
+    direction = new Crafty.math.Vector2D(22 - origin._x, -241.01666259765625 - origin._y);
+    magnitude = direction.magnitude();
+    direction.normalize();
+
+    expectedResults = {};
+    results = Crafty.raycast(origin, direction, magnitude);
+    checkResults(origin, direction, results, expectedResults);
+  });
+
+})();

--- a/tests/2D/spatial-grid.js
+++ b/tests/2D/spatial-grid.js
@@ -1,0 +1,777 @@
+(function() {
+  var module = QUnit.module;
+
+
+  var cellsize = 64;
+
+  var EAST = new Crafty.math.Vector2D(1, 0).normalize();
+  var WEST = new Crafty.math.Vector2D(-1, 0).normalize();
+  var SOUTH = new Crafty.math.Vector2D(0, 1).normalize();
+  var NORTH = new Crafty.math.Vector2D(0, -1).normalize();
+  var SOUTH_EAST = new Crafty.math.Vector2D(1, 1).normalize();
+  var NORTH_EAST = new Crafty.math.Vector2D(1, -1).normalize();
+  var SOUTH_WEST = new Crafty.math.Vector2D(-1, 1).normalize();
+  var NORTH_WEST = new Crafty.math.Vector2D(-1, -1).normalize();
+
+  var ANGLE_POS_41 = new Crafty.math.Vector2D(
+        Math.cos(41 * Math.PI / 180),
+        -Math.sin(41 * Math.PI / 180) // y-axis is inverted in Crafty
+      ).normalize();
+  var ANGLE_NEG_22_5 = new Crafty.math.Vector2D(
+        Math.cos(-22.5 * Math.PI / 180),
+        -Math.sin(-22.5 * Math.PI / 180) // y-axis is inverted in Crafty
+      ).normalize();
+  var ANGLE_POS_112_5 = new Crafty.math.Vector2D(
+        Math.cos(112.5 * Math.PI / 180),
+        -Math.sin(112.5 * Math.PI / 180) // y-axis is inverted in Crafty
+      ).normalize();
+
+
+  //////////////////////
+  // UTILITY FUNCTIONS
+  //////////////////////
+
+  function insertEntry (cellX, cellY, cellWidth, cellHeight) {
+    cellX = cellX || 0;
+    cellY = cellY || 0;
+    cellWidth = cellWidth || 1;
+    cellHeight = cellHeight || 1;
+
+    return Crafty.map.insert({
+      _x: cellX * cellsize + 1,
+      _y: cellY * cellsize + 1,
+      _w: cellWidth * cellsize - 2,
+      _h: cellHeight * cellsize - 2,
+    });
+  }
+
+  function refreshEntry(entry, cellX, cellY, cellWidth, cellHeight) {
+    cellX = cellX || 0;
+    cellY = cellY || 0;
+    cellWidth = cellWidth || 1;
+    cellHeight = cellHeight || 1;
+
+    entry.obj._x = cellX * cellsize + 1;
+    entry.obj._y = cellY * cellsize + 1;
+    entry.obj._w = cellWidth * cellsize - 2;
+    entry.obj._h = cellHeight * cellsize - 2;
+
+    Crafty.map.refresh(entry);
+  }
+
+  function removeEntry (entry) {
+    Crafty.map.remove(entry);
+  }
+
+  function checkHashKeys (entry, cellX, cellY, cellWidth, cellHeight) {
+    var keys = entry.keys;
+    cellX = cellX || 0;
+    cellY = cellY || 0;
+    cellWidth = cellWidth || 1;
+    cellHeight = cellHeight || 1;
+
+    strictEqual(keys.x1 + cellWidth - 1, keys.x2, "entity should occupy cellWidth cells in x-axis");
+    strictEqual(keys.y1 + cellHeight - 1, keys.y2, "entity should occupy cellHeight cells in y-axis");
+    strictEqual(keys.x1, cellX, "cell col start index should match");
+    strictEqual(keys.y1, cellY, "cell row start index should match");
+    strictEqual(keys.x2, cellX + cellWidth - 1, "cell col end index should match");
+    strictEqual(keys.y2, cellY + cellHeight - 1, "cell row end index should match");
+  }
+
+
+  function createEntity (cellX, cellY, cellWidth, cellHeight) {
+    cellX = cellX || 0;
+    cellY = cellY || 0;
+    cellWidth = cellWidth || 1;
+    cellHeight = cellHeight || 1;
+
+    var e = Crafty.e("2D, Collision").attr({
+      x: cellX * cellsize + 1,
+      y: cellY * cellsize + 1,
+      w: cellWidth * cellsize - 2,
+      h: cellHeight * cellsize - 2,
+    });
+
+    return e;
+  }
+
+  //////////////////////
+  // TESTS
+  //////////////////////
+
+  module("Spatial map");
+
+  test("Spatial map - entry properly added, removed & shifted", function() {
+    var found;
+    var objToId = function(obj) {
+      return obj[0];
+    };
+
+    // no entity found in empty map
+    found = Crafty.map.search({
+      _x: -25 * cellsize, _w: 50 * cellsize,
+      _y: -25 * cellsize, _h: 50 * cellsize
+    });
+
+    strictEqual(found.length, 0, "no entities should have been found");
+
+    // entity found in map where created
+    var e = createEntity(-11, -7, 3, 1);
+    found = Crafty.map.search({
+      _x: -10.5 * cellsize, _w: 1,
+      _y: -6.5 * cellsize, _h: 1
+    }).map(objToId);
+
+    strictEqual(found.length, 1, "1 entity should have been found");
+    ok(found.indexOf(e[0]) >= 0, "entity e found");
+
+    // entity found in map after moving
+    e.x = 11 * cellsize;
+    e.y = 7 * cellsize;
+    found = Crafty.map.search({
+      _x: 11.5 * cellsize, _w: 1,
+      _y: 7.5 * cellsize, _h: 1
+    }).map(objToId);
+
+    strictEqual(found.length, 1, "1 entity should have been found");
+    ok(found.indexOf(e[0]) >= 0, "entity e found");
+
+    // both entities found in map
+    var f = createEntity(3, -5, 1, 1);
+    found = Crafty.map.search({
+      _x: -25 * cellsize, _w: 50 * cellsize,
+      _y: -25 * cellsize, _h: 50 * cellsize
+    }).map(objToId);
+
+    strictEqual(found.length, 2, "2 entities should have been found");
+    ok(found.indexOf(e[0]) >= 0, "entity e found");
+    ok(found.indexOf(f[0]) >= 0, "entity f found");
+
+    // no entities found in map after destroyed
+    e.destroy();
+    f.destroy();
+    found = Crafty.map.search({
+      _x: -25 * cellsize, _w: 50 * cellsize,
+      _y: -25 * cellsize, _h: 50 * cellsize
+    });
+
+    strictEqual(found.length, 0, "no entities should have been found");
+  });
+
+  test("Spatial map integration test - search bounding rectangles", function() {
+    var found,
+        tx, ty;
+
+    // is rectB within rectA?
+    var contains = function(rectA, rectB) {
+      return rectB._x >= rectA._x && rectB._x + rectB._w <= rectA._x + rectA._w &&
+              rectB._y >= rectA._y && rectB._y + rectB._h <= rectA._y + rectA._h;
+    };
+    var objToId = function(obj) {
+      return obj[0];
+    };
+
+
+    // default entity - rectangle
+    var e = createEntity(0, 0, 1, 1);
+    strictEqual(e._mbr, null, "mbr doesn't exist");
+    strictEqual(e._cbr, null, "cbr doesn't exist");
+
+
+    // test point inside hitbox & inside bounds
+    tx = 0.5 * cellsize;
+    ty = 0.5 * cellsize;
+    strictEqual(e.isAt(tx, ty), true, "test point inside hitbox");
+    strictEqual(e.contains(tx, ty, 0, 0), true, "test point inside bounds");
+
+    // search at test point finds entity
+    found = Crafty.map.search({
+      _x: tx, _w: 1,
+      _y: ty, _h: 1
+    }).map(objToId);
+    strictEqual(found.length, 1, "1 entity should have been found");
+    ok(found.indexOf(e[0]) >= 0, "entity e found");
+
+    // test point outside hitbox & outside bounds
+    tx = -0.5 * cellsize;
+    ty = -0.5 * cellsize;
+    strictEqual(e.isAt(tx, ty), false, "test point outside hitbox");
+    strictEqual(e.contains(tx, ty, 0, 0), false, "test point outside bounds");
+
+    // search at test point does not find entity
+    found = Crafty.map.search({
+      _x: tx, _w: 1,
+      _y: ty, _h: 1
+    }).map(objToId);
+    strictEqual(found.length, 0, "no entity should have been found");
+
+
+    // entity rotated - MBR
+    e.origin('center');
+    e.rotation = 45;
+    ok(!!e._mbr, "mbr exists");
+    strictEqual(e._cbr, null, "cbr doesn't exist");
+
+
+    // test point outside hitbox & inside bounds (top-left corner of MBR)
+    tx = e._x + e._w/2 - e._w/2 * Math.sqrt(2);
+    ty = e._y + e._h/2 - e._h/2 * Math.sqrt(2);
+    strictEqual(e.isAt(tx, ty), false, "test point outside hitbox");
+    strictEqual(e.contains(tx, ty, 0, 0), true, "test point inside bounds");
+
+    // search at test point finds entity
+    found = Crafty.map.search({
+      _x: tx, _w: 1,
+      _y: ty, _h: 1
+    }).map(objToId);
+    strictEqual(found.length, 1, "1 entity should have been found");
+    ok(found.indexOf(e[0]) >= 0, "entity e found");
+
+    // test point outside hitbox & outside bounds (a bit beyond top-left corner of MBR)
+    tx -= 2;
+    ty -= 2;
+    strictEqual(e.isAt(tx, ty), false, "test point outside hitbox");
+    strictEqual(e.contains(tx, ty, 0, 0), false, "test point outside bounds");
+
+    // search at test point does not find entity
+    found = Crafty.map.search({
+      _x: tx, _w: 1,
+      _y: ty, _h: 1
+    }).map(objToId);
+    strictEqual(found.length, 0, "no entity should have been found");
+
+
+    // entity with hitbox inside its bounds - MBR
+    e.rotation = 90;
+    e.collision([ // collision hitbox relative to 90° clockwise rotated entity
+      0, 0,
+      cellsize/2, 0,
+      cellsize/2, cellsize/2,
+      0, cellsize/2
+    ]);
+    ok(!!e._mbr, "mbr exists");
+    strictEqual(e._cbr, null, "cbr doesn't exist");
+
+
+    // test point inside hitbox & inside bounds
+    tx = 3*cellsize/4;
+    ty = cellsize/4;
+    strictEqual(e.isAt(tx, ty), true, "test point inside hitbox");
+    strictEqual(e.contains(tx, ty, 0, 0), true, "test point inside bounds");
+
+    // search at test point finds entity
+    found = Crafty.map.search({
+      _x: tx, _w: 1,
+      _y: ty, _h: 1
+    }).map(objToId);
+    strictEqual(found.length, 1, "1 entity should have been found");
+    ok(found.indexOf(e[0]) >= 0, "entity e found");
+
+    // test point outside hitbox & inside bounds
+    tx = cellsize/4;
+    ty = cellsize/4;
+    strictEqual(e.isAt(tx, ty), false, "test point outside hitbox");
+    strictEqual(e.contains(tx, ty, 0, 0), true, "test point inside bounds");
+
+    // search at test point finds entity
+    found = Crafty.map.search({
+      _x: tx, _w: 1,
+      _y: ty, _h: 1
+    }).map(objToId);
+    strictEqual(found.length, 1, "1 entity should have been found");
+    ok(found.indexOf(e[0]) >= 0, "entity e found");
+
+    // test point outside hitbox & outside bounds
+    tx = e.x + e.w + 1;
+    ty = e.y + e.h + 1;
+    strictEqual(e.isAt(tx, ty), false, "test point outside hitbox");
+    strictEqual(e.contains(tx, ty, 0, 0), false, "test point outside bounds");
+
+    // search at test point does not find entity
+    found = Crafty.map.search({
+      _x: tx, _w: 1,
+      _y: ty, _h: 1
+    }).map(objToId);
+    strictEqual(found.length, 0, "no entity should have been found");
+
+
+    // entity with hitbox outside its bounds - CBR
+    e.collision([ // collision hitbox relative to 90° clockwise rotated entity
+      -10.5*cellsize, 10.5*cellsize,
+      -10.5*cellsize, 5.5*cellsize,
+      -5.5*cellsize, 5.5*cellsize,
+      -5.5*cellsize, 10.5*cellsize
+    ]);
+    ok(!!e._mbr, "mbr exists");
+    ok(!!e._cbr, "cbr exists");
+    // TODO remove this after cbr update fixed
+    e.x++;
+    e.x--;
+
+
+    // test point inside hitbox & inside bounds
+    tx = -7.5*cellsize;
+    ty = -7.5*cellsize;
+    strictEqual(e.isAt(tx, ty), true, "test point inside hitbox");
+    strictEqual(e.contains(tx, ty, 0, 0), false, "test point outside MBR");
+    strictEqual(contains(e._cbr, {_x: tx, _y: ty, _w: 0, _h: 0}), true, "test point inside CBR");
+
+    // search at test point finds entity
+    found = Crafty.map.search({
+      _x: tx, _w: 1,
+      _y: ty, _h: 1
+    }).map(objToId);
+    strictEqual(found.length, 1, "1 entity should have been found");
+    ok(found.indexOf(e[0]) >= 0, "entity e found");
+
+    // test point outside hitbox & inside bounds
+    tx = cellsize/2;
+    ty = cellsize/2;
+    strictEqual(e.isAt(tx, ty), false, "test point outside hitbox");
+    strictEqual(e.contains(tx, ty, 0, 0), true, "test point inside MBR");
+    strictEqual(contains(e._cbr, {_x: tx, _y: ty, _w: 0, _h: 0}), true, "test point inside CBR");
+
+    // search at test point finds entity
+    found = Crafty.map.search({
+      _x: tx, _w: 1,
+      _y: ty, _h: 1
+    }).map(objToId);
+    strictEqual(found.length, 1, "1 entity should have been found");
+    ok(found.indexOf(e[0]) >= 0, "entity e found");
+
+    // test point outside hitbox & outside bounds
+    tx = e.x + e.w + 1;
+    ty = e.y + e.h + 1;
+    strictEqual(e.isAt(tx, ty), false, "test point outside hitbox");
+    strictEqual(e.contains(tx, ty, 0, 0), false, "test point outside MBR");
+    strictEqual(contains(e._cbr, {_x: tx, _y: ty, _w: 0, _h: 0}), false, "test point outside CBR");
+
+    // search at test point does not find entity
+    found = Crafty.map.search({
+      _x: tx, _w: 1,
+      _y: ty, _h: 1
+    }).map(objToId);
+    strictEqual(found.length, 0, "no entity should have been found");
+
+
+    e.destroy();
+  });
+
+  test("Spatial map integration test - iterate bounding rectangles", function() {
+    var found,
+        keysT, keysB, keysH,
+        tx, ty;
+
+    // are keysB within keysA?
+    var containsKeys = function(keysA, keysB) {
+      return keysB.x1 >= keysA.x1 && keysB.x2 <= keysA.x2 &&
+              keysB.y1 >= keysA.y1 && keysB.y2 <= keysA.y2;
+    };
+    var hashKeys = function(x, y, w, h) {
+      if (x instanceof Crafty.polygon) {
+        // assuming points start at top-left corner
+        // [0, 0, this._w, 0, this._w, this._h, 0, this._h]
+        h = x.points[5] - x.points[1];
+        w = x.points[4] - x.points[0];
+        y = x.points[1];
+        x = x.points[0];
+      } else if (typeof x === 'object') {
+        h = x._h;
+        w = x._w;
+        y = x._y;
+        x = x._x;
+      }
+
+      var keys = {};
+      keys.x1 = Math.floor(x / cellsize);
+      keys.y1 = Math.floor(y / cellsize);
+      keys.x2 = Math.floor((w + x) / cellsize);
+      keys.y2 = Math.floor((h + y) / cellsize);
+
+      return keys;
+    };
+
+    var addObj = function(obj) {
+      found[obj[0]] = true;
+    };
+
+
+    // default entity - rectangle
+    var e = createEntity(0, 0, 10, 10);
+    strictEqual(e._mbr, null, "mbr doesn't exist");
+    strictEqual(e._cbr, null, "cbr doesn't exist");
+
+
+    // test point cell inside hitbox cell & inside bounds cell
+    tx = 0.5 * cellsize;
+    ty = 0.5 * cellsize;
+    keysT = hashKeys(tx, ty, 0, 0);
+    keysH = hashKeys(e.map);
+    keysB = hashKeys(e._cbr || e._mbr || e);
+    strictEqual(containsKeys(keysH, keysT), true, "test point cell inside hitbox cell");
+    strictEqual(containsKeys(keysB, keysT), true, "test point cell inside bounds cell");
+
+    // iteration at test point finds entity
+    found = {};
+    Crafty.map.traverseRay({_x: tx, _y: ty}, NORTH_EAST, addObj);
+    strictEqual(Object.keys(found).length, 1, "1 entity should have been found");
+    strictEqual(found[e[0]], true, "entity e found");
+
+    // test point cell outside hitbox cell & outside bounds cell
+    tx = -0.5 * cellsize;
+    ty = -0.5 * cellsize;
+    keysT = hashKeys(tx, ty, 0, 0);
+    keysH = hashKeys(e.map);
+    keysB = hashKeys(e._cbr || e._mbr || e);
+    strictEqual(containsKeys(keysH, keysT), false, "test point cell outside hitbox cell");
+    strictEqual(containsKeys(keysB, keysT), false, "test point cell outside bounds cell");
+
+    // iteration at test point does not find entity
+    found = {};
+    Crafty.map.traverseRay({_x: tx, _y: ty}, NORTH_EAST, addObj);
+    strictEqual(Object.keys(found).length, 0, "no entity should have been found");
+
+
+    // entity rotated - MBR
+    e.origin('center');
+    e.rotation = 45;
+    ok(!!e._mbr, "mbr exists");
+    strictEqual(e._cbr, null, "cbr doesn't exist");
+
+
+    // test point cell outside hitbox cell & inside bounds cell (top-left corner of MBR)
+    tx = e._x + e._w/2 - e._w/2 * Math.sqrt(2);
+    ty = e._y + e._h/2 - e._h/2 * Math.sqrt(2);
+    keysT = hashKeys(tx, ty, 0, 0);
+    keysH = hashKeys(e.map);
+    keysB = hashKeys(e._cbr || e._mbr || e);
+    strictEqual(containsKeys(keysH, keysT), false, "test point cell outside hitbox cell");
+    strictEqual(containsKeys(keysB, keysT), true, "test point cell inside bounds cell");
+
+    // iteration at test point finds entity
+    found = {};
+    Crafty.map.traverseRay({_x: tx, _y: ty}, SOUTH_WEST, addObj);
+    strictEqual(Object.keys(found).length, 1, "1 entity should have been found");
+    strictEqual(found[e[0]], true, "entity e found");
+
+    // test point cell outside hitbox cell & outside bounds cell (a bit beyond top-left corner of MBR)
+    tx = (Math.floor(tx / cellsize) - 0.5) * cellsize;
+    ty = (Math.floor(ty / cellsize) - 0.5) * cellsize;
+    keysT = hashKeys(tx, ty, 0, 0);
+    keysH = hashKeys(e.map);
+    keysB = hashKeys(e._cbr || e._mbr || e);
+    strictEqual(containsKeys(keysH, keysT), false, "test point cell outside hitbox cell");
+    strictEqual(containsKeys(keysB, keysT), false, "test point cell inside bounds cell");
+
+    // iteration at test point does not find entity
+    found = {};
+    Crafty.map.traverseRay({_x: tx, _y: ty}, NORTH_WEST, addObj);
+    strictEqual(Object.keys(found).length, 0, "no entity should have been found");
+
+
+    // entity with hitbox inside its bounds - MBR
+    e.rotation = 0;
+    e.collision([
+      0, 0,
+      cellsize/2, 0,
+      cellsize/2, cellsize/2,
+      0, cellsize/2
+    ]);
+    ok(!!e._mbr, "mbr exists");
+    strictEqual(e._cbr, null, "cbr doesn't exist");
+
+
+    // test point cell inside hitbox cell & inside bounds cell
+    tx = 3*cellsize/4;
+    ty = cellsize/4;
+    keysT = hashKeys(tx, ty, 0, 0);
+    keysH = hashKeys(e.map);
+    keysB = hashKeys(e._cbr || e._mbr || e);
+    strictEqual(containsKeys(keysH, keysT), true, "test point cell inside hitbox cell");
+    strictEqual(containsKeys(keysB, keysT), true, "test point cell inside bounds cell");
+
+    // iteration at test point finds entity
+    found = {};
+    Crafty.map.traverseRay({_x: tx, _y: ty}, SOUTH_EAST, addObj);
+    strictEqual(Object.keys(found).length, 1, "1 entity should have been found");
+    strictEqual(found[e[0]], true, "entity e found");
+
+    // test point cell outside hitbox cell & inside bounds cell
+    tx = 9.5*cellsize;
+    ty = 9.5*cellsize;
+    keysT = hashKeys(tx, ty, 0, 0);
+    keysH = hashKeys(e.map);
+    keysB = hashKeys(e._cbr || e._mbr || e);
+    strictEqual(containsKeys(keysH, keysT), false, "test point cell outside hitbox cell");
+    strictEqual(containsKeys(keysB, keysT), true, "test point cell inside bounds cell");
+
+    // iteration at test point finds entity
+    found = {};
+    Crafty.map.traverseRay({_x: tx, _y: ty}, WEST, addObj);
+    strictEqual(Object.keys(found).length, 1, "1 entity should have been found");
+    strictEqual(found[e[0]], true, "entity e found");
+
+    // test point cell outside hitbox cell & outside bounds cell
+    tx = (Math.floor((e.x + e.w) / cellsize) + 1.5) * cellsize;
+    ty = (Math.floor((e.y + e.h) / cellsize) + 1.5) * cellsize;
+    keysT = hashKeys(tx, ty, 0, 0);
+    keysH = hashKeys(e.map);
+    keysB = hashKeys(e._cbr || e._mbr || e);
+    strictEqual(containsKeys(keysH, keysT), false, "test point cell outside hitbox cell");
+    strictEqual(containsKeys(keysB, keysT), false, "test point cell inside bounds cell");
+
+    // iteration at test point does not find entity
+    found = {};
+    Crafty.map.traverseRay({_x: tx, _y: ty}, NORTH_EAST, addObj);
+    strictEqual(Object.keys(found).length, 0, "no entity should have been found");
+
+
+    // entity with hitbox outside its bounds - CBR
+    e.collision([
+      -10.5*cellsize, -10.5*cellsize,
+      -5.5*cellsize, -10.5*cellsize,
+      -5.5*cellsize, -5.5*cellsize,
+      -10.5*cellsize, -5.5*cellsize
+    ]);
+    ok(!!e._mbr, "mbr exists");
+    ok(!!e._cbr, "cbr exists");
+    // TODO remove this after cbr update fixed
+    e.x++;
+    e.x--;
+
+
+    // test point cell inside hitbox cell & inside bounds cell
+    tx = -7.5*cellsize;
+    ty = -7.5*cellsize;
+    keysT = hashKeys(tx, ty, 0, 0);
+    keysH = hashKeys(e.map);
+    keysB = hashKeys(e._cbr || e._mbr || e);
+    strictEqual(containsKeys(keysH, keysT), true, "test point cell inside hitbox cell");
+    strictEqual(containsKeys(keysB, keysT), true, "test point cell inside bounds cell");
+
+    // iteration at test point finds entity
+    found = {};
+    Crafty.map.traverseRay({_x: tx, _y: ty}, EAST, addObj);
+    strictEqual(Object.keys(found).length, 1, "1 entity should have been found");
+    strictEqual(found[e[0]], true, "entity e found");
+
+    // test point cell outside hitbox cell & inside bounds cell
+    tx = cellsize/2;
+    ty = cellsize/2;
+    keysT = hashKeys(tx, ty, 0, 0);
+    keysH = hashKeys(e.map);
+    keysB = hashKeys(e._cbr || e._mbr || e);
+    strictEqual(containsKeys(keysH, keysT), false, "test point cell outside hitbox cell");
+    strictEqual(containsKeys(keysB, keysT), true, "test point cell inside bounds cell");
+
+    // iteration at test point finds entity
+    found = {};
+    Crafty.map.traverseRay({_x: tx, _y: ty}, NORTH, addObj);
+    strictEqual(Object.keys(found).length, 1, "1 entity should have been found");
+    strictEqual(found[e[0]], true, "entity e found");
+
+    // test point cell outside hitbox cell & outside bounds cell
+    tx = (Math.floor((e.x + e.w) / cellsize) + 1.5) * cellsize;
+    ty = (Math.floor((e.y + e.h) / cellsize) + 1.5) * cellsize;
+    keysT = hashKeys(tx, ty, 0, 0);
+    keysH = hashKeys(e.map);
+    keysB = hashKeys(e._cbr || e._mbr || e);
+    strictEqual(containsKeys(keysH, keysT), false, "test point cell outside hitbox cell");
+    strictEqual(containsKeys(keysB, keysT), false, "test point cell inside bounds cell");
+
+    // iteration at test point does not find entity
+    found = {};
+    Crafty.map.traverseRay({_x: tx, _y: ty}, SOUTH, addObj);
+    strictEqual(Object.keys(found).length, 0, "no entity should have been found");
+
+
+    e.destroy();
+  });
+
+  test("Spatial map - boundaries", function() {
+    var bounds;
+
+    // infinite bounds w/o entities
+    bounds = Crafty.map.boundaries();
+    strictEqual(bounds.min.x, Infinity, "infinite min bound");
+    strictEqual(bounds.min.y, Infinity, "infinite min bound");
+    strictEqual(bounds.max.x, -Infinity, "-infinite max bound");
+    strictEqual(bounds.max.y, -Infinity, "-infinite max bound");
+
+    // bounds = bottom left entity
+    var e = createEntity(-5, 3, 1, 1);
+    bounds = Crafty.map.boundaries();
+    strictEqual(bounds.min.x, e._x, "min bound matches entity's top left corner");
+    strictEqual(bounds.min.y, e._y, "min bound matches entity's top left corner");
+    strictEqual(bounds.max.x, e._x + e._w, "min bound matches entity's bottom right corner");
+    strictEqual(bounds.max.y, e._y + e._h, "min bound matches entity's bottom right corner");
+
+    // bounds = bottom left entity + top right entity
+    var f = createEntity(3, -5, 1, 1);
+    bounds = Crafty.map.boundaries();
+    strictEqual(bounds.min.x, e._x, "min x matches e's left side");
+    strictEqual(bounds.min.y, f._y, "min y matches f's top side");
+    strictEqual(bounds.max.x, f._x + f._w, "max x matches f's right side");
+    strictEqual(bounds.max.y, e._y + e._h, "max y matches e's bottom side");
+
+    // bounds = bottom left entity + middle entity + top right entity
+    var g = createEntity(0, 0, 1, 1);
+    bounds = Crafty.map.boundaries();
+    strictEqual(bounds.min.x, e._x, "min x matches e's left side");
+    strictEqual(bounds.min.y, f._y, "min y matches f's top side");
+    strictEqual(bounds.max.x, f._x + f._w, "max x matches f's right side");
+    strictEqual(bounds.max.y, e._y + e._h, "max y matches e's bottom side");
+
+    // bounds = middle entity
+    e.destroy();
+    f.destroy();
+    bounds = Crafty.map.boundaries();
+    strictEqual(bounds.min.x, g._x, "min bound matches entity's top left corner");
+    strictEqual(bounds.min.y, g._y, "min bound matches entity's top left corner");
+    strictEqual(bounds.max.x, g._x + g._w, "min bound matches entity's bottom right corner");
+    strictEqual(bounds.max.y, g._y + g._h, "min bound matches entity's bottom right corner");
+
+    // infinite bounds w/o entities
+    g.destroy();
+    bounds = Crafty.map.boundaries();
+    strictEqual(bounds.min.x, Infinity, "infinite min bound");
+    strictEqual(bounds.min.y, Infinity, "infinite min bound");
+    strictEqual(bounds.max.x, -Infinity, "-infinite max bound");
+    strictEqual(bounds.max.y, -Infinity, "-infinite max bound");
+  });
+
+  test("Spatial map - entry to cell hash", function() {
+    var e = insertEntry(0, 0, 1, 1);
+    checkHashKeys(e, 0, 0, 1, 1);
+
+    // modifying dimension
+    refreshEntry(e, 0, 0, 2, 1);
+    checkHashKeys(e, 0, 0, 2, 1);
+
+    // moving
+    refreshEntry(e, 0, 1, 2, 1);
+    checkHashKeys(e, 0, 1, 2, 1);
+
+    var f = insertEntry(-13, 7, 11, 17);
+    checkHashKeys(f, -13, 7, 11, 17);
+
+    // moving & modifying dimension
+    refreshEntry(f, 3, 1, 23, 9);
+    checkHashKeys(f, 3, 1, 23, 9);
+
+    removeEntry(e);
+    removeEntry(f);
+  });
+
+  test("Spatial map - iteration - finds all entities in order", function() {
+    /*  (0,0)     (3,0)
+           ╔═╦═╦═╦═╗
+      e -> ║ ║ ║ ║3║
+           ╠═╬═╬═╬═╣
+           ║ ║ ║3║2║
+           ╠═╬═╬═╬═╣
+           ║ ║2║3║ ║
+      g ^> ╠═╬═╬═╬═╣
+           ║1║1║ ║ ║
+           ╚═╩═╩═╩═╝
+        h ^>    ^ (3,3)
+                f
+    */
+    var e = createEntity(1, 0, 3, 1);
+    var f = createEntity(2, 1, 1, 2);
+    var g = createEntity(1, 0, 3, 3);
+    var h = createEntity(0, 0, 4, 4);
+    var cellEntities = [
+      [h[0]],             // (0,3)
+      [h[0]],             // (1,3)
+      [h[0], g[0]],       // (1,2)
+      [h[0], g[0], f[0]], // (2,2)
+      [h[0], g[0], f[0]], // (2,1)
+      [h[0], g[0]],       // (3,1)
+      [h[0], g[0], e[0]]  // (3,0)
+    ];
+
+    var oldCellDistance = -Infinity,
+        cellNo = 0;
+
+    Crafty.map.traverseRay({_x: 0 + 1, _y: 4 * cellsize - 1}, ANGLE_POS_41, function(obj, previousCellDistance) {
+      if (previousCellDistance !== oldCellDistance) {
+        cellNo++;
+        oldCellDistance = previousCellDistance;
+      }
+
+      var idx = cellEntities[cellNo].indexOf(obj[0]);
+      ok(idx >= 0, "expected entity inside cell found");
+      cellEntities[cellNo].splice(idx, 1);
+    });
+
+    for (var i = 0; i < cellEntities.length; ++i) {
+      strictEqual(cellEntities[i].length, 0, "all entities inside cell have been found");
+    }
+
+    e.destroy();
+    f.destroy();
+    g.destroy();
+    h.destroy();
+  });
+
+  test("Spatial map - iteration - can be cancelled", function() {
+    var e = createEntity(-4, -2, 10, 5); // entity that spans multiple cells
+    var origin = {_x: -4.25*cellsize, _y: -2.25*cellsize - 10};
+    var direction = ANGLE_NEG_22_5;
+
+    var objFound = false,
+        objCount = 0,
+        cellCount = 0;
+
+    var oldCellDistance = -Infinity;
+    Crafty.map.traverseRay(origin, direction, function(obj, previousCellDistance) {
+      if (previousCellDistance !== oldCellDistance) {
+        cellCount++;
+        oldCellDistance = previousCellDistance;
+      }
+      objCount++;
+
+      if (cellCount === 1 && objCount === 1) {
+        objFound = true;
+        return true; // cancel iteration
+      }
+    });
+
+    strictEqual(objFound, true, "object has been iterated over");
+    strictEqual(cellCount, 1, "iteration ended in next-from-origin cell");
+    strictEqual(objCount, 1, "iteration ended after 1st object");
+
+    e.destroy();
+  });
+
+  test("Spatial map - iteration - previousDistance is monotonically non-decreasing per cell", function() {
+    var e = insertEntry(-10, -10, 20, 20);
+    var oldCellDistance, iteratedOnce;
+
+    oldCellDistance = -Infinity;
+    iteratedOnce = false;
+    Crafty.map.traverseRay({_x: 10*cellsize, _y: 10*cellsize}, NORTH_WEST, function(obj, previousCellDistance) {
+      ok(previousCellDistance >= oldCellDistance,
+        "distance is monotonically non-decreasing while advancing cells diagonally");
+      iteratedOnce = true;
+      oldCellDistance = previousCellDistance;
+    });
+    strictEqual(iteratedOnce, true, "iteration iterated over at least one object");
+
+    oldCellDistance = -Infinity;
+    iteratedOnce = false;
+    Crafty.map.traverseRay({_x: -3.5*cellsize, _y: -1.1*cellsize}, ANGLE_POS_112_5, function(obj, previousCellDistance) {
+      if (previousCellDistance !== -Infinity) {
+        ok(previousCellDistance > oldCellDistance,
+          "distance is strictly monotonically increasing while advancing cells non-diagonally");
+        iteratedOnce = true;
+      }
+      oldCellDistance = previousCellDistance;
+    });
+    strictEqual(iteratedOnce, true, "iteration iterated over at least one object");
+
+    removeEntry(e);
+  });
+
+})();

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -759,6 +759,121 @@
 
   });
 
+  var EAST = new Crafty.math.Vector2D(1, 0).normalize();
+  var SOUTH_EAST = new Crafty.math.Vector2D(1, 1).normalize();
+  var NORTH_EAST = new Crafty.math.Vector2D(1, -1).normalize();
+  var NORTH_WEST = new Crafty.math.Vector2D(-1, -1).normalize();
+
+  test("Polygon intersection", function() {
+    var poly, distance,
+        origin, direction;
+
+    poly = new Crafty.polygon([0,0, 50,0, 50,50, 0,50]);
+
+    // intersection with ray slightly outside entity edge
+    origin = {_x: -1, _y: 25};
+    direction = EAST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance, 1, "ray intersects polygon on its left edge");
+
+    // intersection with ray origin at entity edge
+    origin = {_x: 0, _y: 0};
+    direction = EAST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance, 0, "ray intersects polygon on its left edge");
+
+    // intersection with ray origin inside entity
+    origin = {_x: 25, _y: 25};
+    direction = EAST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance, 25, "ray intersects polygon on its right edge");
+
+    // intersection with ray origin at entity edge
+    origin = {_x: 50, _y: 25};
+    direction = EAST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance, 0, "ray intersects polygon on its right edge");
+
+    // no intersection with ray going away
+    origin = {_x: 51, _y: 25};
+    direction = EAST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance, Infinity, "ray does not intersect polygon");
+
+
+    poly = new Crafty.polygon([-75,-75, -150,-150]);
+
+    // intersection with ray at crossing
+    origin = {_x: -150, _y: -75};
+    direction = NORTH_EAST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance.toFixed(4), (37.5 * Math.sqrt(2)).toFixed(4),
+      "ray intersects polygon at the crossing");
+
+    // no intersection with parallel ray
+    origin = {_x: -76, _y: -75};
+    direction = NORTH_WEST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance, Infinity, "ray does not intersect polygon");
+
+    // intersection with colinear ray starting before polygon
+    origin = {_x: -25, _y: -25};
+    direction = NORTH_WEST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance.toFixed(4), (50 * Math.sqrt(2)).toFixed(4),
+      "ray intersects polygon at polygon's start point");
+
+    // intersection with colinear ray starting at polygon start
+    origin = {_x: -75, _y: -75};
+    direction = NORTH_WEST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance, 0, "ray intersects polygon at polygon's start point");
+
+    // intersection with colinear ray starting inside polygon
+    origin = {_x: -100, _y: -100};
+    direction = NORTH_WEST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance.toFixed(4), (50 * Math.sqrt(2)).toFixed(4),
+      "ray intersects polygon at ray's origin");
+
+    // intersection with colinear ray starting at polygon end
+    origin = {_x: -150, _y: -150};
+    direction = NORTH_WEST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance, 0, "ray intersects polygon at polygon's end point");
+
+    // no intersection with colinear ray starting outside polygon
+    origin = {_x: -151, _y: -151};
+    direction = NORTH_WEST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance, Infinity, "ray does not intersect polygon");
+
+    // intersection with colinear ray starting at polygon end, going opposite direction
+    origin = {_x: -150, _y: -150};
+    direction = SOUTH_EAST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance, 0, "ray intersects polygon at polygon's end point");
+
+    // intersection with colinear ray starting inside polygon, going opposite direction
+    origin = {_x: -100, _y: -100};
+    direction = SOUTH_EAST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance.toFixed(4), (25 * Math.sqrt(2)).toFixed(4),
+      "ray intersects polygon at ray's origin");
+
+    // intersection with colinear ray starting at polygon start, going opposite direction
+    origin = {_x: -75, _y: -75};
+    direction = SOUTH_EAST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance, 0, "ray intersects polygon at polygon's start point");
+
+    // no intersection with colinear ray going opposite direction
+    origin = {_x: -74, _y: -74};
+    direction = SOUTH_EAST;
+    distance = poly.intersectRay(origin, direction);
+    strictEqual(distance, Infinity, "ray does not intersect polygon");
+  });
+
 
   module("Motion");
 

--- a/tests/index-headless.js
+++ b/tests/index-headless.js
@@ -19,3 +19,5 @@ require('./time.js');
 require('./tween.js');
 require('./2D/collision/collision.js');
 require('./2D/collision/sat.js');
+require('./2D/spatial-grid.js');
+require('./2D/raycast.js');

--- a/tests/index.html
+++ b/tests/index.html
@@ -70,5 +70,8 @@
     <script type="text/javascript" src="./animation/sprite-animation.js"></script>
     <script type="text/javascript" src="./2D/collision/collision.js"></script>
     <script type="text/javascript" src="./2D/collision/sat.js"></script>
+    <script type="text/javascript" src="./2D/spatial-grid.js"></script>
+    <script type="text/javascript" src="./2D/raycast.js"></script>
+
   </body>
 </html>


### PR DESCRIPTION
**Development finished. Pending review.**
Fixes outstanding issue #729 .

Screenshot taken from playground example:
![raycast](https://cloud.githubusercontent.com/assets/3935691/13716868/fba5edd2-e7dd-11e5-9dfa-f25b6242da8c.png)

There is still lots to do, but I would appreciate a little input on the API design:
- ~~`Crafty.map.boundaries(findKeys)` was extended to find only hashmap cell keys if optional parameter is provided. Should this stay here (introduces some branching in code) or make an explicit method `Crafty.map.keyBoundaries()` (code duplication)?~~ Added a separate, private method `Crafty.map._keyBoundaries()`.
- `Crafty.map.iterateMap(origin, direction, entryCallback)` iterates the hashmap in the direction of the ray. Calls `entryCallback` for each hashmap entry (obj). If `entryCallback` returns `true`, aborts iteration immediately.
- ~~`Collision.approximateDistanceFromRay(origin, direction)` returns the distance to nearest corner of the entity's bounding rectangle (if there is an intersection).~~ Removed from implementation
- `Crafty.polygon.distanceFromRay(origin, direction)` returns the distance to the closest intersection with any of the polygon's segements (if there is at least one intersection).
- `Crafty.raycast(origin, direction, maxDistance, comp, sort)` uses the above described methods to find an intersection. Returns an array of raycast results, each raycast result looks like `{obj: obj, distance: distance, x: intersection_point_x, y: intersection_point_y}`.
  - If `maxDistance` is Infinity, finds all intersections (this is the default case). If its negative, finds only first intersection. If its a positive value, finds intersection up to that distance.
  - If `comp` string parameter is supplied, returns only entities that have the specified component
  - If `sort` boolean parameter is supplied and is set to `false`, then the results are **not** sorted by distance (opt-out, slight performance gain)
  - ~~`checkBroadphase` dictates whether an approximate broadphase intersection check (`approximateDistanceFromRay`) should be used to filter objects, before checking for exact intersection (with `distanceFromRay`)~~ removed from implementation
- `origin` & `direction` describe the ray. `direction` **must** be normalized. Should this be mentioned in the docs, or should input sanitation (and thus this normalization) be done?
- ~~`Crafty.raycast` returns an array of raycast results. Duplicates are weeded out, but the array is not sorted by distance. Should there be an additional parameter `sort` (similar to the `filter` parameter in [`Crafty.map.search`](http://craftyjs.com/api/Crafty-map.html#Crafty-map-search)) that optionally sorts the results (and has performance impact)?~~ Added

Notes:
- ~~I still have to test whether the approximate broadphase intersection check is worth it, and how many segments a polygon must have (increases complexity of the exact intersection check) to be worth it.~~ Removed from implementation
- ~~Collision (and raycast) logic needs the collision bounding rectangle (`this._cbr || this._mbr || this`). Rendering stuff needs the minimum bounding rectangle (`this._mbr || this`).  
  The considered bounding rectangle is hardcoded in the hashmap's functions (currently the collision one is used). This can possibly lead to (and possibly has already lead to; haven't fully tested) problems with drawing dirty regions on Canvas, when there exists a collision hitbox outside of the entity's natural bounds (`_cbr != null`).  
  Having [separate hashmaps](https://github.com/craftyjs/Crafty/pull/1017#discussion_r55499253) for collision stuff and for each layer would help in configuring each hashmap so that the correct property gets accessed for the bounding rectangle. A more immediate fix would be to provide an optional argument to each of the hashmaps methods, which dictates which bounding rectangle property to use.~~ Nope, render code just uses plain rectangles for searching the spatial map, so it doesn't matter.
