### PR TITLE
Add appveyor integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
+sudo: false
+
 language: node_js
 node_js:
-- '4.2'
+- '4'
+cache:
+  directories:
+  - node_modules
+
 before_install: if [ "$TRAVIS_BRANCH" != "testing" ]; then unset SAUCE_USERNAME && unset SAUCE_ACCESS_KEY; fi
 before_script: npm install -g grunt-cli
 after_success: "./travis-nightly.sh"
 after_failure: if [ "$GH_TOKEN" ]; then grunt gh-pages:crafty-distro-regression-tests; fi
-sudo: false
-cache:
-  directories:
-  - node_modules
+
 env:
   global:
   # GitHub token
@@ -16,5 +19,6 @@ env:
   # OpenSauce credentials: for pre-relase testing
   - secure: NO+7PK5P0XLGbnvdSDBlrlnzqM/hMTy3wxxAp8ZtzEuS2ZOXn8q0KjOO/cAs1NorG1SOl8+XfFZBTR5W504GrHYLP8fNkLJOAyKMfFeTojwQ+385ShVr/NejZFejsc+xJZymIeDsEzBZqosxPOi+8k7jljDK4mzLdKMpt8flWUw=
   - secure: iGO+VCkCq/26Dqrc6+G1nX8Dk+tTqhcINuiIVhxGtMARcY+WIzcyEK/cfXRaLnvIzIxQ0xUoGGnM9xe4DQT8L+BGzo8AGnVbzxITzceWTlhsFepcbOTgqOg0ZGMxQVQ6VBh888Cdks8KsOgtTNhzd+oVgcStsyxZPCVD/7VgNTE=
+
 addons:
   sauce_connect: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+# Test against this version of Node.js.
+environment:
+  matrix:
+  - nodejs_version: "4"
+
+# preserve local npm modules but will reset them if package.json or appveyor.yml is modified
+cache:
+  - node_modules -> package.json, appveyor.yml
+
+version: '{build}'
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the specified version of Node.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+  - npm install -g grunt-cli
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off


### PR DESCRIPTION
Check if Crafty builds and passes tests on Win platforms.
This removes worries of failing native development dependencies (e.g. `phantomjs`) across platforms.
[Tested on my own fork](https://ci.appveyor.com/project/mucaho/crafty) that everything works correctly.
- [x] Add [appveyor.yml](https://www.appveyor.com/docs/appveyor-yml)
- [x] [Register](https://www.appveyor.com/docs#step-2-add-your-project) the craftyjs/Crafty repository with appveyor
- [x] Update documentation in [wiki:Automatic-Build-Testing](https://github.com/craftyjs/Crafty/wiki/Automatic-Build-Testing)
- [x] Add [status badge](https://www.appveyor.com/docs/status-badges#badges-for-projects-with-public-repositories-on-github-and-bitbucket)
- [ ] Optionally protect develop branch by from merges with failing appveyor status checks
