### PR TITLE
Allow a jump to be triggered directly without faking a keypress

### DIFF
--- a/src/controls/controls.js
+++ b/src/controls/controls.js
@@ -436,13 +436,26 @@ Crafty.c("Jumper", {
         if (this.disableControls) return;
 
         if (this._jumpKeys[e.key]) {
-            var ground = this.ground;
-            this.canJump = !!ground;
-            this.trigger("CheckJumping", ground);
-            if (this.canJump) {
-                this.vy = -this._jumpSpeed;
-            }
+            this.jump();
         }
+    },
+
+    /**@
+     * #.jump
+     * @comp Jumper
+     * @sign public this .jump()
+     *
+     * Directly trigger the entity to jump.
+     *
+     */
+    jump: function() {
+        var ground = this.ground;
+        this.canJump = !!ground;
+        this.trigger("CheckJumping", ground);
+        if (this.canJump) {
+            this.vy = -this._jumpSpeed;
+        }
+        return this;
     },
 
     /**@


### PR DESCRIPTION
A quick PR that would allow you to trigger a jump directly, instead of needing to fake a keypress.  (I've seen this come up a couple time in the google group, and there's no need to make people jump[1] through hoops.)
1.  Wow, didn't even notice the terrible unintentional pun here....
