### PR TITLE
Pull control logic out of Multiway into a separate system

### DIFF
--- a/src/controls/controls-system.js
+++ b/src/controls/controls-system.js
@@ -1,0 +1,173 @@
+var Crafty = require('../core/core.js');
+
+
+function InputButtonGroup(keys) {
+    this.keys = keys;
+}
+
+InputButtonGroup.prototype = {
+    // should always have a value if isActive returns true
+    timeDown: null,
+    isActive: function () {
+        for (var k in this.keys) {
+            if (Crafty.keydown[this.keys[k]]){
+                 if (!this.timeDown) {
+                     this.timeDown = Date.now();
+                 }
+                 return true;
+            }
+        }
+        delete this.timeDown;
+        return false;
+    }
+};
+
+// Allow the creation of custom inputs
+Crafty.s("Controls", {
+    init: function () {
+        // internal object to store definitions
+        this._dpads = {};
+    },
+
+    events: {
+        "EnterFrameInput" : function() {
+            this.runEvents();
+        }
+    },
+
+    runEvents: function () {
+        for (var d in this._dpads) {
+            var dpad = this._dpads[d];
+            dpad.oldX = dpad.x;
+            dpad.oldY = dpad.y;
+            this.updateInput(dpad, dpad.multipleDirectionBehavior);
+            this.updateActiveDirection(dpad, dpad.normalize);
+            dpad.event.x = dpad.x;
+            dpad.event.y = dpad.y;
+            if (dpad.x !== dpad.oldX || dpad.y !== dpad.oldY) {
+                Crafty.trigger("DirectionalInput", dpad.event);
+            }
+        }
+    },
+
+    getDpad: function(name) {
+        return this._dpads[name];
+    },
+
+    defineDpad: function (name, definition, options) {
+        // Store the name/definition pair
+        if (this._dpads[name]) delete this._dpads[name];
+
+        var directionDict = {};
+        for (var k in definition) {
+            var direction = definition[k];
+            var keyCode = Crafty.keys[k] || k;
+
+            // create a mapping of directions to all associated keycodes
+            if (!directionDict[direction]) {
+                directionDict[direction] = [];
+            }
+            directionDict[direction].push(keyCode);
+            
+        }
+
+        // Create a useful definition from the input format that tracks state
+        var parsedDefinition = {};
+        for (var d in directionDict) {
+            parsedDefinition[d] = {
+                input: new InputButtonGroup(directionDict[d]),
+                active: false,
+                n: this.parseDirection(d)
+            };
+        }
+        if (typeof options === 'undefined') {
+            options = {};
+        }
+        if (typeof options.normalize === 'undefined'){
+            options.normalize = false;
+        }
+        if (typeof options.multipleDirectionBehavior === 'undefined') {
+            options.multipleDirectionBehavior = "all";
+        }
+        // Create the fully realized dpad object
+        this._dpads[name] = {
+            name: name,
+            directions: parsedDefinition,
+            x: 0,
+            y: 0,
+            oldX: 0,
+            oldY: 0,
+            event: { x: 0, y: 0, name: name },
+            normalize: options.normalize,
+            multipleDirectionBehavior: options.multipleDirectionBehavior
+        };
+    },
+
+    // Takes an amount in degrees and converts it to an x/y object.
+    // Clamps to avoid rounding issues with sin/cos
+    parseDirection: function (direction) {
+        return {
+            x: Math.round(Math.cos(direction * (Math.PI / 180)) * 1000) / 1000,
+            y: Math.round(Math.sin(direction * (Math.PI / 180)) * 1000) / 1000
+        };
+    },
+
+    // dpad definition is a map of directions to keys array and active flag
+    updateActiveDirection: function (dpad, normalize) {
+        dpad.x = 0;
+        dpad.y = 0;
+        for (var d in dpad.directions) {
+            var dir = dpad.directions[d];
+            if (!dir.active) continue;
+            dpad.x += dir.n.x;
+            dpad.y += dir.n.y;
+        }
+
+        // Normalize
+        if (normalize) {
+            var m = Math.sqrt(dpad.x * dpad.x + dpad.y * dpad.y);
+            if (m > 0) {
+                dpad.x = dpad.x / m;
+                dpad.y = dpad.y / m;
+            }
+        }
+    },
+
+    // Has to handle three cases concerning multiple active input groups:
+    // - "all": all directions are active
+    // - "last": one direction at a time, new directions replace old ones
+    // - "first": one direction at a time, new directions are ignored while old ones are still active 
+    updateInput: function (dpad, multiBehavior) {
+        var d, dir;
+        var winner;
+
+
+        for (d in dpad.directions) {
+            dir = dpad.directions[d];
+            dir.active = false;
+
+            if (dir.input.isActive()) {
+                if (multiBehavior === "all") {
+                    dir.active = true;
+                } else {
+                    if (!winner) {
+                        winner = dir;
+                    } else {
+                        if (multiBehavior === "first") {
+                            if (winner.input.timeDown > dir.input.timeDown) {
+                                winner = dir;
+                            }
+                        }
+                        if (multiBehavior === "last") {
+                            if (winner.input.timeDown < dir.input.timeDown) {
+                                winner = dir;
+                            }
+                        }
+                    }
+                }      
+            }  
+        }
+        // If we picked a winner, set it active
+        if (winner) winner.active = true;
+    }
+});

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -1510,6 +1510,8 @@ Crafty.extend({
                         dt: dt,
                         gameTime: gameTime
                     };
+                    // Handle any changes due to user input
+                    Crafty.trigger("EnterFrameInput", frameData);
                     // Everything that changes over time hooks into this event
                     Crafty.trigger("EnterFrame", frameData);
                     // Event that happens after "EnterFrame", e.g. for resolivng collisions applied through movement during "EnterFrame" events
@@ -1565,13 +1567,13 @@ Crafty.extend({
              * @param timestep - the duration to pass each frame.  Defaults to milliSecPerFrame (20 ms) if not specified.
              */
             simulateFrames: function (frames, timestep) {
-                if (typeof timestep === "undefined")
-                    timestep = milliSecPerFrame;
+                timestep = timestep || milliSecPerFrame;
                 while (frames-- > 0) {
                     var frameData = {
                         frame: frame++,
                         dt: timestep
                     };
+                    Crafty.trigger("EnterFrameInput", frameData);
                     Crafty.trigger("EnterFrame", frameData);
                     Crafty.trigger("ExitFrame", frameData);
                 }

--- a/src/crafty-headless.js
+++ b/src/crafty-headless.js
@@ -23,6 +23,7 @@ module.exports = function() {
     requireNew('./spatial/rect-manager');
     requireNew('./spatial/math');
 
+    require('./controls/controls-system');
     requireNew('./controls/controls');
     requireNew('./controls/keycodes');
 
@@ -42,6 +43,10 @@ module.exports = function() {
             return false;
         }
     });
-
+    // dummy keydown registry
+    Crafty.keydown = {};
+    Crafty.resetKeyDown = function() {
+        Crafty.keydown = {};
+    };
     return Crafty;
 };

--- a/src/crafty.js
+++ b/src/crafty.js
@@ -44,6 +44,7 @@ require('./isometric/diamond-iso');
 require('./isometric/isometric');
 
 require('./controls/inputs');
+require('./controls/controls-system');
 require('./controls/controls');
 require('./controls/device');
 require('./controls/keycodes');

--- a/tests/2d.js
+++ b/tests/2d.js
@@ -1597,9 +1597,13 @@
     ok(done, "Integrationtest completed");
   });
 
