### PR TITLE
Clarify licensing + MIT only

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function (grunt) {
                 ' * <%= pkg.name %> <%= pkg.version %>\n' +
                 ' * <%= pkg.author.url %>\n *\n' +
                 ' * Copyright <%= grunt.template.today("yyyy") %>, <%= pkg.author.name %>\n' +
-                ' * Dual licensed under the MIT or GPL licenses.\n' +
+                ' * Licensed under the MIT license.\n' +
                 ' */\n\n';
 
     var docGen = function() {

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2010 Louis Stowasser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "game",
     "engine"
   ],
-  "license": ["GPL", "MIT"],
+  "license": ["MIT"],
   "main": "dist/crafty.js",
   "ignore": [
     "**",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "https://github.com/craftyjs/Crafty.git"
   },
-  "licenses": "(GPL OR MIT)",
+  "licenses": "MIT",
   "description": "Crafty is a modern component and event based framework for developing games in JavaScript that targets DOM, Canvas and WebGL.",
   "keywords": [
     "framework",


### PR DESCRIPTION
The actual compiled crafty file indicates that it's under the MIT + GPL licenses.  As flagged in issue #781, there isn't an actual license file present in the repo, and there's no mention of what version of the GPL is intended.

This adds the MIT license to the repo.  Possibly we should simply nix the mention of the GPL, since it's too vague to be useful, and the MIT is more permissive in any case.
