### PR TITLE
Change to the fourway component

### DIFF
--- a/src/controls/controls.js
+++ b/src/controls/controls.js
@@ -530,6 +530,59 @@ Crafty.c("Fourway", {
 
     init: function () {
         this.requires("Multiway");
+        
+        this.unbind("KeyDown", this._keydown)
+            .unbind("KeyUp", this._keyup);
+        
+        this.bind("KeyDown", this.__keydown)
+            .bind("KeyUp", this.__keyup);
+    },
+
+    __keydown: function (e) {
+        var direction = this._keyDirection[e.key];
+        if (direction !== undefined) { // if this is a key we are interested in 
+            if (this._activeDirections[direction] === 0 && !this.disableControls) { // if key is first one pressed for this direction
+                
+                this.vx = this._directionSpeed[direction].x;
+                this.vy = this._directionSpeed[direction].y;
+                                                                        
+                }
+                 
+            this._activeDirections[direction]++;
+            
+            }
+            
+                 
+            
+        
+    },
+
+    __keyup: function (e) {
+        var direction = this._keyDirection[e.key];
+        if (direction !== undefined) { // if this is a key we are interested in
+            this._activeDirections[direction]--;
+                    
+            if (this._activeDirections[direction] === 0 && !this.disableControls) { // if key is last one unpressed for this direction
+                
+                this.vx = 0;
+                this.vy = 0;
+                
+                for(var dir in this._activeDirections){
+                    
+                    if(this._activeDirections[dir] === 1){
+                        
+                        this.vx = this._directionSpeed[dir].x;
+                        this.vy = this._directionSpeed[dir].y;
+                                        
+                    }
+                            
+                }
+                
+                
+            }
+            
+            
+        }
     },
 
     /**@
@@ -542,8 +595,8 @@ Crafty.c("Fourway", {
      * Component will listen for key events and move the entity
      * in the respective direction by the speed passed in the argument.
      */
-    fourway: function (speed) {
-        this.multiway(speed || this._speed, {
+    fourway: function (speed, keys) {
+        this.multiway(speed || this._speed, keys || {
             UP_ARROW: -90,
             DOWN_ARROW: 90,
             RIGHT_ARROW: 0,


### PR DESCRIPTION
I have tried to limit diagonal movement for the fourway component. Previously, the fourway component was a thin wrapper for multiway, which simpy adds each keypress to the vx and vy. With the changes I propose, the fourway component limits diagonal movement and does not add velocity but sets a new velocity with each key press, and checks for keys still pressed at the keyup event setting the new velocity accordingly. I am using this implementation for an isometric game. If one were to use it for an rpg it would probably have to be limited further. Perhaps an fourway rpg component should be created as well.  

As a final note, I am unsure whether I handled the new binding of keydown and keyup in the simplest way. Let me know.