-
+  // Import keysUp/Down helper functions defined in common.js
+  var keysUp = global.keysUp;
+  var keysDown = global.keysDown;
+  
   test("Integrationtest - Twoway", function() {
     var done = false;
+    Crafty.resetKeyDown();
 
     var ground = Crafty.e("2D, platform")
           .attr({ x: 0, y: 200, w: 10, h: 20 });
@@ -1618,13 +1622,13 @@
         this.bind("LiftedOffGround", function() {
           liftCount++;
           this.bind("EnterFrame", function() {
-            this.trigger("KeyDown", {key: Crafty.keys.UP_ARROW});
+            keysDown(Crafty.keys.UP_ARROW);
             if (this.velocity().y < -this._jumpSpeed)
               ok(false, "Twoway should not modify velocity");
           });
         });
 
-        this.trigger("KeyDown", {key: Crafty.keys.UP_ARROW});
+        keysDown(Crafty.keys.UP_ARROW);
       } else {
         strictEqual(landCount, 2, "two land on ground events should have been registered");
         strictEqual(liftCount, 1, "one lift off ground event should have been registered");
@@ -1632,14 +1636,13 @@
         ground.destroy();
         player.destroy();
 
-        this.trigger("KeyUp", {key: Crafty.keys.UP_ARROW});
-        this.trigger("KeyUp", {key: Crafty.keys.UP_ARROW});
+        keysUp(Crafty.keys.UP_ARROW);
         done = true;
       }
     });
 
     Crafty.timer.simulateFrames(75);
-    ok(done, "Integrationtest completed");
+    ok(done, "Integration test completed");
   });
 
 })();

--- a/tests/common.js
+++ b/tests/common.js
@@ -15,6 +15,23 @@ global.Round = function(x){
   return Math.round(x*100)/100;
 };
 
+global.keysUp = function() {
+  var keysToRelease = Array.prototype.slice.call(arguments);
+    for (var k in keysToRelease) {
+      var key = Crafty.keys[keysToRelease[k]] || keysToRelease[k];
+      Crafty.keydown[key] = false;
+      Crafty.trigger("KeyUp", {key: key});
+    } 
+};
+global.keysDown = function() {
+    var keysToPress = Array.prototype.slice.call(arguments);
+    for (var k in keysToPress) {
+      var key = Crafty.keys[keysToPress[k]] || keysToPress[k];
+      Crafty.keydown[key] = true;
+      Crafty.trigger("KeyDown", {key: key});
+    }
+};
+
 //////////////////
 // QUnit config //
 //////////////////


### PR DESCRIPTION
This is a first draft at pulling the control logic out of Multiway into a system.  It's not fully tested, ~~and a lot of the names are temporary~~, but since there have been a couple of multiway related suggestions lately I thought I should present this alternative.  @matthijsgroen  @Wanderer101
- The control system lets you define dpads using the same syntax that Multiway uses, and emits events with a directional vector
- A new "Dpad" component allows you to tie callbacks to specific dpad events.  Multiway uses this concept to update the objects speed when necessary.
- The new system has options for normalized/clamped input (#1047) and axis-only movement (#1046, aka only listen to one direction button at a time)
- Behind the scenes, instead of listening for keyup/keydown events, the control system checks which keys are down each frame, and update the direction based on that info.  That makes it easier to maintain a consistent state.
- To remove any ambiguity in when motion/control events happen, I tried introducing a new top level event (called "EnterFrameInput" for now) that fires before "EnterFrame".  The idea here would be to first update any state based on user input, and then actually process the game frame.  I'm not committed to this idea, but it does seem useful.

TODO
- [x] Fix tests
