### PR TITLE
Introduce UpdateFrame event

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Crafty.e("2D, DOM, Color, Collision")
     .attr({ x: 300, y: 150, w: 10, h: 10,
             dX: Crafty.math.randomInt(2, 5),
             dY: Crafty.math.randomInt(2, 5) })
-    .bind('EnterFrame', function () {
+    .bind('UpdateFrame', function () {
         //hit floor or roof
         if (this.y <= 0 || this.y >= 290)
             this.dY *= -1;

--- a/playgrounds/parallax.html
+++ b/playgrounds/parallax.html
@@ -80,7 +80,7 @@
         .textColor("white")
         .textFont({size: '20px', family:'Arial'})
         .attr({x: 10, y: 130, w: 200})
-        .bind("EnterFrame", function(){
+        .bind("UpdateFrame", function(){
             this.text("Distance: " + Math.floor(Math.abs(Crafty.viewport.x)));
         });
 

--- a/src/controls/controls-system.js
+++ b/src/controls/controls-system.js
@@ -92,7 +92,7 @@ Crafty.s("Controls", {
     },
 
     events: {
-        "EnterFrameInput": function () {
+        "EnterFrame": function () {
             this.runEvents();
         },
         "KeyDown": function () {

--- a/src/controls/controls.js
+++ b/src/controls/controls.js
@@ -305,7 +305,7 @@ Crafty.c("Multiway", {
     },
 
     events: {
-        "EnterFrame": function() {
+        "UpdateFrame": function() {
             if (!this.disableControls) {
                 if (typeof this._speed.x !== 'undefined' && this._speed.x !== null){
                     this.vx = this._speed.x * this._direction.x;

--- a/src/controls/inputs.js
+++ b/src/controls/inputs.js
@@ -1089,7 +1089,7 @@ Crafty.c("Keyboard", {
      * @example
      * ~~~
      * ent.requires('Keyboard')
-     *    .bind('EnterFrame', function() {
+     *    .bind('UpdateFrame', function() {
      *       if (this.isDown('SPACE'))
      *          this.y--;
      *    });

--- a/src/core/time.js
+++ b/src/core/time.js
@@ -11,7 +11,7 @@ module.exports = {
     init: function () {
         this._delays = [];
         this._delaysPaused = false;
-        this.bind("EnterFrame", function (frameData) {
+        this.bind("UpdateFrame", function (frameData) {
             if (this._delaysPaused) return;
             var index = this._delays.length;
             while (--index >= 0) {

--- a/src/core/tween.js
+++ b/src/core/tween.js
@@ -16,7 +16,7 @@ module.exports = {
     this.tweenGroup = {};
     this.tweenStart = {};
     this.tweens = [];
-    this.uniqueBind("EnterFrame", this._tweenTick);
+    this.uniqueBind("UpdateFrame", this._tweenTick);
 
   },
 

--- a/src/debug/debug-layer.js
+++ b/src/debug/debug-layer.js
@@ -194,7 +194,7 @@ Crafty.c("VisibleMBR", {
     init: function () {
         this.requires("DebugRectangle")
             .debugFill("purple")
-            .bind("EnterFrame", this._assignRect);
+            .bind("PreRender", this._assignRect);
     },
 
     // Internal method for updating the MBR drawn.

--- a/src/graphics/particles.js
+++ b/src/graphics/particles.js
@@ -107,7 +107,7 @@ Crafty.c("Particles", {
             y: Crafty.viewport.y
         };
 
-        this.bind('EnterFrame', function () {
+        this.bind('UpdateFrame', function () {
             if (this._particlesPaused) return;
             relativeX = this.x + Crafty.viewport.x;
             relativeY = this.y + Crafty.viewport.y;

--- a/src/graphics/sprite-animation.js
+++ b/src/graphics/sprite-animation.js
@@ -269,7 +269,7 @@ Crafty.c("SpriteAnimation", {
         this._setFrame(0);
 
         // Start the anim
-        this.bind("EnterFrame", this._animationTick);
+        this.bind("UpdateFrame", this._animationTick);
         this._isPlaying = true;
         this.trigger("StartAnimation", currentReel);
 
@@ -288,7 +288,7 @@ Crafty.c("SpriteAnimation", {
      */
     resumeAnimation: function() {
         if (this._isPlaying === false &&  this._currentReel !== null) {
-            this.bind("EnterFrame", this._animationTick);
+            this.bind("UpdateFrame", this._animationTick);
             this._isPlaying = true;
             this._currentReel.easing.resume();
             this.trigger("StartAnimation", this._currentReel);
@@ -308,7 +308,7 @@ Crafty.c("SpriteAnimation", {
      */
     pauseAnimation: function () {
         if (this._isPlaying === true) {
-            this.unbind("EnterFrame", this._animationTick);
+            this.unbind("UpdateFrame", this._animationTick);
             this._isPlaying = false;
             this._reels[this._currentReelId].easing.pause();
         }
@@ -451,7 +451,7 @@ Crafty.c("SpriteAnimation", {
         return this;
     },
 
-    // Bound to "EnterFrame".  Progresses the animation by dt, changing the frame if necessary.
+    // Bound to "UpdateFrame".  Progresses the animation by dt, changing the frame if necessary.
     // dt is multiplied by the animationSpeed property
     _animationTick: function(frameData) {
         var currentReel = this._reels[this._currentReelId];

--- a/src/graphics/text.js
+++ b/src/graphics/text.js
@@ -204,12 +204,12 @@ Crafty.c("Text", {
      * 
      * @sign public this .dynamicTextGeneration(bool dynamicTextOn[, string textUpdateEvent])
      * @param dynamicTextOn - A flag that indicates whether dyanamic text should be on or off.
-     * @param textUpdateEvent - The name of the event which will trigger text to be updated.  Defaults to "EnterFrame".  (This parameter does nothing if dynamicTextOn is false.)
+     * @param textUpdateEvent - The name of the event which will trigger text to be updated.  Defaults to "UpdateFrame".  (This parameter does nothing if dynamicTextOn is false.)
      *
      * Turns on (or off) dynamic text generation for this entity.  While dynamic text generation is on, 
      * if the `.text()` method is called with a text generating function, the text will be updated each frame.
      * 
-     * If textUpdateEvent is provided, text generation will be bound to that event instead of "EnterFrame".
+     * If textUpdateEvent is provided, text generation will be bound to that event instead of "UpdateFrame".
      *
      * The text generating function is invoked with the event object parameter, which the event was triggered with.
      * 
@@ -232,7 +232,7 @@ Crafty.c("Text", {
     dynamicTextGeneration: function(dynamicTextOn, textUpdateEvent) {
         this.unbind(this._textUpdateEvent, this._dynamicTextUpdate);
         if (dynamicTextOn) {
-            this._textUpdateEvent = textUpdateEvent || "EnterFrame";
+            this._textUpdateEvent = textUpdateEvent || "UpdateFrame";
             this.bind(this._textUpdateEvent, this._dynamicTextUpdate);
         }
         return this;

--- a/src/graphics/viewport.js
+++ b/src/graphics/viewport.js
@@ -208,7 +208,7 @@ Crafty.extend({
         pan: (function () {
             var targetX, targetY, startingX, startingY, easing;
 
-            function enterFrame(e) {
+            function updateFrame(e) {
                 easing.tick(e.dt);
                 var v = easing.value();
                 Crafty.viewport.x = (1-v) * startingX + v * targetX;
@@ -222,7 +222,7 @@ Crafty.extend({
             }
 
             function stopPan(){
-                Crafty.unbind("EnterFrame", enterFrame);
+                Crafty.unbind("UpdateFrame", updateFrame);
             }
 
             Crafty._preBind("StopCamera", stopPan);
@@ -244,7 +244,7 @@ Crafty.extend({
                 easing = new Crafty.easing(time, easingFn);
 
                 // bind to event, using uniqueBind prevents multiple copies from being bound
-                Crafty.uniqueBind("EnterFrame", enterFrame);
+                Crafty.uniqueBind("UpdateFrame", updateFrame);
                        
             };
         })(),
@@ -360,13 +360,13 @@ Crafty.extend({
             
 
             function stopZoom(){
-                Crafty.unbind("EnterFrame", enterFrame);
+                Crafty.unbind("UpdateFrame", updateFrame);
             }
             Crafty._preBind("StopCamera", stopZoom);
 
             var startingZoom, finalZoom, finalAmount, startingX, finalX, startingY, finalY, easing;
 
-            function enterFrame(e){
+            function updateFrame(e){
                 var amount, v;
 
                 easing.tick(e.dt);
@@ -427,7 +427,7 @@ Crafty.extend({
 
                 easing = new Crafty.easing(time, easingFn);
 
-                Crafty.uniqueBind("EnterFrame", enterFrame);
+                Crafty.uniqueBind("UpdateFrame", updateFrame);
             };
 
             

--- a/src/spatial/collision.js
+++ b/src/spatial/collision.js
@@ -547,7 +547,7 @@ Crafty.c("Collision", {
      *                     The second argument passed will be a Boolean indicating whether the collision with a component occurs for the first time.
      * @param callbackOff - Callback method executed once as soon as collision stops.
      *
-     * Creates an EnterFrame event calling `.hit()` each frame.  When a collision is detected the `callbackOn` will be invoked.
+     * Creates an `UpdateFrame` event calling `.hit()` each frame.  When a collision is detected the `callbackOn` will be invoked.
      *
      * Note that the `callbackOn` will be invoked every frame the collision is active, not just the first time the collision occurs.
      * Use the second argument passed to `callbackOn` to differentiate that, which will be `true` if it's the first time the collision occurs.
@@ -575,7 +575,7 @@ Crafty.c("Collision", {
      */
     onHit: function (component, callbackOn, callbackOff) {
         var justHit = false;
-        this.bind("EnterFrame", function () {
+        this.bind("UpdateFrame", function () {
             var hitData = this.hit(component);
             if (hitData) {
                 callbackOn.call(this, hitData, !justHit);
@@ -640,10 +640,10 @@ Crafty.c("Collision", {
      *
      * If you want more fine-grained control consider using `.hit()` or even `Crafty.map.search()`.
      *
-     * @note Hit checks are performed upon entering each new frame (using
-     * the *EnterFrame* event). It is entirely possible for object to move in
+     * @note Hit checks are performed on each new frame (using
+     * the *UpdateFrame* event). It is entirely possible for object to move in
      * said frame after the checks were performed (even if the more is the
-     * result of *EnterFrame*, as handlers run in no particular order). In such
+     * result of *UpdateFrame*, as handlers run in no particular order). In such
      * a case, the hit events will not fire until the next check is performed in
      * the following frame.
      *
@@ -682,7 +682,7 @@ Crafty.c("Collision", {
             this._collisionData[component] = collisionData = { occurring: false, handler: null };
             collisionData.handler = this._createCollisionHandler(component, collisionData);
 
-            this.bind("EnterFrame", collisionData.handler);
+            this.bind("UpdateFrame", collisionData.handler);
         }
 
         return this;
@@ -726,7 +726,7 @@ Crafty.c("Collision", {
 
         if (components.length === 0) {
             for (collisionData in this._collisionData) {
-                this.unbind("EnterFrame", collisionData.handler);
+                this.unbind("UpdateFrame", collisionData.handler);
             }
 
             this._collisionData = {};
@@ -744,7 +744,7 @@ Crafty.c("Collision", {
                 continue;
             }
 
-            this.unbind("EnterFrame", collisionData.handler);
+            this.unbind("UpdateFrame", collisionData.handler);
             delete this._collisionData[component];
         }
 

--- a/src/spatial/motion.js
+++ b/src/spatial/motion.js
@@ -135,10 +135,10 @@ Crafty.c("AngularMotion", {
 
         this.__oldRotationDirection = 0;
 
-        this.bind("EnterFrame", this._angularMotionTick);
+        this.bind("UpdateFrame", this._angularMotionTick);
     },
     remove: function(destroyed) {
-        this.unbind("EnterFrame", this._angularMotionTick);
+        this.unbind("UpdateFrame", this._angularMotionTick);
     },
 
     /**@
@@ -329,10 +329,10 @@ Crafty.c("Motion", {
         this.__movedEvent = {axis: '', oldValue: 0};
         this.__oldDirection = {x: 0, y: 0};
 
-        this.bind("EnterFrame", this._linearMotionTick);
+        this.bind("UpdateFrame", this._linearMotionTick);
     },
     remove: function(destroyed) {
-        this.unbind("EnterFrame", this._linearMotionTick);
+        this.unbind("UpdateFrame", this._linearMotionTick);
     },
 
     /**@

--- a/src/spatial/platform.js
+++ b/src/spatial/platform.js
@@ -52,7 +52,7 @@ Crafty.c("Supportable", {
         this.defineField("ground", function() { return this._ground; }, function(newValue) {});
     },
     remove: function(destroyed) {
-        this.unbind("EnterFrame", this._detectGroundTick);
+        this.unbind("UpdateFrame", this._detectGroundTick);
     },
 
     /*@
@@ -82,7 +82,7 @@ Crafty.c("Supportable", {
      */
     startGroundDetection: function(ground) {
         if (ground) this._groundComp = ground;
-        this.uniqueBind("EnterFrame", this._detectGroundTick);
+        this.uniqueBind("UpdateFrame", this._detectGroundTick);
 
         return this;
     },
@@ -98,7 +98,7 @@ Crafty.c("Supportable", {
      * Disable ground detection for this component. It can be reenabled by calling .startGroundDetection()
      */
     stopGroundDetection: function() {
-        this.unbind("EnterFrame", this._detectGroundTick);
+        this.unbind("UpdateFrame", this._detectGroundTick);
 
         return this;
     },

--- a/tests/unit/controls/controls.js
+++ b/tests/unit/controls/controls.js
@@ -168,7 +168,7 @@
       if (landCount === 1) {
         this.bind("LiftedOffGround", function() {
           liftCount++;
-          this.bind("EnterFrame", function() {
+          this.bind("UpdateFrame", function() {
             keysDown(Crafty.keys.UP_ARROW);
             if (this.velocity().y < -this._jumpSpeed)
               _.ok(false, "Twoway should not modify velocity");

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -339,12 +339,12 @@
     var frameFunction = function() {
       frameNumber = Crafty.frame();
     };
-    Crafty.bind('EnterFrame', frameFunction);
+    Crafty.bind('UpdateFrame', frameFunction);
     Crafty.timer.simulateFrames(1);
 
     _.ok(frameNumber, '.frame function should return a value.');
 
-    Crafty.unbind('EnterFrame', frameFunction);
+    Crafty.unbind('UpdateFrame', frameFunction);
   });
 
   // TODO: add test for Crafty.stop() once problematic side effects are fixed!
@@ -357,34 +357,41 @@
 
     var enterFrameFunc = function() {
       counter++;
-      _.ok(counter === 1 || counter === 3 || counter === 5, "different counter value expected");
+      _.ok(counter === 1 || counter === 4 || counter === 7, "different counter value expected");
+    };
+    var updateFrameFunc = function() {
+      counter++;
+      _.ok(counter === 2 || counter === 5 || counter === 8, "different counter value expected");
     };
     var exitFrameFunc = function() {
       counter++;
-      _.ok(counter === 2 || counter === 4 || counter === 6, "different counter value expected");
+      _.ok(counter === 3 || counter === 6 || counter === 9, "different counter value expected");
     };
     var preRenderFunc = function() {
       counter++;
-      _.ok(counter === 7, "different counter value expected");
+      _.ok(counter === 10, "different counter value expected");
     };
     var renderSceneFunc = function() {
       counter++;
-      _.ok(counter === 8, "different counter value expected");
+      _.ok(counter === 11, "different counter value expected");
     };
     var postRenderFunc = function() {
       counter++;
-      _.ok(counter === 9, "different counter value expected");
+      _.ok(counter === 12, "different counter value expected");
     };
 
     Crafty.bind("EnterFrame", enterFrameFunc);
+    Crafty.bind("UpdateFrame", updateFrameFunc);
     Crafty.bind("ExitFrame", exitFrameFunc);
     Crafty.bind("PreRender", preRenderFunc);
     Crafty.bind("RenderScene", renderSceneFunc);
     Crafty.bind("PostRender", postRenderFunc);
 
-    Crafty.timer.simulateFrames(3); // 3*2 frame events + 1*3 render events
+    Crafty.timer.simulateFrames(3); // 3*3 frame events + 1*3 render events
+    _.strictEqual(counter, 12, "12 events should have been fired");
 
     Crafty.unbind("EnterFrame", enterFrameFunc);
+    Crafty.unbind("UpdateFrame", updateFrameFunc);
     Crafty.unbind("ExitFrame", exitFrameFunc);
     Crafty.unbind("PreRender", preRenderFunc);
     Crafty.unbind("RenderScene", renderSceneFunc);
@@ -437,7 +444,7 @@
       _.strictEqual(fps, 25);
       _.strictEqual(Crafty.timer.FPS(), 25);
     });
-    Crafty.one("EnterFrame", function(frameData) {
+    Crafty.one("UpdateFrame", function(frameData) {
       _.strictEqual(frameData.dt, 1000/25);
     });
     Crafty.timer.FPS(25);
@@ -447,7 +454,7 @@
       _.strictEqual(fps, 50);
       _.strictEqual(Crafty.timer.FPS(), 50);
     });
-    Crafty.one("EnterFrame", function(frameData) {
+    Crafty.one("UpdateFrame", function(frameData) {
       _.strictEqual(frameData.dt, 1000/50);
     });
     Crafty.timer.FPS(50);

--- a/tests/unit/core/time.js
+++ b/tests/unit/core/time.js
@@ -140,7 +140,7 @@
     var framesFunc = function() {
       framesPlayed++;
     };
-    Crafty.bind("EnterFrame", framesFunc);
+    Crafty.bind("UpdateFrame", framesFunc);
 
     Crafty.timer.simulateFrames(1);
     _.strictEqual(framesPlayed, 1, "A frame should have been simulated");
@@ -148,17 +148,16 @@
     Crafty.timer.simulateFrames(100);
     _.strictEqual(framesPlayed, 101, "101 frames should have been simulated");
 
-    Crafty.unbind("EnterFrame", framesFunc);
+    Crafty.unbind("UpdateFrame", framesFunc);
   });
 
   test("curTime", function(_) {
     _.expect(1);
     var done = _.async(); // pause the QUnit so the timeout has time to complete.
     var startTime, lastKnownTime;
-
     var framesTriggered = 0;
 
-    Crafty.e("").bind("EnterFrame", function(params) {
+    Crafty.e("").bind("UpdateFrame", function(params) {
       framesTriggered++;
       if (!startTime) {
         startTime = params.gameTime;

--- a/tests/unit/spatial/platform.js
+++ b/tests/unit/spatial/platform.js
@@ -364,7 +364,7 @@
 
 
     var vel = -1;
-    player.bind("EnterFrame", function() {
+    player.bind("UpdateFrame", function() {
       if (!this.ground) {
         _.ok(this.velocity().y > vel, "velocity should increase");
         vel = this.velocity().y;


### PR DESCRIPTION
This event replaces the `EnterFrame` event.
The `EnterFrame` event now triggers before the `UpdateFrame` event.

This is a potentially breaking change. While code may still work with binding to `EnterFrame`, it may introduce latency from previous / to next state update.

Could be useful for setting-up movement in response to input events before the state updates.
This is better than doing it after the state updates, which is already possible with `ExitFrame`, because there is added latency before the input is checked and after it is processed (up to `20ms` in the default case).
Additionally, having input processing bound to the `UpdateFrame` does not guarantee it will be executed before the `Motion` updates, which also bind to an arbitrary execution order triggered by `UpdateFrame`.
- [x] Replaces all triggered callbacks of the `EnterFrame` event to be triggered by `UpdateFrame` instead.
- [x] Fixes (hopefully) all api docs to reflect the change.
- [x] Fixes documentation on Crafty's website to reflect the change.
