### PR TITLE
Document the  "kind" of thing associated with a docblock

### DIFF
--- a/build/api-gen/doc-components.jsx
+++ b/build/api-gen/doc-components.jsx
@@ -26,8 +26,7 @@ var MarkdownBlock = React.createClass({
   render: function() {
     var raw = this.props.value;
     var rawHtml = this.convert(raw);
-    var key = this.props.key;
-    return <span key={key} className="markdown" dangerouslySetInnerHTML={{__html: rawHtml}} />
+    return <span className="markdown" dangerouslySetInnerHTML={{__html: rawHtml}} />
   }
 })
 
@@ -46,11 +45,11 @@ var ToC = React.createClass({
       }
     }
     catArray.sort(nameSort);
-    var catElements = catArray.map( function(cat, index){return <Category key={cat.name} catName = {cat.name} pages = {cat.pages}/>});
-    return (
+    var catElements = catArray.map( function(cat, index){return <Category key={cat.name} catName = {cat.name} pages = {cat.pages} />});
+    return ( 
       <ul id = "doc-level-one">
         <li><a href="events.html">List of Events</a></li>
-        <Category catName = {primary} pages = {toc.categories[primary].pages}/>
+        <Category catName = {primary} pages = {toc.categories[primary].pages} />
         {catElements}
       </ul>
     )
@@ -58,9 +57,11 @@ var ToC = React.createClass({
 
 })
 
+// The logic for choosing the link name and target is complicated due to the inconsistent way these are tagged in source
 var DocLink = React.createClass({
   render: function() {
     var target = this.props.target;
+    var kind = this.props.kind || "missing";
     var linkText, href;
     var parent = (this.props.parentPage) ? this.props.parentPage.main.name : undefined;
     // If the link target starts with the name of the page, assume it is an internal link
@@ -94,14 +95,16 @@ var DocLink = React.createClass({
       linkText = target;
       href = cleanName(target) + ".html";
     }
-    return <a href={href}>{linkText}</a>
+    return <a href={href} className={"kind-" + kind}>{linkText}</a>
   }
 })
 
 var Category = React.createClass({
   render: function() {
-    this.props.pages.sort(stringSort);
-    var pages = this.props.pages.map(function(page, index){return <li key={page}><DocLink target={page}/></li>});
+    this.props.pages.sort(nameSort);
+    var dictionary = this.props.dict;
+    var pages = this.props.pages.map(function(page, index){return <li key={page.name}><DocLink target={page.name} kind={page.kind}/></li>});
+
     return ( 
       <li className="category">
         {this.props.catName}

--- a/build/api-gen/dynamic-server.js
+++ b/build/api-gen/dynamic-server.js
@@ -13,7 +13,7 @@ var cleanName = require("./clean-name");
 function startServer(grunt, input){
     var api = grunt.file.readJSON(input),
       index = createIndex(api),
-      pages = index.pages,
+      pages = index.pages,  
       props = {data: api, index: index};
 
     function createPage(selector, filename) {

--- a/build/api-gen/index-docs.js
+++ b/build/api-gen/index-docs.js
@@ -17,7 +17,7 @@ function createIndex(blocks) {
     if (block.categories) {
       for (var j = 0; j < block.categories.length; j++) {
         if (block.name) {
-          cat(block.categories[j]).pages.push(block.name)
+          cat(block.categories[j]).pages.push( {name: block.name, kind: block.kind});
         }
         comp(block.name).main = block;
       }

--- a/build/parseNodes.coffee
+++ b/build/parseNodes.coffee
@@ -136,9 +136,18 @@ addNode =
 		parent.requires = iterator.current().value
 		iterator.next()
 
+	kind: (parent, iterator)->
+		parent.kind = iterator.current().value
+		iterator.next()
+	
+	private: (parent, iterator)->
+		parent.private = true
+		iterator.next()
+	
+
 	#These are used only in 2d math files, and so don't have much meaning!
 	public: (parent, iterator)->
-		parent.public = true;
+		parent.private = false;
 		iterator.next()
 	class: (parent, iterator)->
 		parent.class = iterator.current().value

--- a/build/parseSourceDocs.coffee
+++ b/build/parseSourceDocs.coffee
@@ -64,17 +64,17 @@ nameRe = /^\s*\#[^\#]/
 emptyRe = /^\s*$/
 
 # Check whether a tag should be greedy or lazy when consuming subsequent lines
+# A lazy tag will stop parsing at a newline
 lazyTag = (tag) ->
     switch tag 
-        when "name", "comp", "category", "example", "sign"
+        when "name", "comp", "category", "example", "sign", "kind", "private"
             true
         else
             false
 
 # Assign each line to a node, throwing away empty lines that aren't directly after untagged lines
-# Guaranteed to leave the buffer in a state where buffer.current() hasn't yet been processed
+# Promises to leave the buffer in a state where buffer.current() hasn't yet been processed
 nextNode = (buffer)->
-
     
     # Find next non-empty line
     while (buffer.isOpen() and buffer.current().indexOf('*/') == -1) and (clean = cleanLine( buffer.current() )).length == 0
@@ -188,7 +188,7 @@ parseNode = (tag, value)->
         }
 
 
-
+ 
 # The top level method: given a list of files, parses each file into an array of docblocks, which are themeselves arrays of nodes
 # Returns one array of all the docblocks parsed
 parse = (files)->

--- a/src/controls/controls-system.js
+++ b/src/controls/controls-system.js
@@ -72,6 +72,7 @@ ToggleInputGroup.prototype = {
 /**@
  * #Controls
  * @category Controls
+ * @kind System
  * 
  * A built-in system for linking specific inputs to general types of input events.
  * 

--- a/src/controls/controls.js
+++ b/src/controls/controls.js
@@ -3,6 +3,7 @@ var Crafty = require('../core/core.js');
 /**@
  * #Draggable
  * @category Controls
+ * @kind Component
  * Enable drag and drop of the entity. Listens to events from `MouseDrag` and moves entity accordingly.
  *
  * @see MouseDrag
@@ -130,6 +131,7 @@ Crafty.c("Draggable", {
 /**@
  * #Controllable
  * @category Controls
+ * @kind Component
  *
  * Used to bind methods to generalized input events.
  *
@@ -256,6 +258,7 @@ Crafty.c("Controllable", {
 /**@
  * #Multiway
  * @category Controls
+ * @kind Component
  *
  * Used to bind keys to directions and have the entity move accordingly.
  *
@@ -380,6 +383,7 @@ Crafty.c("Multiway", {
 /**@
  * #Jumper
  * @category Controls
+ * @kind Component
  * @trigger CheckJumping - When entity is about to jump. This event is triggered with the object the entity is about to jump from (if it exists). Third parties can respond to this event and enable the entity to jump.
  *
  * Make the entity jump in response to key events.
@@ -548,6 +552,7 @@ Crafty.c("Jumper", {
 /**@
  * #Fourway
  * @category Controls
+ * @kind Component
  *
  * Move an entity in four directions by using the
  * `Up Arrow`, `Left Arrow`, `Down Arrow`, `Right Arrow` keys or `W`, `A`, `S`, `D`.
@@ -594,6 +599,7 @@ Crafty.c("Fourway", {
 /**@
  * #Twoway
  * @category Controls
+ * @kind Component
  *
  * Move an entity left or right using the `Left Arrow`, `Right Arrow` keys or `D` and `A`
  * and make it jump using `Up Arrow` or `W`.

--- a/src/controls/device.js
+++ b/src/controls/device.js
@@ -5,6 +5,7 @@ Crafty.extend({
     /**@
      * #Crafty.device
      * @category Misc
+     * @kind Property
      *
      * Methods relating to devices such as tablets or phones
      */
@@ -83,6 +84,8 @@ Crafty.extend({
         /**@
          * #Crafty.device.deviceOrientation
          * @comp Crafty.device
+         * @kind Method
+         * 
          * @sign public Crafty.device.deviceOrientation(Function callback)
          * @param callback - Callback method executed once as soon as device orientation is change
          *
@@ -122,6 +125,8 @@ Crafty.extend({
         /**@
          * #Crafty.device.deviceMotion
          * @comp Crafty.device
+         * @kind Method
+         * 
          * @sign public Crafty.device.deviceMotion(Function callback)
          * @param callback - Callback method executed once as soon as device motion is change
          *

--- a/src/controls/inputs.js
+++ b/src/controls/inputs.js
@@ -10,6 +10,7 @@ Crafty.extend({
     /**@
      * #Crafty.lastEvent
      * @category Input
+     * @kind Property
      * Check which mouse event occured most recently (useful for determining mouse position in every frame).
      *
      * The native [`MouseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) is augmented with additional properties.
@@ -34,6 +35,7 @@ Crafty.extend({
     /**@
      * #Crafty.keydown
      * @category Input
+     * @kind Property
      * Check which keys (referred by `Crafty.keys` key codes) are currently down.
      *
      * @example
@@ -48,6 +50,7 @@ Crafty.extend({
     /**@
      * #Crafty.selected
      * @category Input
+     * @kind Property
      * @trigger CraftyFocus - is triggered when Crafty's stage gets selected
      * @trigger CraftyBlur - is triggered when Crafty's stage is no longer selected
      *
@@ -78,6 +81,7 @@ Crafty.extend({
     /**@
      * #Crafty.multitouch
      * @category Input
+     * @kind Method
      * @sign public this .multitouch(Boolean bool)
      * @param bool - Turns multitouch on and off.  The initial state is off (false).
      *
@@ -132,6 +136,8 @@ Crafty.extend({
     /**@
      * #Crafty.mouseDispatch
      * @category Input
+     * @private
+     * @kind Method
      *
      * Internal method which dispatches mouse events received by Crafty.
      *
@@ -230,6 +236,8 @@ Crafty.extend({
     /**@
      * #Crafty.touchDispatch
      * @category Input
+     * @kind Method
+     * @private
      *
      * Internal method which dispatches touch events received by Crafty (crafty.stage.elem).
      * The touch events get dispatched to the closest entity to the source of the event (if available).
@@ -416,6 +424,8 @@ Crafty.extend({
     /**@
      * #Crafty.findPointerEventTargetByComponent
      * @category Input
+     * @kind Method
+     * @private
      * 
      * @sign public this .findPointerEventTargetByComponent(String comp, Event e[, Object target])
      * Finds closest entity with certain component at a given event.
@@ -502,6 +512,8 @@ Crafty.extend({
     /**@
      * #Crafty.mouseWheelDispatch
      * @category Input
+     * @kind Method
+     * @private
      *
      * Internal method which dispatches mouse wheel events received by Crafty.
      * @trigger MouseWheelScroll - is triggered when mouse is scrolled on stage - { direction: +1 | -1} - Scroll direction (up | down)
@@ -579,6 +591,8 @@ Crafty.extend({
     /**@
      * #Crafty.keyboardDispatch
      * @category Input
+     * @kind Method
+     * @private
      *
      * Internal method which dispatches keyboard events received by Crafty.
      * @trigger KeyDown - is triggered for each entity when the DOM 'keydown' event is triggered. - { key: `Crafty.keys` keyCode (Number), originalEvent: original KeyboardEvent } - Crafty's KeyboardEvent
@@ -706,6 +720,7 @@ Crafty._preBind("CraftyStop", function () {
 /**@
  * #Mouse
  * @category Input
+ * @kind Component
  *
  * Provides the entity with mouse related events.
  *
@@ -771,6 +786,7 @@ Crafty.c("Mouse", {
 /**@
  * #Touch
  * @category Input
+ * @kind Component
  * Provides the entity with touch related events
  * @trigger TouchStart - when entity is touched - TouchPoint
  * @trigger TouchMove - when finger is moved over entity - TouchPoint
@@ -817,6 +833,8 @@ Crafty.c("Touch", {
 /**@
  * #AreaMap
  * @category Input
+ * @kind Component
+ * 
  * Component used by Mouse and Touch.
  * Can be added to other entities for use with the Crafty.findClosestEntityByComponent method.
  * 
@@ -848,6 +866,7 @@ Crafty.c("AreaMap", {
     /**@
      * #.areaMap
      * @comp AreaMap
+     * @kind Method
      *
      * @trigger NewAreaMap - when a new areaMap is assigned - Crafty.polygon
      *
@@ -904,6 +923,8 @@ Crafty.c("AreaMap", {
 /**@
  * #Button
  * @category Input
+ * @kind Component
+ * 
  * Provides the entity with touch or mouse functionality, depending on whether this is a pc 
  * or mobile device, and also on multitouch configuration.
  *
@@ -921,6 +942,8 @@ Crafty.c("Button", {
 /**@
  * #MouseDrag
  * @category Input
+ * @kind Component
+ * 
  * Provides the entity with drag and drop mouse events.
  * @trigger Dragging - is triggered each frame the entity is being dragged - MouseEvent
  * @trigger StartDrag - is triggered when dragging begins - MouseEvent
@@ -962,6 +985,8 @@ Crafty.c("MouseDrag", {
     /**@
      * #.startDrag
      * @comp MouseDrag
+     * @kind Method
+     * 
      * @sign public this .startDrag(void)
      *
      * Make the entity produce drag events, essentially making the entity follow the mouse positions.
@@ -983,6 +1008,8 @@ Crafty.c("MouseDrag", {
     /**@
      * #.stopDrag
      * @comp MouseDrag
+     * @kind Method
+     * 
      * @sign public this .stopDrag(void)
      *
      * Stop the entity from producing drag events, essentially reproducing the drop.
@@ -1005,6 +1032,7 @@ Crafty.c("MouseDrag", {
 /**@
  * #Keyboard
  * @category Input
+ * @kind Component
  *
  * Provides entity with keyboard events.
  * @trigger KeyDown - is triggered for each entity when the DOM 'keydown' event is triggered. - { key: `Crafty.keys` keyCode (Number), originalEvent: original KeyboardEvent } - Crafty's KeyboardEvent
@@ -1038,6 +1066,8 @@ Crafty.c("Keyboard", {
     /**@
      * #.isDown
      * @comp Keyboard
+     * @kind Method
+     * 
      * @sign public Boolean isDown(String keyName)
      * @param keyName - Name of the key to check. See `Crafty.keys`.
      * @sign public Boolean isDown(Number keyCode)

--- a/src/controls/keycodes.js
+++ b/src/controls/keycodes.js
@@ -5,6 +5,8 @@ Crafty.extend({
     /**@
      * #Crafty.keys
      * @category Input
+     * @kind Property
+     * 
      * Object of key names and the corresponding Unicode key code.
      *
      * ~~~
@@ -199,6 +201,8 @@ Crafty.extend({
     /**@
      * #Crafty.mouseButtons
      * @category Input
+     * @kind Property
+     * 
      * An object mapping mouseButton names to the corresponding button ID.
      * In all mouseEvents, we add the `e.mouseButton` property with a value normalized to match e.button of modern webkit browsers:
      *

--- a/src/core/animation.js
+++ b/src/core/animation.js
@@ -4,6 +4,7 @@ var Crafty = require('../core/core.js');
 /**@
  * #Crafty.easing
  * @category Animation
+ * @kind Class
  * 
  *
  * An object for tracking transitions.  Typically used indirectly through "SpriteAnimation", "Tween", or viewport animations.

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -3,6 +3,7 @@ var version = require('./version');
 /**@
  * #Crafty
  * @category Core
+ * @kind CoreObject
  *
  * `Crafty` is both an object, and a function for selecting entities.
  * Its many methods and properties are discussed individually.
@@ -77,6 +78,8 @@ initState();
 /**@
  * #Crafty Core
  * @category Core
+ * @kind CoreObject
+ * 
  * @trigger NewEntityName - After setting new name for entity - String - entity name
  * @trigger NewComponent - when a new component is added to the entity - String - Component
  * @trigger RemoveComponent - when a component is removed from the entity - String - Component
@@ -190,6 +193,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.setName
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public this .setName(String name)
      * @param name - A human readable name for debugging purposes.
      *
@@ -212,6 +217,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.getName
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public this .getName(String name)
      * @returns A human readable name for debugging purposes.
      *
@@ -232,6 +239,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.addComponent
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public this .addComponent(String componentList)
      * @param componentList - A string of components to add separated by a comma `,`
      * @sign public this .addComponent(String Component1[, .., String ComponentN])
@@ -303,6 +312,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.toggleComponent
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public this .toggleComponent(String ComponentList)
      * @param ComponentList - A string of components to add or remove separated by a comma `,`
      * @sign public this .toggleComponent(String Component1[, .., String componentN])
@@ -364,6 +375,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.requires
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public this .requires(String componentList)
      * @param componentList - List of components that must be added
      *
@@ -385,6 +398,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.removeComponent
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public this .removeComponent(String Component[, soft])
      * @param component - Component to remove
      * @param soft - Whether to soft remove it (defaults to `true`)
@@ -427,6 +442,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.getId
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public Number .getId(void)
      * @returns the ID of this entity.
      *
@@ -447,6 +464,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.has
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public Boolean .has(String component)
      * @param component - The name of the component to check
      * @returns `true` or `false` depending on if the
@@ -463,6 +482,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.attr
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @trigger Change - when properties change - {key: value}
      *
      * @sign public this .attr(String property, Any value[, Boolean silent[, Boolean recursive]])
@@ -622,6 +643,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.toArray
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public this .toArray(void)
      *
      * This method will simply return the found entities as an array of ids.  To get an array of the actual entities, use `get()`.
@@ -634,6 +657,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
     * #.timeout
     * @comp Crafty Core
+    * @kind Method
+
     * @sign public this .timeout(Function callback, Number delay)
     * @param callback - Method to execute after given amount of milliseconds
     * @param delay - Amount of milliseconds to execute the method
@@ -663,6 +688,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.bind
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public this .bind(String eventName, Function callback)
      * @param eventName - Name of the event to bind to
      * @param callback - Method to execute when the event is triggered
@@ -714,6 +741,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.uniqueBind
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public Number .uniqueBind(String eventName, Function callback)
      * @param eventName - Name of the event to bind to
      * @param callback - Method to execute upon event triggered
@@ -732,6 +761,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.one
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public Number one(String eventName, Function callback)
      * @param eventName - Name of the event to bind to
      * @param callback - Method to execute upon event triggered
@@ -754,6 +785,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.unbind
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public this .unbind(String eventName[, Function callback])
      * @param eventName - Name of the event to unbind
      * @param callback - Function to unbind
@@ -780,6 +813,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.trigger
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public this .trigger(String eventName[, Object data])
      * @param eventName - Event to trigger
      * @param data - Arbitrary data that will be passed into every callback as an argument
@@ -813,6 +848,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.each
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public this .each(Function method)
      * @param method - Method to call on each iteration
      *
@@ -846,6 +883,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.get
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public Array .get()
      * @returns An array of entities corresponding to the active selector
      *
@@ -893,6 +932,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.clone
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public Entity .clone(void)
      * @returns Cloned entity of the current entity
      *
@@ -921,6 +962,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.setter
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public this .setter(String property, Function callback)
      * @param property - Property to watch for modification
      * @param callback - Method to execute if the property is modified
@@ -938,6 +981,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.defineField
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public this .defineField(String property, Function getCallback, Function setCallback)
      * @param property - Property name to assign getter & setter to
      * @param getCallback - Method to execute if the property is accessed
@@ -970,6 +1015,8 @@ Crafty.fn = Crafty.prototype = {
     /**@
      * #.destroy
      * @comp Crafty Core
+     * @kind Method
+     * 
      * @sign public this .destroy(void)
      * Will remove all event listeners and delete all properties as well as removing from the stage
      */
@@ -996,6 +1043,8 @@ Crafty.fn.init.prototype = Crafty.fn;
 /**@
  * #Crafty.extend
  * @category Core
+ * @kind Method
+ * 
  * @sign public this Crafty.extend(Object obj)
  * @param obj - An object whose fields will be copied onto Crafty.  This is a shallow copy.
  *
@@ -1155,6 +1204,8 @@ Crafty.extend({
     /**@
      * #Crafty.init
      * @category Core
+     * @kind Method
+     * 
      * @trigger Load - Just after the viewport is initialised. Before the EnterFrame loops is started
      * @sign public this Crafty.init([Number width, Number height, String stage_elem])
      * @sign public this Crafty.init([Number width, Number height, HTMLElement stage_elem])
@@ -1208,6 +1259,8 @@ Crafty.extend({
     /**@
      * #Crafty.getVersion
      * @category Core
+     * @kind Method
+     * 
      * @sign public String Crafty.getVersion()
      * @returns Current version of Crafty as a string
      *
@@ -1225,6 +1278,8 @@ Crafty.extend({
     /**@
      * #Crafty.stop
      * @category Core
+     * @kind Method
+     * 
      * @trigger CraftyStop - when the game is stopped  - {bool clearState}
      * @sign public this Crafty.stop([bool clearState])
      * @param clearState - if true the stage and all game state is cleared.
@@ -1267,6 +1322,8 @@ Crafty.extend({
     /**@
      * #Crafty.pause
      * @category Core
+     * @kind Method
+     * 
      * @trigger Pause - when the game is paused
      * @trigger Unpause - when the game is unpaused
      * @sign public this Crafty.pause(void)
@@ -1305,6 +1362,8 @@ Crafty.extend({
     /**@
      * #Crafty.isPaused
      * @category Core
+     * @kind Method
+     * 
      * @sign public Boolean Crafty.isPaused()
      * @returns Whether the game is currently paused.
      *
@@ -1320,6 +1379,8 @@ Crafty.extend({
     /**@
      * #Crafty.timer
      * @category Game Loop
+     * @kind CoreObject
+     * 
      * Handles game ticks
      */
     timer: (function () {
@@ -1402,6 +1463,7 @@ Crafty.extend({
             /**@
              * #Crafty.timer.steptype
              * @comp Crafty.timer
+             * @kind Method
              *
              * @trigger NewSteptype - when the current steptype changes - { mode, maxTimeStep } - New steptype
              *
@@ -1446,6 +1508,8 @@ Crafty.extend({
             /**@
              * #Crafty.timer.step
              * @comp Crafty.timer
+             * @kind Method
+             * 
              * @sign public void Crafty.timer.step()
              * @trigger EnterFrame - Triggered on each frame.  Passes the frame number, and the amount of time since the last frame.  If the time is greater than maxTimestep, that will be used instead.  (The default value of maxTimestep is 50 ms.) - { frame: Number, dt:Number }
              * @trigger ExitFrame - Triggered after each frame.  Passes the frame number, and the amount of time since the last frame.  If the time is greater than maxTimestep, that will be used instead.  (The default value of maxTimestep is 50 ms.) - { frame: Number, dt:Number }
@@ -1537,6 +1601,8 @@ Crafty.extend({
             /**@
              * #Crafty.timer.FPS
              * @comp Crafty.timer
+             * @kind Method
+             * 
              * @sign public void Crafty.timer.FPS()
              * Returns the target frames per second. This is not an actual frame rate.
              * @sign public void Crafty.timer.FPS(Number value)
@@ -1561,6 +1627,8 @@ Crafty.extend({
             /**@
              * #Crafty.timer.simulateFrames
              * @comp Crafty.timer
+             * @kind Method
+             * 
              * @sign public this Crafty.timer.simulateFrames(Number frames[, Number timestep])
              * Advances the game state by a number of frames and draws the resulting stage at the end. Useful for tests and debugging.
              * @param frames - number of frames to simulate
@@ -1588,6 +1656,8 @@ Crafty.extend({
     /**@
      * #Crafty.e
      * @category Core
+     * @kind Method
+     * 
      * @trigger NewEntity - When the entity is created and all components are added - { id:Number }
      * @sign public Entity Crafty.e(String componentList)
      * @param componentList - List of components to assign to new entity
@@ -1628,6 +1698,8 @@ Crafty.extend({
     /**@
      * #Crafty.c
      * @category Core
+     * @kind Method
+     * 
      * @sign public void Crafty.c(String name, Object component)
      * @param name - Name of the component
      * @param component - Object with the component's properties and methods
@@ -1704,6 +1776,8 @@ Crafty.extend({
     /**@
      * #Crafty.trigger
      * @category Core, Events
+     * @kind Method
+     * 
      * @sign public void Crafty.trigger(String eventName, * data)
      * @param eventName - Name of the event to trigger
      * @param data - Arbitrary data to pass into the callback as an argument
@@ -1732,6 +1806,8 @@ Crafty.extend({
     /**@
      * #Crafty.bind
      * @category Core, Events
+     * @kind Method
+     * 
      * @sign public Function bind(String eventName, Function callback)
      * @param eventName - Name of the event to bind to
      * @param callback - Method to execute upon event triggered
@@ -1753,6 +1829,8 @@ Crafty.extend({
     /**@
      * #Crafty.uniqueBind
      * @category Core, Events
+     * @kind Method
+     * 
      * @sign public Function uniqueBind(String eventName, Function callback)
      * @param eventName - Name of the event to bind to
      * @param callback - Method to execute upon event triggered
@@ -1770,6 +1848,8 @@ Crafty.extend({
     /**@
      * #Crafty.one
      * @category Core, Events
+     * @kind Method
+     * 
      * @sign public Function one(String eventName, Function callback)
      * @param eventName - Name of the event to bind to
      * @param callback - Method to execute upon event triggered
@@ -1791,6 +1871,8 @@ Crafty.extend({
     /**@
      * #Crafty.unbind
      * @category Core, Events
+     * @kind Method
+     * 
      * @sign public Boolean Crafty.unbind(String eventName, Function callback)
      * @param eventName - Name of the event to unbind
      * @param callback - Function to unbind
@@ -1822,6 +1904,8 @@ Crafty.extend({
     /**@
      * #Crafty.frame
      * @category Core
+     * @kind Method
+     * 
      * @sign public Number Crafty.frame(void)
      * @returns the current frame number
      */
@@ -1848,6 +1932,8 @@ Crafty.extend({
     /**@
      * #Crafty.settings
      * @category Core
+     * @kind CoreObject
+     * 
      * Modify the inner workings of Crafty through the settings.
      */
     settings: (function () {
@@ -1858,6 +1944,8 @@ Crafty.extend({
             /**@
              * #Crafty.settings.register
              * @comp Crafty.settings
+             * @kind Method
+             * 
              * @sign public void Crafty.settings.register(String settingName, Function callback)
              * @param settingName - Name of the setting
              * @param callback - Function to execute when use modifies setting
@@ -1873,6 +1961,8 @@ Crafty.extend({
             /**@
              * #Crafty.settings.modify
              * @comp Crafty.settings
+             * @kind Method
+             * 
              * @sign public void Crafty.settings.modify(String settingName, * value)
              * @param settingName - Name of the setting
              * @param value - Value to set the setting to
@@ -1890,6 +1980,8 @@ Crafty.extend({
             /**@
              * #Crafty.settings.get
              * @comp Crafty.settings
+             * @kind Method
+             * 
              * @sign public * Crafty.settings.get(String settingName)
              * @param settingName - Name of the setting
              * @returns Current value of the setting
@@ -1907,6 +1999,8 @@ Crafty.extend({
     /**@
      * #Crafty.defineField
      * @category Core
+     * @kind Method
+     * 
      * @sign public void Crafty.defineField(Object object, String property, Function getCallback, Function setCallback)
      * @param object - Object to define property on
      * @param property - Property name to assign getter & setter to
@@ -1961,6 +2055,8 @@ function UID() {
 /**@
  * #Crafty.clone
  * @category Core
+ * @kind Method
+ * 
  * @sign public Object .clone(Object obj)
  * @param obj - an object
  *

--- a/src/core/extensions.js
+++ b/src/core/extensions.js
@@ -4,6 +4,8 @@ var document = (typeof window !== "undefined") && window.document;
 /**@
  * #Crafty.support
  * @category Misc, Core
+ * @kind CoreObject
+ * 
  * Determines feature support for what Crafty can do.
  */
 (function testSupport() {
@@ -19,6 +21,7 @@ var document = (typeof window !== "undefined") && window.document;
     /**@
      * #Crafty.mobile
      * @comp Crafty.device
+     * @kind Property
      *
      * Determines if Crafty is running on mobile device.
      *
@@ -36,6 +39,8 @@ var document = (typeof window !== "undefined") && window.document;
     /**@
      * #Crafty.support.defineProperty
      * @comp Crafty.support
+     * @kind Property
+     * 
      * Is `Object.defineProperty` supported?
      */
     support.defineProperty = (function () {
@@ -51,6 +56,8 @@ var document = (typeof window !== "undefined") && window.document;
     /**@
      * #Crafty.support.audio
      * @comp Crafty.support
+     * @kind Property
+     * 
      * Is HTML5 `Audio` supported?
      */
     support.audio = (typeof window !== "undefined") && ('canPlayType' in document.createElement('audio'));
@@ -58,6 +65,8 @@ var document = (typeof window !== "undefined") && window.document;
     /**@
      * #Crafty.support.prefix
      * @comp Crafty.support
+     * @kind Property
+     * 
      * Returns the browser specific prefix (`Moz`, `O`, `ms`, `webkit`, `node`).
      */
     support.prefix = (match[1] || match[0]);
@@ -71,6 +80,8 @@ var document = (typeof window !== "undefined") && window.document;
         /**@
          * #Crafty.support.versionName
          * @comp Crafty.support
+         * @kind Property
+         * 
          * Version of the browser
          */
         support.versionName = match[2];
@@ -78,6 +89,8 @@ var document = (typeof window !== "undefined") && window.document;
         /**@
          * #Crafty.support.version
          * @comp Crafty.support
+         * @kind Property
+         * 
          * Version number of the browser as an Integer (first number)
          */
         support.version = +(match[2].split("."))[0];
@@ -86,6 +99,8 @@ var document = (typeof window !== "undefined") && window.document;
     /**@
      * #Crafty.support.canvas
      * @comp Crafty.support
+     * @kind Property
+     * 
      * Is the `canvas` element supported?
      */
     support.canvas = (typeof window !== "undefined") && ('getContext' in document.createElement("canvas"));
@@ -93,6 +108,8 @@ var document = (typeof window !== "undefined") && window.document;
     /**@
      * #Crafty.support.webgl
      * @comp Crafty.support
+     * @kind Property
+     * 
      * Is WebGL supported on the canvas element?
      */
     if (support.canvas) {
@@ -111,6 +128,8 @@ var document = (typeof window !== "undefined") && window.document;
     /**@
      * #Crafty.support.css3dtransform
      * @comp Crafty.support
+     * @kind Property
+     * 
      * Is css3Dtransform supported by browser.
      */
     support.css3dtransform = (typeof window !== "undefined") && ((typeof document.createElement("div").style.Perspective !== "undefined") || (typeof document.createElement("div").style[support.prefix + "Perspective"] !== "undefined"));
@@ -118,6 +137,7 @@ var document = (typeof window !== "undefined") && window.document;
     /**@
      * #Crafty.support.deviceorientation
      * @comp Crafty.support
+     * @kind Property
      * Is deviceorientation event supported by browser.
      */
     support.deviceorientation = (typeof window !== "undefined") && ((typeof window.DeviceOrientationEvent !== "undefined") || (typeof window.OrientationEvent !== "undefined"));
@@ -125,6 +145,8 @@ var document = (typeof window !== "undefined") && window.document;
     /**@
      * #Crafty.support.devicemotion
      * @comp Crafty.support
+     * @kind Property
+     * 
      * Is devicemotion event supported by browser.
      */
     support.devicemotion = (typeof window !== "undefined") && (typeof window.DeviceMotionEvent !== "undefined");
@@ -137,6 +159,8 @@ module.exports = {
     /**@
      * #Crafty.addEvent
      * @category Events, Misc
+     * @kind Method
+     * 
      * @sign public this Crafty.addEvent(Object ctx, HTMLElement obj, String event, Function callback)
      * @param ctx - Context of the callback or the value of `this`
      * @param obj - Element to add the DOM event to
@@ -194,6 +218,8 @@ module.exports = {
     /**@
      * #Crafty.removeEvent
      * @category Events, Misc
+     * @kind Method
+     * 
      * @sign public this Crafty.removeEvent(Object ctx, HTMLElement obj, String event, Function callback)
      * @param ctx - Context of the callback or the value of `this`
      * @param obj - Element the event is on
@@ -226,6 +252,8 @@ module.exports = {
     /**@
      * #Crafty.background
      * @category Graphics, Stage
+     * @kind Method
+     * 
      * @sign public void Crafty.background(String style)
      * @param style - Modify the background with a color or image
      *

--- a/src/core/loader.js
+++ b/src/core/loader.js
@@ -4,6 +4,8 @@ module.exports = {
     /**@
      * #Crafty.assets
      * @category Assets
+     * @kind Property
+     * 
      * An object containing every asset used in the current Crafty game.
      * The key is the URL and the value is the `Audio` or `Image` object.
      *
@@ -20,6 +22,8 @@ module.exports = {
     /**@
      * #Crafty.paths
      * @category Assets
+     * @kind Method
+     * 
      * @sign public void Crafty.paths([Object paths])
      * @param paths - Object containing paths for audio and images folders
      *
@@ -64,6 +68,8 @@ module.exports = {
     /**@
      * #Crafty.asset
      * @category Assets
+     * @kind Method
+     * 
      * @trigger NewAsset - After setting new asset - Object - key and value of new added asset.
      * @sign public void Crafty.asset(String key, Object asset)
      * @param key - asset url.
@@ -102,6 +108,7 @@ module.exports = {
     /**@
      * #Crafty.image_whitelist
      * @category Assets
+     * @kind Method
      *
      * A list of file extensions that can be loaded as images by Crafty.load
      *
@@ -144,6 +151,8 @@ module.exports = {
     /**@
      * #Crafty.load
      * @category Assets
+     * @kind Method
+     * 
      * @sign public void Crafty.load(Object assets, Function onLoad[, Function onProgress[, Function onError]])
      * @param assets - Object JSON formatted (or JSON string), with assets to load (accepts sounds, images and sprites)
      * @param onLoad - Callback when the assets are loaded
@@ -359,6 +368,7 @@ module.exports = {
     /**@
      * #Crafty.removeAssets
      * @category Assets
+     * @kind Method
      *
      * @sign public void Crafty.removeAssets(Object assets)
      * @param data - Object JSON formatted (or JSON string), with assets to remove (accepts sounds, images and sprites)

--- a/src/core/model.js
+++ b/src/core/model.js
@@ -4,6 +4,8 @@ var Crafty = require('../core/core.js');
 /**@
  * #Model
  * @category Model
+ * @kind Component
+ * 
  * Model is a component that offers new features for isolating business
  * logic in your application. It offers default values, dirty values,
  * and deep events on your data.
@@ -76,6 +78,8 @@ module.exports = {
   /**@
    * #.is_dirty
    * @comp Model
+   * @kind Method
+   * 
    * Helps determine when data or the entire component is "dirty" or has changed attributes.
    *
    * @example

--- a/src/core/scenes.js
+++ b/src/core/scenes.js
@@ -8,6 +8,8 @@ module.exports = {
     /**@
      * #Crafty.scene
      * @category Scenes, Stage
+     * @kind Method
+     * 
      * @trigger SceneChange - just before a new scene is initialized - { oldScene:String, newScene:String }
      * @trigger SceneDestroy - just before the current scene is destroyed - { newScene:String  }
      *
@@ -94,6 +96,7 @@ module.exports = {
     /* 
      * #Crafty.defineScene
      * @category Scenes, Stage
+     * @kind Method
      *
      * @sign public void Crafty.enterScene(String name[, Data])
      * @param name - Name of the scene to run.
@@ -117,6 +120,8 @@ module.exports = {
     /* 
      * #Crafty.enterScene
      * @category Scenes, Stage
+     * @kind Method
+     * 
      * @trigger SceneChange - just before a new scene is initialized - { oldScene:String, newScene:String }
      * @trigger SceneDestroy - just before the current scene is destroyed - { newScene:String  }
      *

--- a/src/core/storage.js
+++ b/src/core/storage.js
@@ -10,6 +10,8 @@ try {
 /**@
  * #Storage
  * @category Utilities
+ * @kind Component
+ * 
  * Very simple way to get and set values, which will persist when the browser is closed also.
  * Storage wraps around HTML5 Web Storage, which is well-supported across browsers and platforms, but limited to 5MB total storage per domain.
  * Storage is also available for node, which is permanently persisted to the `./localStorage` folder - take care of removing entries. Note that multiple Crafty instances use the same storage, so care has to be taken not to overwrite existing entries.
@@ -17,6 +19,8 @@ try {
 /**@
  * #Crafty.storage
  * @comp Storage
+ * @kind Method
+ * 
  * @sign Crafty.storage(String key)
  * @param key - a key you would like to get from the storage. 
  * @returns The stored value, or `null` if none saved under that key exists
@@ -91,6 +95,8 @@ var store = function(key, value) {
 /**@
  * #Crafty.storage.remove
  * @comp Storage
+ * @kind Method
+ * 
  * @sign Crafty.storage.remove(String key)
  * @param key - a key where you will like to delete the value of.
  *

--- a/src/core/systems.js
+++ b/src/core/systems.js
@@ -7,6 +7,7 @@ Crafty._systems = {};
 /**@
  * #Crafty.s
  * @category Core
+ * @kind Method
  *
  * Registers a system.
  *

--- a/src/core/time.js
+++ b/src/core/time.js
@@ -1,6 +1,7 @@
 /**@
  * #Delay
  * @category Utilities
+ * @kind Component
  *
  * A component for triggering functions after a given amount of time.
  *
@@ -40,6 +41,7 @@ module.exports = {
     /**@
      * #.delay
      * @comp Delay
+     * @kind Method
      * @sign public this.delay(Function callback, Number delay[, Number repeat[, Function callbackOff]])
      * @param callback - Method to execute after given amount of milliseconds. If reference of a
      * method is passed, there's possibility to cancel the delay.
@@ -92,6 +94,8 @@ module.exports = {
     /**@
      * #.cancelDelay
      * @comp Delay
+     * @kind Method
+     * 
      * @sign public this.cancelDelay(Function callback)
      * @param callback - Method reference passed to .delay
      *
@@ -123,6 +127,8 @@ module.exports = {
     /**@
      * #.pauseDelays
      * @comp Delay
+     * @kind Method
+     * 
      * @sign public this.pauseDelays()
      *
      * The pauseDelays method will pause all delays of this
@@ -147,6 +153,8 @@ module.exports = {
     /**@
      * #.resumeDelays
      * @comp Delay
+     * @kind Method
+     * 
      * @sign public this.resumeDelays()
      *
      * The resumeDelays method will resume earlier paused delays for this

--- a/src/core/tween.js
+++ b/src/core/tween.js
@@ -4,6 +4,8 @@ var Crafty = require('../core/core.js');
 /**@
  * #Tween
  * @category Animation
+ * @kind Component
+ * 
  * @trigger TweenEnd - when a tween finishes - String - property
  *
  * Component to animate the change in 2D properties over time.
@@ -43,6 +45,8 @@ module.exports = {
   /**@
   * #.tween
   * @comp Tween
+  * @kind Method
+  *
   * @sign public this .tween(Object properties, Number duration[, String|function easingFn])
   * @param properties - Object of numeric properties and what they should animate to
   * @param duration - Duration to animate the properties over, in milliseconds.
@@ -98,6 +102,8 @@ module.exports = {
   /**@
   * #.cancelTween
   * @comp Tween
+  * @kind Method
+  *
   * @sign public this .cancelTween(String target)
   * @param target - The property to cancel
   *
@@ -123,6 +129,8 @@ module.exports = {
   /**@
   * #.pauseTweens
   * @comp Tween
+  * @kind Method
+  *
   * @sign public this .pauseTweens()
   *
   * Pauses all tweens associated with the entity
@@ -132,8 +140,10 @@ module.exports = {
   },
 
   /**@
-  * #.resumeTWeens
+  * #.resumeTweens
   * @comp Tween
+  * @kind Method
+  *
   * @sign public this .resumeTweens()
   *
   * Resumes all paused tweens associated with the entity

--- a/src/crafty-headless.js
+++ b/src/crafty-headless.js
@@ -18,6 +18,8 @@ module.exports = function() {
     requireNew('./core/version');
 
     requireNew('./spatial/2d');
+    require('./spatial/motion');
+    require('./spatial/platform');
     requireNew('./spatial/collision');
     requireNew('./spatial/spatial-grid');
     requireNew('./spatial/rect-manager');

--- a/src/crafty.js
+++ b/src/crafty.js
@@ -12,6 +12,8 @@ Crafty.c('Tween', require('./core/tween'));
 require('./core/systems');
 
 require('./spatial/2d');
+require('./spatial/motion');
+require('./spatial/platform');
 require('./spatial/collision');
 require('./spatial/spatial-grid');
 require('./spatial/rect-manager');

--- a/src/debug/debug-layer.js
+++ b/src/debug/debug-layer.js
@@ -4,6 +4,8 @@ var Crafty = require('../core/core.js'),
 /**@
  * #DebugCanvas
  * @category Debug
+ * @kind Component
+ * 
  * @trigger DebugDraw - when the entity is ready to be drawn to the stage
  * @trigger NoCanvas - if the browser does not support canvas
  *
@@ -43,6 +45,8 @@ Crafty.c("DebugCanvas", {
     /**@
      * #.debugAlpha
      * @comp DebugCanvas
+     * @kind Method
+     * 
      * @sign public  .debugAlpha(Number alpha)
      * @param alpha - The alpha level the component will be drawn with
      */
@@ -54,6 +58,8 @@ Crafty.c("DebugCanvas", {
     /**@
      * #.debugFill
      * @comp DebugCanvas
+     * @kind Method
+     * 
      * @sign public  .debugFill([String fillStyle])
      * @param fillStyle - The color the component will be filled with.  Defaults to "red". Pass the boolean false to turn off filling.
      * @example
@@ -71,6 +77,8 @@ Crafty.c("DebugCanvas", {
     /**@
      * #.debugStroke
      * @comp DebugCanvas
+     * @kind Method
+     * 
      * @sign public  .debugStroke([String strokeStyle])
      * @param strokeStyle - The color the component will be outlined with.  Defaults to "red".  Pass the boolean false to turn this off.
      * @example
@@ -115,6 +123,7 @@ Crafty.c("DebugCanvas", {
 /**@
  * #DebugRectangle
  * @category Debug
+ * @kind Component
  *
  * A component for rendering an object with a position and dimensions to the debug canvas.
  *
@@ -135,6 +144,8 @@ Crafty.c("DebugRectangle", {
     /**@
      * #.debugRectangle
      * @comp DebugRectangle
+     * @kind Method
+     * 
      * @sign public  .debugRectangle(Object rect)
      * @param rect - an object with _x, _y, _w, and _h to draw
      *
@@ -172,6 +183,7 @@ Crafty.c("DebugRectangle", {
 /**@
  * #VisibleMBR
  * @category Debug
+ * @kind Component
  *
  * Adding this component to an entity will cause it's MBR to be drawn to the debug canvas.
  *
@@ -201,6 +213,7 @@ Crafty.c("VisibleMBR", {
 /**@
  * #DebugPolygon
  * @category Debug
+ * @kind Component
  *
  * For drawing a polygon to the debug canvas
  *
@@ -219,6 +232,8 @@ Crafty.c("DebugPolygon", {
     /**@
      * #.debugPolygon
      * @comp DebugPolygon
+     * @kind Method
+     * 
      * @sign public  .debugPolygon(Polygon poly)
      * @param poly - a polygon to render
      *
@@ -254,6 +269,7 @@ Crafty.c("DebugPolygon", {
 /**@
  * #WiredHitBox
  * @category Debug
+ * @kind Component
  *
  * Adding this component to an entity with a Collision component will cause its collision polygon to be drawn to the debug canvas as an outline
  *
@@ -275,6 +291,7 @@ Crafty.c("WiredHitBox", {
 /**@
  * #SolidHitBox
  * @category Debug
+ * @kind Component
  *
  * Adding this component to an entity with a Collision component will cause its collision polygon to be drawn to the debug canvas, with a default alpha level of 0.7.
  *
@@ -296,6 +313,7 @@ Crafty.c("SolidHitBox", {
 /**@
  * #WiredAreaMap
  * @category Debug
+ * @kind Component
  *
  * Adding this component to an entity with an AreaMap component will cause its click polygon to be drawn to the debug canvas as an outline.
  * Following click areas exist for an entity (in decreasing order of priority): AreaMap, Hitbox, MBR. Use the appropriate debug components to display them.
@@ -318,6 +336,7 @@ Crafty.c("WiredAreaMap", {
 /**@
  * #SolidAreaMap
  * @category Debug
+ * @kind Component
  *
  * Adding this component to an entity with an AreaMap component will cause its click polygon to be drawn to the debug canvas, with a default alpha level of 0.7.
  * Following click areas exist for an entity (in decreasing order of priority): AreaMap, Hitbox, MBR. Use the appropriate debug components to display them.

--- a/src/debug/logging.js
+++ b/src/debug/logging.js
@@ -4,6 +4,7 @@ var Crafty = require('../core/core.js');
 /**@
  * #Crafty.log
  * @category Debug
+ * @kind Method
  *
  * @sign Crafty.log( arguments )
  * @param arguments - arguments which are passed to `console.log`
@@ -14,6 +15,7 @@ var Crafty = require('../core/core.js');
 /**@
  * #Crafty.error
  * @category Debug
+ * @kind Method
  *
  * @sign Crafty.error( arguments )
  * @param arguments - arguments which are passed to `console.error`

--- a/src/graphics/canvas-layer.js
+++ b/src/graphics/canvas-layer.js
@@ -4,6 +4,7 @@ var Crafty = require('../core/core.js');
 /**@
  * #CanvasLayer
  * @category Graphics
+ * @kind System
  *
  * An object for creating the canvas layer system.
  *
@@ -32,6 +33,9 @@ Crafty._registerLayerTemplate("Canvas", {
     /**@
      * #.dirty
      * @comp CanvasLayer
+     * @kind Method
+     * @private
+     * 
      * @sign public .dirty(ent)
      * @param ent - The entity to add
      *
@@ -44,6 +48,9 @@ Crafty._registerLayerTemplate("Canvas", {
     /**@
      * #.attach
      * @comp CanvasLayer
+     * @kind Method
+     * @private
+     * 
      * @sign public .attach(ent)
      * @param ent - The entity to add
      *
@@ -58,8 +65,11 @@ Crafty._registerLayerTemplate("Canvas", {
     /**@
      * #.detach
      * @comp CanvasLayer
+     * @kind Method
+     * @private
+     * 
      * @sign public .detach(ent)
-     * @param ent - The entity to add
+     * @param ent - The entity to detach
      *
      * Removes an entity to the list of Canvas objects to draw
      */
@@ -74,6 +84,7 @@ Crafty._registerLayerTemplate("Canvas", {
     /**@
      * #.context
      * @comp CanvasLayer
+     * @kind Property
      *
      * This will return the 2D context associated with the canvas layer's canvas element.
      */
@@ -82,6 +93,8 @@ Crafty._registerLayerTemplate("Canvas", {
     /**@
      * #._canvas
      * @comp CanvasLayer
+     * @kind Property
+     * @private
      *
      * The canvas element associated with the canvas layer.
      */
@@ -176,6 +189,9 @@ Crafty._registerLayerTemplate("Canvas", {
     /**@
      * #._drawDirty
      * @comp CanvasLayer
+     * @kind Method
+     * @private
+     * 
      * @sign public ._drawDirty()
      *
      * - Triggered by the "RenderScene" event
@@ -276,6 +292,9 @@ Crafty._registerLayerTemplate("Canvas", {
     /**@
      * #._drawAll
      * @comp CanvasLayer
+     * @kind Method
+     * @private
+     * 
      * @sign public CanvasLayer.drawAll([Object rect])
      * @param rect - a rectangular region {_x: x_val, _y: y_val, _w: w_val, _h: h_val}
      *

--- a/src/graphics/canvas.js
+++ b/src/graphics/canvas.js
@@ -4,6 +4,8 @@ var Crafty = require('../core/core.js');
 /**@
  * #Canvas
  * @category Graphics
+ * @kind Component
+ * 
  * @trigger Draw - when the entity is ready to be drawn to the stage - {type: "canvas", pos, co, ctx}
  * @trigger NoCanvas - if the browser does not support canvas
  *
@@ -40,6 +42,8 @@ Crafty.c("Canvas", {
     /**@
      * #.draw
      * @comp Canvas
+     * @kind Method
+     * 
      * @sign public this .draw([[Context ctx, ]Number x, Number y, Number w, Number h])
      * @param ctx - Canvas 2D context if drawing on another canvas is required
      * @param x - X offset for drawing a segment

--- a/src/graphics/color.js
+++ b/src/graphics/color.js
@@ -7,6 +7,10 @@ var Crafty = require('../core/core.js'),
 /**@
  * #Crafty.assignColor
  * @category Graphics
+ * @kind Method
+ * 
+ * Maps a wide vareity of color representations to a set of simple rgb(a) properties. 
+ * 
  * @sign Crafty.assignColor(color[, assignee])
  * @param color - a string represenation of the color to assign, in any valid HTML format
  * @param assignee - an object to use instead of creating one from scratch
@@ -165,6 +169,8 @@ Crafty.defaultShader("Color", new Crafty.WebGLShader(
 /**@
  * #Color
  * @category Graphics
+ * @kind Component
+ * 
  * Draw a colored rectangle.
  */
 Crafty.c("Color", {
@@ -218,6 +224,8 @@ Crafty.c("Color", {
     /**@
      * #.color
      * @comp Color
+     * @kind Method
+     * 
      * @trigger Invalidate - when the color changes
      *
      * Will assign the color and opacity, either through a string shorthand, or through explicit rgb values.

--- a/src/graphics/dom-helper.js
+++ b/src/graphics/dom-helper.js
@@ -4,6 +4,7 @@ var Crafty = require('../core/core.js'),
 Crafty.extend({
     /**@
      * #Crafty.domHelper
+     * @kind Property
      * @category Graphics
      *
      * Collection of utilities for using the DOM.
@@ -40,6 +41,8 @@ Crafty.extend({
         /**@
          * #Crafty.domHelper.getStyle
          * @comp Crafty.domHelper
+         * @kind Method
+         * 
          * @sign public Object Crafty.domHelper.getStyle(HTMLElement obj, String property)
          * @param obj - HTML element to find the style
          * @param property - Style to return
@@ -79,6 +82,8 @@ Crafty.extend({
         /**@
          * #Crafty.domHelper.translate
          * @comp Crafty.domHelper
+         * @kind Method
+         * 
          * @sign public Object Crafty.domHelper.translate(Number clientX, Number clientY[, DrawLayer layer])
          * @param clientX - clientX position in the browser screen
          * @param clientY - clientY position in the browser screen

--- a/src/graphics/dom-layer.js
+++ b/src/graphics/dom-layer.js
@@ -5,6 +5,7 @@ var Crafty = require('../core/core.js'),
 /**@
  * #DomLayer
  * @category Graphics
+ * @kind System
  *
  * Collection of mostly private methods to represent entities using the DOM.
  */
@@ -23,6 +24,9 @@ Crafty._registerLayerTemplate("DOM", {
     /**@
      * #._div
      * @comp DomLayer
+     * @kind Property
+     * @private
+     * 
      * A div inside the `#cr-stage` div that holds all DOM entities.
      */
     _div: null,
@@ -83,7 +87,11 @@ Crafty._registerLayerTemplate("DOM", {
     /**@
      * #.debug
      * @comp DomLayer
+     * @kind Method
+     * 
      * @sign public .debug()
+     * 
+     * Logs the current list of entities that have been invalidated in this layer.
      */
     debug: function () {
         Crafty.log(this._changedObjs);
@@ -93,6 +101,9 @@ Crafty._registerLayerTemplate("DOM", {
     /**@
      * #._render
      * @comp DomLayer
+     * @kind Method
+     * @private
+     * 
      * @sign public .render()
      *
      * When "RenderScene" is triggered, draws all DOM entities that have been flagged
@@ -125,6 +136,9 @@ Crafty._registerLayerTemplate("DOM", {
     /**@
      * #.dirty
      * @comp DomLayer
+     * @kind Method
+     * @private
+     * 
      * @sign public .dirty(ent)
      * @param ent - The entity to mark as dirty
      *
@@ -137,6 +151,9 @@ Crafty._registerLayerTemplate("DOM", {
     /**@
      * #.attach
      * @comp DomLayer
+     * @kind Method
+     * @private
+     * 
      * @sign public .attach(ent)
      * @param ent - The entity to add
      *
@@ -154,6 +171,9 @@ Crafty._registerLayerTemplate("DOM", {
     /**@
      * #.detach
      * @comp DomLayer
+     * @kind Method
+     * @private
+     * 
      * @sign public .detach(ent)
      * @param ent - The entity to remove
      *

--- a/src/graphics/dom.js
+++ b/src/graphics/dom.js
@@ -4,6 +4,7 @@ var Crafty = require('../core/core.js'),
 /**@
  * #DOM
  * @category Graphics
+ * @kind Component
  *
  * A component which renders entities as DOM nodes, specifically `<div>`s.
  */
@@ -11,6 +12,7 @@ Crafty.c("DOM", {
     /**@
      * #._element
      * @comp DOM
+     * @kind Property
      * The DOM element used to represent the entity.
      */
     _element: null,
@@ -20,6 +22,8 @@ Crafty.c("DOM", {
     /**@
      * #.avoidCss3dTransforms
      * @comp DOM
+     * @kind Property
+     * 
      * Avoids using of CSS 3D Transform for positioning when true. Default value is false.
      */
     avoidCss3dTransforms: false,
@@ -58,6 +62,8 @@ Crafty.c("DOM", {
     /**@
      * #.getDomId
      * @comp DOM
+     * @kind Method
+     * 
      * @sign public this .getId()
      *
      * Get the Id of the DOM element used to represent the entity.
@@ -95,6 +101,8 @@ Crafty.c("DOM", {
     /**@
      * #.DOM
      * @comp DOM
+     * @kind Method
+     * 
      * @trigger Draw - when the entity is ready to be drawn to the stage - { style:String, type:"DOM", co}
      * @sign public this .DOM(HTMLElement elem)
      * @param elem - HTML element that will replace the dynamically created one
@@ -116,6 +124,9 @@ Crafty.c("DOM", {
     /**@
      * #.draw
      * @comp DOM
+     * @kind Method
+     * @private
+     * 
      * @sign public this .draw(void)
      *
      * Updates the CSS properties of the node to draw on the stage.
@@ -208,6 +219,8 @@ Crafty.c("DOM", {
     /**@
      * #.css
      * @comp DOM
+     * @kind Method
+     * 
      * @sign public css(String property, String value)
      * @param property - CSS property to modify
      * @param value - Value to give the CSS property

--- a/src/graphics/drawing.js
+++ b/src/graphics/drawing.js
@@ -4,6 +4,8 @@ Crafty.extend({
     /**@
      * #Crafty.pixelart
      * @category Graphics
+     * @kind Method
+     * 
      * @sign public void Crafty.pixelart(Boolean enabled)
      * @param enabled - whether to preserve sharp edges when rendering images
      *

--- a/src/graphics/html.js
+++ b/src/graphics/html.js
@@ -4,6 +4,7 @@ var Crafty = require('../core/core.js');
 /**@
  * #HTML
  * @category Graphics
+ * @kind Component
  *
  * A component which allows for the insertion of arbitrary HTML into a DOM entity.  
  *
@@ -19,6 +20,8 @@ Crafty.c("HTML", {
     /**@
      * #.replace
      * @comp HTML
+     * @kind Method
+     * 
      * @sign public this .replace(String html)
      * @param html - arbitrary html
      *
@@ -41,6 +44,8 @@ Crafty.c("HTML", {
     /**@
      * #.append
      * @comp HTML
+     * @kind Method
+     * 
      * @sign public this .append(String html)
      * @param html - arbitrary html
      *
@@ -63,6 +68,8 @@ Crafty.c("HTML", {
     /**@
      * #.prepend
      * @comp HTML
+     * @kind Method
+     * 
      * @sign public this .prepend(String html)
      * @param html - arbitrary html
      *

--- a/src/graphics/image.js
+++ b/src/graphics/image.js
@@ -29,6 +29,8 @@ Crafty.defaultShader("Image", new Crafty.WebGLShader(
 /**@
  * #Image
  * @category Graphics
+ * @kind Component
+ * 
  * Draw an image with or without repeating (tiling).
  */
 Crafty.c("Image", {
@@ -48,6 +50,8 @@ Crafty.c("Image", {
     /**@
      * #.image
      * @comp Image
+     * @kind Method
+     * 
      * @trigger Invalidate - when the image is loaded
      * @sign public this .image(String url[, String repeat])
      * @param url - URL of the image

--- a/src/graphics/layers.js
+++ b/src/graphics/layers.js
@@ -45,6 +45,7 @@ Crafty.extend({
 
     /**@
      * #Crafty.createLayer
+     * @kind Method
      * @category Graphics
      *
      * @sign public void Crafty.createLayer(string name, string type[, object options])

--- a/src/graphics/particles.js
+++ b/src/graphics/particles.js
@@ -4,6 +4,8 @@ var Crafty = require('../core/core.js'),
 /**@
  * #Particles
  * @category Graphics
+ * @kind Component
+ * 
  * @trigger ParticleEnd - when the particle animation has finished
  *
  * Based on Parcycle by Mr. Speaker, licensed under the MIT, Ported by Leo Koppelkamm
@@ -23,6 +25,8 @@ Crafty.c("Particles", {
     /**@
      * #.particles
      * @comp Particles
+     * @kind Method
+     * 
      * @sign public this .particles(Object options)
      * @param options - Map of options that specify the behavior and look of the particles.
      *
@@ -386,6 +390,8 @@ Crafty.c("Particles", {
     /**@
      * #.pauseParticles
      * @comp Particles
+     * @kind Method
+     * 
      * @sign public this.pauseParticles()
      *
      * The pauseParticles will freeze these particles in execution.
@@ -406,6 +412,8 @@ Crafty.c("Particles", {
     /**@
      * #.resumeParticles
      * @comp Particles
+     * @kind Method
+     * 
      * @sign public this.resumeParticles()
      *
      * The resumeParticles will resume earlier paused particles

--- a/src/graphics/renderable.js
+++ b/src/graphics/renderable.js
@@ -4,6 +4,8 @@ var Crafty = require('../core/core.js');
 /**@
  * #Renderable
  * @category Graphics
+ * @kind Component
+ * 
  * Component for any entity that has a position on the stage.
  * @trigger Invalidate - when the entity needs to be redrawn
  */
@@ -15,6 +17,8 @@ Crafty.c("Renderable", {
     /**@
      * #.alpha
      * @comp Renderable
+     * @kind Property
+     * 
      * Transparency of an entity. Must be a decimal value between 0.0 being fully transparent to 1.0 being fully opaque.
      */
     _alpha: 1.0,
@@ -22,6 +26,8 @@ Crafty.c("Renderable", {
     /**@
      * #.visible
      * @comp Renderable
+     * @kind Property
+     * 
      * If the entity is visible or not. Accepts a true or false value.
      * Can be used for optimization by setting an entities visibility to false when not needed to be drawn.
      *
@@ -116,6 +122,8 @@ Crafty.c("Renderable", {
     /**@
      * #.flip
      * @comp Renderable
+     * @kind Method
+     * 
      * @trigger Invalidate - when the entity has flipped
      * @sign public this .flip(String dir)
      * @param dir - Flip direction
@@ -139,6 +147,8 @@ Crafty.c("Renderable", {
     /**@
      * #.unflip
      * @comp Renderable
+     * @kind Method
+     * 
      * @trigger Invalidate - when the entity has unflipped
      * @sign public this .unflip(String dir)
      * @param dir - Unflip direction

--- a/src/graphics/sprite-animation.js
+++ b/src/graphics/sprite-animation.js
@@ -4,6 +4,8 @@ var Crafty = require('../core/core.js');
 /**@
  * #SpriteAnimation
  * @category Animation
+ * @kind Component
+ * 
  * @trigger StartAnimation - When an animation starts playing, or is resumed from the paused state - {Reel}
  * @trigger AnimationEnd - When the animation finishes - { Reel }
  * @trigger FrameChange - Each time the frame of the current reel changes - { Reel }
@@ -67,6 +69,8 @@ Crafty.c("SpriteAnimation", {
     /**@
      * #.reel
      * @comp SpriteAnimation
+     * @kind Method
+     * 
      * Used to define reels, to change the active reel, and to fetch the id of the active reel.
      *
      * @sign public this .reel(String reelId, Duration duration, Number fromX, Number fromY, Number frameCount[, Number rowLength])
@@ -191,6 +195,8 @@ Crafty.c("SpriteAnimation", {
     /**@
      * #.animate
      * @comp SpriteAnimation
+     * @kind Method
+     * 
      * @sign public this .animate([String reelId] [, Number loopCount])
      * @param reelId - ID of the animation reel to play.  Defaults to the current reel if none is specified.
      * @param loopCount - Number of times to repeat the animation. Use -1 to repeat indefinitely.  Defaults to 1.
@@ -258,6 +264,8 @@ Crafty.c("SpriteAnimation", {
     /**@
      * #.resumeAnimation
      * @comp SpriteAnimation
+     * @kind Method
+     * 
      * @sign public this .resumeAnimation()
      *
      * This will resume animation of the current reel from its current state.
@@ -277,6 +285,8 @@ Crafty.c("SpriteAnimation", {
     /**@
      * #.pauseAnimation
      * @comp SpriteAnimation
+     * @kind Method
+     * 
      * @sign public this .pauseAnimation(void)
      *
      * Pauses the currently playing animation, or does nothing if no animation is playing.
@@ -294,6 +304,8 @@ Crafty.c("SpriteAnimation", {
     /**@
      * #.resetAnimation
      * @comp SpriteAnimation
+     * @kind Method
+     * 
      * @sign public this .resetAnimation()
      *
      * Resets the current animation to its initial state.  Resets the number of loops to the last specified value, which defaults to 1.
@@ -314,6 +326,8 @@ Crafty.c("SpriteAnimation", {
     /**@
      * #.loops
      * @comp SpriteAnimation
+     * @kind Method
+     * 
      * @sign public this .loops(Number loopCount)
      * @param loopCount - The number of times to play the animation
      *
@@ -343,6 +357,8 @@ Crafty.c("SpriteAnimation", {
 
     /**@
      * #.reelPosition
+     * @kind Method
+     * 
      * @comp SpriteAnimation
      *
      * @sign public this .reelPosition(Integer position)
@@ -441,6 +457,8 @@ Crafty.c("SpriteAnimation", {
     /**@
      * #.isPlaying
      * @comp SpriteAnimation
+     * @kind Method
+     * 
      * @sign public Boolean .isPlaying([String reelId])
      * @param reelId - The reelId of the reel we wish to examine
      * @returns The current animation state
@@ -463,6 +481,8 @@ Crafty.c("SpriteAnimation", {
     /**@
      * #.getReel
      * @comp SpriteAnimation
+     * @kind Method
+     * 
      * @sign public Reel .getReel()
      * @returns The current reel, or null if there is no active reel
      *

--- a/src/graphics/sprite.js
+++ b/src/graphics/sprite.js
@@ -27,6 +27,8 @@ Crafty.defaultShader("Sprite", new Crafty.WebGLShader(
 Crafty.extend({
     /**@
      * #Crafty.sprite
+     * @kind Method
+     * 
      * @category Graphics
      * @sign public this Crafty.sprite([Number tile, [Number tileh]], String url, Object map[, Number paddingX[, Number paddingY[, Boolean paddingAroundBorder]]])
      * @param tile - Tile size of the sprite map, defaults to 1
@@ -168,6 +170,8 @@ Crafty.extend({
 /**@
  * #Sprite
  * @category Graphics
+ * @kind Component
+ * 
  * @trigger Invalidate - when the sprites change
  *
  * A component for using tiles in a sprite map.

--- a/src/graphics/text.js
+++ b/src/graphics/text.js
@@ -4,6 +4,8 @@ var Crafty = require('../core/core.js');
 /**@
  * #Text
  * @category Graphics
+ * @kind Component
+ * 
  * @trigger Invalidate - when the text is changed
  * @requires Canvas or DOM
  * Component to make a text entity.
@@ -109,6 +111,8 @@ Crafty.c("Text", {
     /**@
      * #.text
      * @comp Text
+     * @kind Method
+     * 
      * @sign public this .text(String text)
      * @param text - String of text that will be inserted into the DOM or Canvas element.
      *
@@ -158,6 +162,8 @@ Crafty.c("Text", {
     /**@
      * #.dynamicTextGeneration
      * @comp Text
+     * @kind Method
+     * 
      * @sign public this .dynamicTextGeneration(bool dynamicTextOn[, string textUpdateEvent])
      * @param dynamicTextOn - A flag that indicates whether dyanamic text should be on or off.
      * @param textUpdateEvent - The name of the event which will trigger text to be updated.  Defaults to "EnterFrame".  (This parameter does nothing if dynamicTextOn is false.)
@@ -220,6 +226,8 @@ Crafty.c("Text", {
     /**@
      * #.textColor
      * @comp Text
+     * @kind Method
+     * 
      * @sign public this .textColor(String color)
      * @param color - The color in name, hex, rgb or rgba
      *
@@ -249,6 +257,8 @@ Crafty.c("Text", {
 
     /**@
      * @comp Text
+     * @kind Method
+     * 
      * @sign public this .textAlign(String alignment)
      * @param alignment - The new alignment of the text.
      *
@@ -265,6 +275,8 @@ Crafty.c("Text", {
     /**@
      * #.textFont
      * @comp Text
+     * @kind Method
+     * 
      * @triggers Invalidate
      * @sign public this .textFont(String key, * value)
      * @param key - Property of the entity to modify
@@ -315,6 +327,8 @@ Crafty.c("Text", {
     /**@
      * #.unselectable
      * @comp Text
+     * @kind Method
+     * 
      * @triggers Invalidate
      * @sign public this .unselectable()
      *

--- a/src/graphics/viewport.js
+++ b/src/graphics/viewport.js
@@ -5,6 +5,8 @@ Crafty.extend({
     /**@
      * #Crafty.viewport
      * @category Stage
+     * @kind Property
+     * 
      * @trigger ViewportScroll - when the viewport's x or y coordinates change
      * @trigger ViewportScale - when the viewport's scale changes
      * @trigger ViewportResize - when the viewport's dimension's change
@@ -45,6 +47,7 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.clampToEntities
          * @comp Crafty.viewport
+         * @kind Property
          *
          * Decides if the viewport functions should clamp to game entities.
          * When set to `true` functions such as Crafty.viewport.mouselook() will not allow you to move the
@@ -57,6 +60,7 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.x
          * @comp Crafty.viewport
+         * @kind Property
          *
          * Will move the stage and therefore every visible entity along the `x`
          * axis in the opposite direction.
@@ -69,6 +73,7 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.y
          * @comp Crafty.viewport
+         * @kind Property
          *
          * Will move the stage and therefore every visible entity along the `y`
          * axis in the opposite direction.
@@ -82,6 +87,7 @@ Crafty.extend({
         /**@
          * #Crafty.viewport._scale
          * @comp Crafty.viewport
+         * @kind Property
          *
          * This value is the current scale (zoom) of the viewport. When the value is bigger than 1, everything
          * looks bigger (zoomed in). When the value is less than 1, everything looks smaller (zoomed out). This
@@ -96,6 +102,7 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.bounds
          * @comp Crafty.viewport
+         * @kind Property
          *
          * A rectangle which defines the bounds of the viewport.
          * It should be an object with two properties, `max` and `min`,
@@ -120,6 +127,8 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.scroll
          * @comp Crafty.viewport
+         * @kind Method
+         * 
          * @sign Crafty.viewport.scroll(String axis, Number val)
          * @param axis - 'x' or 'y'
          * @param val - The new absolute position on the axis
@@ -145,6 +154,8 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.rect
          * @comp Crafty.viewport
+         * @kind Method
+         * 
          * @sign public Object Crafty.viewport.rect([Object out])
          * @param Object out - an optional Object to write the `rect` to
          * @return a rectangle encompassing the currently visible viewport region.
@@ -178,6 +189,8 @@ Crafty.extend({
 
          * #Crafty.viewport.pan
          * @comp Crafty.viewport
+         * @kind Method
+         * 
          * @sign public void Crafty.viewport.pan(Number dx, Number dy, Number time[, String|function easingFn])
          * @param Number dx - The distance along the x axis
          * @param Number dy - The distance along the y axis
@@ -239,6 +252,8 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.follow
          * @comp Crafty.viewport
+         * @kind Method
+         * 
          * @sign public void Crafty.viewport.follow(Object target, Number offsetx, Number offsety)
          * @param Object target - An entity with the 2D component
          * @param Number offsetx - Follow target's center should be offsetx pixels away from viewport's center. Positive values puts target to the right of the screen.
@@ -292,6 +307,8 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.centerOn
          * @comp Crafty.viewport
+         * @kind Method
+         * 
          * @sign public void Crafty.viewport.centerOn(Object target, Number time)
          * @param Object target - An entity with the 2D component
          * @param Number time - The duration in ms of the camera motion
@@ -320,6 +337,8 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.zoom
          * @comp Crafty.viewport
+         * @kind Method
+         * 
          * @sign public void Crafty.viewport.zoom(Number amt, Number cent_x, Number cent_y, Number time[, String|function easingFn])
          * @param Number amt - amount to zoom in on the target by (eg. 2, 4, 0.5)
          * @param Number cent_x - the center to zoom on
@@ -416,6 +435,8 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.scale
          * @comp Crafty.viewport
+         * @kind Method
+         * 
          * @sign public void Crafty.viewport.scale(Number amt)
          * @param Number amt - amount to zoom/scale in on the elements
          *
@@ -443,9 +464,12 @@ Crafty.extend({
 
             };
         })(),
+
         /**@
          * #Crafty.viewport.mouselook
          * @comp Crafty.viewport
+         * @kind Method
+         * 
          * @sign public void Crafty.viewport.mouselook(Boolean active)
          * @param Boolean active - Activate or deactivate mouselook
          *
@@ -531,6 +555,8 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.init
          * @comp Crafty.stage
+         * @kind Method
+         * 
          * @sign public void Crafty.viewport.init([Number width, Number height, String stage_elem])
          * @sign public void Crafty.viewport.init([Number width, Number height, HTMLElement stage_elem])
          * @param Number width - Width of the viewport
@@ -579,12 +605,16 @@ Crafty.extend({
             /**@
              * #Crafty.stage
              * @category Core
+             * @kind CoreObject
+             * 
              * The stage where all the DOM entities will be placed.
              */
 
             /**@
              * #Crafty.stage.elem
              * @comp Crafty.stage
+             * @kind Property
+             * 
              * The `#cr-stage` div element.
              */
 
@@ -738,6 +768,7 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.reload
          * @comp Crafty.stage
+         * @kind Method
          *
          * @sign public Crafty.viewport.reload()
          *
@@ -766,6 +797,8 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.reset
          * @comp Crafty.stage
+         * @kind Method
+         * 
          * @trigger StopCamera - called to cancel camera animations
          *
          * @sign public Crafty.viewport.reset()
@@ -785,6 +818,8 @@ Crafty.extend({
         /**@
          * #Crafty.viewport.onScreen
          * @comp Crafty.viewport
+         * @kind Method
+         * 
          * @sign public Crafty.viewport.onScreen(Object rect)
          * @param rect - A rectangle with field {_x: x_val, _y: y_val, _w: w_val, _h: h_val}
          *

--- a/src/graphics/webgl-layer.js
+++ b/src/graphics/webgl-layer.js
@@ -176,6 +176,7 @@ RenderProgramWrapper.prototype = {
 /**@
  * #WebGLLayer
  * @category Graphics
+ * @kind System
  *
  * A collection of methods to handle webgl contexts.
  */
@@ -191,6 +192,7 @@ Crafty._registerLayerTemplate("WebGL", {
     /**@
      * #.context
      * @comp WebGLLayer
+     * @kind Property
      *
      * This will return the context of the webgl canvas element.
      */
@@ -426,6 +428,9 @@ Crafty._registerLayerTemplate("WebGL", {
     /**@
      * #.dirty
      * @comp WebGLLayer
+     * @kind Method
+     * @private
+     * 
      * @sign public .dirty(ent)
      * @param ent - The entity to mark as dirty
      *
@@ -438,6 +443,9 @@ Crafty._registerLayerTemplate("WebGL", {
     /**@
      * #.attach
      * @comp WebGLLayer
+     * @kind Method
+     * @private
+     * 
      * @sign public .attach(ent)
      * @param ent - The entity to add
      *
@@ -451,6 +459,9 @@ Crafty._registerLayerTemplate("WebGL", {
     /**@
      * #.detach
      * @comp WebGLLayer
+     * @kind Method
+     * @private
+     * 
      * @sign public .detach(ent)
      * @param ent - The entity to remove
      *

--- a/src/graphics/webgl.js
+++ b/src/graphics/webgl.js
@@ -3,6 +3,8 @@ var Crafty = require('../core/core.js');
 /**@
  * #WebGL
  * @category Graphics
+ * @kind Component
+ * 
  * @trigger Draw - when the entity is ready to be drawn to the stage - {type: "canvas", pos, co, ctx}
  * @trigger NoCanvas - if the browser does not support canvas
  *
@@ -26,6 +28,8 @@ Crafty.extend({
     /**@
      * #Crafty.WebGLShader
      * @category Graphics
+     * @kind Method
+     * 
      * @sign public Crafty.WebGLShader Crafty.WebGLShader(String vertexShaderCode, String fragmentShaderCode, Array attributeList, Function drawCallback(e, entity))
      * @param vertexShaderCode - GLSL code for the vertex shader
      * @param fragmentShaderCode - GLSL code for the fragment shader
@@ -124,6 +128,8 @@ Crafty.extend({
     /**@
      * #Crafty.defaultShader
      * @category Graphics
+     * @kind Method
+     * 
      * @sign public Crafty.WebGLShader Crafty.defaultShader(String component[, Crafty.WebGLShader shader])
      * @param component - Name of the component to assign a default shader to
      * @param shader - New default shader to assign to a component
@@ -160,6 +166,7 @@ Crafty.c("WebGL", {
     /**@
      * #.context
      * @comp WebGL
+     * @kind Property
      *
      * The webgl context this entity will be rendered to.
      */
@@ -192,6 +199,9 @@ Crafty.c("WebGL", {
     /**@
      * #.draw
      * @comp WebGL
+     * @kind Method
+     * @private
+     * 
      * @sign public this .draw([[Context ctx, ]Number x, Number y, Number w, Number h])
      * @param ctx - Optionally supply a different r 2D context if drawing on another canvas is required
      * @param x - X offset for drawing a segment

--- a/src/isometric/diamond-iso.js
+++ b/src/isometric/diamond-iso.js
@@ -5,6 +5,8 @@ Crafty.extend({
     /**@
      * #Crafty.diamondIso
      * @category 2D
+     * @kind CoreObject
+     * 
      * Place entities in a 45deg diamond isometric fashion. It is similar to isometric but has another grid locations
      * In this mode, the x axis and y axis are aligned to the edges of tiles with x increasing being down and to the
      * right and y being down and to the left.
@@ -32,6 +34,8 @@ Crafty.extend({
         /**@
          * #Crafty.diamondIso.init
          * @comp Crafty.diamondIso
+         * @kind Method
+         * 
          * @sign public this Crafty.diamondIso.init(Number tileWidth,Number tileHeight,Number mapWidth,Number mapHeight)
          * @param tileWidth - The size of base tile width's grid space in Pixel
          * @param tileHeight - The size of base tile height grid space in Pixel
@@ -72,6 +76,8 @@ Crafty.extend({
         /**@
          * #Crafty.diamondIso.place
          * @comp Crafty.diamondIso
+         * @kind Method
+         * 
          * @sign public this Crafty.diamondIso.place(Entity tile,Number x, Number y, Number layer)
          * @param x - The `x` position to place the tile
          * @param y - The `y` position to place the tile

--- a/src/isometric/isometric.js
+++ b/src/isometric/isometric.js
@@ -5,6 +5,8 @@ Crafty.extend({
     /**@
      * #Crafty.isometric
      * @category 2D
+     * @kind CoreObject
+     * 
      * Place entities in a 45deg isometric fashion. The alignment of this
      * grid's axes for tile placement is 90 degrees.  If you are looking
      * to have the grid of tile indicies for this.place aligned to the tiles
@@ -24,6 +26,8 @@ Crafty.extend({
         /**@
          * #Crafty.isometric.size
          * @comp Crafty.isometric
+         * @kind Method
+         * 
          * @sign public this Crafty.isometric.size(Number tileSize)
          * @param tileSize - The size of the tiles to place.
          *
@@ -46,6 +50,8 @@ Crafty.extend({
         /**@
          * #Crafty.isometric.place
          * @comp Crafty.isometric
+         * @kind Method
+         * 
          * @sign public this Crafty.isometric.place(Number x, Number y, Number z, Entity tile)
          * @param x - The `x` position to place the tile
          * @param y - The `y` position to place the tile
@@ -73,6 +79,8 @@ Crafty.extend({
         /**@
          * #Crafty.isometric.pos2px
          * @comp Crafty.isometric
+         * @kind Method
+         * 
          * @sign public Object Crafty.isometric.pos2px(Number x,Number y)
          * @param x - A position along the x axis
          * @param y - A position along the y axis
@@ -95,6 +103,8 @@ Crafty.extend({
         /**@
          * #Crafty.isometric.px2pos
          * @comp Crafty.isometric
+         * @kind Method
+         * 
          * @sign public Object Crafty.isometric.px2pos(Number left,Number top)
          * @param top - Offset from the top in pixels
          * @param left - Offset from the left in pixels
@@ -118,7 +128,8 @@ Crafty.extend({
         /**@
          * #Crafty.isometric.centerAt
          * @comp Crafty.isometric
-         *
+         * @kind Method
+         * 
          * @sign public Obect Crafty.isometric.centerAt()
          * @returns An object with `top` and `left` fields represneting the viewport's current center
          *
@@ -151,6 +162,8 @@ Crafty.extend({
         /**@
          * #Crafty.isometric.area
          * @comp Crafty.isometric
+         * @kind Method
+         * 
          * @sign public Object Crafty.isometric.area()
          * @return An obect with `x` and `y` fields, each of which have a start and end field.
          * In other words, the object has this structure: `{x:{start Number,end Number},y:{start Number,end Number}}`

--- a/src/sound/sound.js
+++ b/src/sound/sound.js
@@ -5,6 +5,7 @@ Crafty.extend({
     /**@
      * #Crafty.audio
      * @category Audio
+     * @kind CoreObject
      *
      * Add sound files and play them. Chooses best format for browser support.
      * Due to the nature of HTML5 audio, three types of audio files will be
@@ -53,6 +54,8 @@ Crafty.extend({
         /**@
          * #Crafty.audio.supports
          * @comp Crafty.audio
+         * @kind Method
+         * 
          * @sign public this Crafty.audio.supports(String extension)
          * @param extension - A file extension to check audio support for
          *
@@ -80,6 +83,9 @@ Crafty.extend({
         /**@
          * #Crafty.audio.create
          * @comp Crafty.audio
+         * @kind Method
+         * @private
+         * 
          * @sign public this Crafty.audio.create(String id, String url)
          * @param id - A string to refer to sounds
          * @param url - A string pointing to the sound file
@@ -115,6 +121,8 @@ Crafty.extend({
         /**@
          * #Crafty.audio.add
          * @comp Crafty.audio
+         * @kind Method
+         * 
          * @sign public this Crafty.audio.add(String id, String url)
          * @param id - A string to refer to sounds
          * @param url - A string pointing to the sound file
@@ -190,6 +198,8 @@ Crafty.extend({
         /**@
          * #Crafty.audio.play
          * @comp Crafty.audio
+         * @kind Method
+         * 
          * @sign public this Crafty.audio.play(String id)
          * @sign public this Crafty.audio.play(String id, Number repeatCount)
          * @sign public this Crafty.audio.play(String id, Number repeatCount, Number volume)
@@ -260,6 +270,8 @@ Crafty.extend({
         /**@
          * #Crafty.audio.setChannels
          * @comp Crafty.audio
+         * @kind Method
+         * 
          * @sign public this Crafty.audio.setChannels(Number n)
          * @param n - The maximum number of channels
          */
@@ -305,6 +317,8 @@ Crafty.extend({
         /**@
          * #Crafty.audio.remove
          * @comp Crafty.audio
+         * @kind Method
+         * 
          * @sign public this Crafty.audio.remove([String id])
          * @param id - A string to refer to sounds
          *
@@ -348,6 +362,8 @@ Crafty.extend({
         /**@
          * #Crafty.audio.stop
          * @comp Crafty.audio
+         * @kind Method
+         * 
          * @sign public this Crafty.audio.stop([Number ID])
          *
          * Stops any playing sound. if id is not set, stop all sounds which are playing
@@ -375,6 +391,9 @@ Crafty.extend({
         /**
          * #Crafty.audio._mute
          * @comp Crafty.audio
+         * @kind Method
+         * @kind private
+         * 
          * @sign public this Crafty.audio._mute([Boolean mute])
          *
          * Mute or unmute every Audio instance that is playing.
@@ -392,6 +411,8 @@ Crafty.extend({
         /**@
          * #Crafty.audio.toggleMute
          * @comp Crafty.audio
+         * @kind Method
+         * 
          * @sign public this Crafty.audio.toggleMute()
          *
          * Mute or unmute every Audio instance that is playing. Toggles between
@@ -414,6 +435,8 @@ Crafty.extend({
         /**@
          * #Crafty.audio.mute
          * @comp Crafty.audio
+         * @kind Method
+         * 
          * @sign public this Crafty.audio.mute()
          *
          * Mute every Audio instance that is playing.
@@ -429,6 +452,8 @@ Crafty.extend({
         /**@
          * #Crafty.audio.unmute
          * @comp Crafty.audio
+         * @kind Method
+         * 
          * @sign public this Crafty.audio.unmute()
          *
          * Unmute every Audio instance that is playing.
@@ -445,6 +470,8 @@ Crafty.extend({
         /**@
          * #Crafty.audio.pause
          * @comp Crafty.audio
+         * @kind Method
+         * 
          * @sign public this Crafty.audio.pause(string ID)
          * @param {string} id - The id of the audio object to pause
          *
@@ -471,6 +498,8 @@ Crafty.extend({
         /**@
          * #Crafty.audio.unpause
          * @comp Crafty.audio
+         * @kind Method
+         * 
          * @sign public this Crafty.audio.unpause(string ID)
          * @param {string} id - The id of the audio object to unpause
          *
@@ -496,6 +525,8 @@ Crafty.extend({
         /**@
          * #Crafty.audio.togglePause
          * @comp Crafty.audio
+         * @kind Method
+         * 
          * @sign public this Crafty.audio.togglePause(string ID)
          * @param {string} id - The id of the audio object to pause/
          *
@@ -526,6 +557,8 @@ Crafty.extend({
         /**@
          * #Crafty.audio.isPlaying
          * @comp Crafty.audio
+         * @kind Method
+         * 
          * @sign public Boolean Crafty.audio.isPlaying(string ID)
          * @param {string} id - The id of the audio object
          * @return a Boolean indicating whether the audio is playing or not

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -6,6 +6,8 @@ var Crafty = require('../core/core.js'),
 /**@
  * #Crafty.map
  * @category 2D
+ * @kind CoreObject
+ * 
  * Functions related with querying entities.
  * @see Crafty.HashMap
  */
@@ -19,6 +21,8 @@ var M = Math,
 /**@
  * #2D
  * @category 2D
+ * @kind Component
+ * 
  * Component for any entity that has a position on the stage.
  * @trigger Move - when the entity has moved - { _x:Number, _y:Number, _w:Number, _h:Number } - Old position
  * @trigger Invalidate - when the entity needs to be redrawn
@@ -29,6 +33,8 @@ Crafty.c("2D", {
     /**@
      * #.x
      * @comp 2D
+     * @kind Property
+     * 
      * The `x` position on the stage. When modified, will automatically be redrawn.
      * Is actually a getter/setter so when using this value for calculations and not modifying it,
      * use the `._x` property.
@@ -37,6 +43,8 @@ Crafty.c("2D", {
     _x: 0,
     /**@
      * #.y
+     * @kind Property
+     * 
      * @comp 2D
      * The `y` position on the stage. When modified, will automatically be redrawn.
      * Is actually a getter/setter so when using this value for calculations and not modifying it,
@@ -47,6 +55,8 @@ Crafty.c("2D", {
     /**@
      * #.w
      * @comp 2D
+     * @kind Property
+     * 
      * The width of the entity. When modified, will automatically be redrawn.
      * Is actually a getter/setter so when using this value for calculations and not modifying it,
      * use the `._w` property.
@@ -58,6 +68,8 @@ Crafty.c("2D", {
     /**@
      * #.h
      * @comp 2D
+     * @kind Property
+     * 
      * The height of the entity. When modified, will automatically be redrawn.
      * Is actually a getter/setter so when using this value for calculations and not modifying it,
      * use the `._h` property.
@@ -70,6 +82,8 @@ Crafty.c("2D", {
     /**@
      * #.z
      * @comp 2D
+     * @kind Property
+     * 
      * The `z` index on the stage. When modified, will automatically be redrawn.
      * Is actually a getter/setter so when using this value for calculations and not modifying it,
      * use the `._z` property.
@@ -86,6 +100,8 @@ Crafty.c("2D", {
     /**@
      * #._globalZ
      * @comp 2D
+     * @kind Property
+     * 
      * When two entities overlap, the one with the larger `_globalZ` will be on top of the other.
      */
     _globalZ: null,
@@ -93,6 +109,8 @@ Crafty.c("2D", {
     /**@
      * #.rotation
      * @comp 2D
+     * @kind Property
+     * 
      * The rotation state of the entity, in clockwise degrees.
      * `this.rotation = 0` sets it to its original orientation; `this.rotation = 10`
      * sets it to 10 degrees clockwise from its original orientation;
@@ -276,6 +294,8 @@ Crafty.c("2D", {
     /**@
      * #.offsetBoundary
      * @comp 2D
+     * @kind Method
+     * 
      * Extends the MBR of the entity by a specified amount.
      * 
      * @trigger BoundaryOffset - when the MBR offset changes
@@ -410,6 +430,8 @@ Crafty.c("2D", {
     /**@
      * #.area
      * @comp 2D
+     * @kind Method
+     * 
      * @sign public Number .area(void)
      * Calculates the area of the entity
      */
@@ -420,6 +442,8 @@ Crafty.c("2D", {
     /**@
      * #.intersect
      * @comp 2D
+     * @kind Method
+     * 
      * @sign public Boolean .intersect(Number x, Number y, Number w, Number h)
      * @param x - X position of the rect
      * @param y - Y position of the rect
@@ -450,6 +474,8 @@ Crafty.c("2D", {
     /**@
      * #.within
      * @comp 2D
+     * @kind Method
+     * 
      * @sign public Boolean .within(Number x, Number y, Number w, Number h)
      * @param x - X position of the rect
      * @param y - Y position of the rect
@@ -480,6 +506,8 @@ Crafty.c("2D", {
     /**@
      * #.contains
      * @comp 2D
+     * @kind Method
+     * 
      * @sign public Boolean .contains(Number x, Number y, Number w, Number h)
      * @param x - X position of the rect
      * @param y - Y position of the rect
@@ -510,6 +538,8 @@ Crafty.c("2D", {
     /**@
      * #.pos
      * @comp 2D
+     * @kind Method
+     * 
      * @sign public Object .pos([Object pos])
      * @param pos - an object to use as output
      * @returns an object with `_x`, `_y`, `_w`, and `_h` properties; if an object is passed in, it will be reused rather than creating a new object.
@@ -531,6 +561,8 @@ Crafty.c("2D", {
     /**@
      * #.mbr
      * @comp 2D
+     * @kind Method
+     * 
      * @sign public Object .mbr([Object mbr])
      * @param mbr - an object to use as output
      * @returns an object with `_x`, `_y`, `_w`, and `_h` properties; if an object is passed in, it will be reused rather than creating a new object.
@@ -560,6 +592,8 @@ Crafty.c("2D", {
     /**@
      * #.isAt
      * @comp 2D
+     * @kind Method
+     * 
      * @sign public Boolean .isAt(Number x, Number y)
      * @param x - X position of the point
      * @param y - Y position of the point
@@ -583,6 +617,8 @@ Crafty.c("2D", {
     /**@
      * #.move
      * @comp 2D
+     * @kind Method
+     * 
      * @sign public this .move(String dir, Number by)
      * @param dir - Direction to move (n,s,e,w,ne,nw,se,sw)
      * @param by - Amount to move in the specified direction
@@ -601,6 +637,8 @@ Crafty.c("2D", {
     /**@
      * #.shift
      * @comp 2D
+     * @kind Method
+     * 
      * @sign public this .shift(Number x, Number y, Number w, Number h)
      * @param x - Amount to move X
      * @param y - Amount to move Y
@@ -622,6 +660,9 @@ Crafty.c("2D", {
     /**@
      * #._cascade
      * @comp 2D
+     * @kind Method
+     * @private
+     * 
      * @sign public void ._cascade(e)
      * @param e - An object describing the motion
      *
@@ -659,6 +700,8 @@ Crafty.c("2D", {
     /**@
      * #.attach
      * @comp 2D
+     * @kind Method
+     * 
      * @sign public this .attach(Entity obj[, .., Entity objN])
      * @param obj - Child entity(s) to attach
      *
@@ -694,6 +737,8 @@ Crafty.c("2D", {
     /**@
      * #.detach
      * @comp 2D
+     * @kind Method
+     * 
      * @sign public this .detach([Entity obj])
      * @param obj - The entity to detach. Left blank will remove all attached entities
      *
@@ -725,7 +770,8 @@ Crafty.c("2D", {
     /**@
      * #.origin
      * @comp 2D
-     *
+     * @kind Method
+     * 
      * @sign public this .origin(Number x, Number y)
      * @param x - Pixel value of origin offset on the X axis
      * @param y - Pixel value of origin offset on the Y axis
@@ -864,826 +910,13 @@ Crafty.c("2D", {
     }
 });
 
-/**@
- * #Supportable
- * @category 2D
- * @trigger LandedOnGround - When entity has landed. This event is triggered with the object the entity landed on.
- * @trigger LiftedOffGround - When entity has lifted off. This event is triggered with the object the entity stood on before lift-off.
- * @trigger CheckLanding - When entity is about to land. This event is triggered with the object the entity is about to land on. Third parties can respond to this event and prevent the entity from being able to land.
- *
- * Component that detects if the entity collides with the ground. This component is automatically added and managed by the Gravity component.
- * The appropriate events are fired when the entity state changes (lands on ground / lifts off ground). The current ground entity can also be accessed with `.ground`.
- */
-Crafty.c("Supportable", {
-    /**@
-     * #.ground
-     * @comp Supportable
-     *
-     * Access the ground entity (which may be the actual ground entity if it exists, or `null` if it doesn't exist) and thus whether this entity is currently on the ground or not. 
-     * The ground entity is also available through the events, when the ground entity changes.
-     */
-    _ground: null,
-    _groundComp: null,
-    _preventGroundTunneling: false,
 
-    /**@
-     * #.canLand
-     * @comp Supportable
-     *
-     * The canLand boolean determines if the entity is allowed to land or not (e.g. perhaps the entity should not land if it's not falling).
-     * The Supportable component will trigger a "CheckLanding" event. 
-     * Interested parties can listen to this event and prevent the entity from landing by setting `canLand` to false.
-     *
-     * @example
-     * ~~~
-     * var player = Crafty.e("2D, Gravity");
-     * player.bind("CheckLanding", function(ground) {
-     *     if (player.y + player.h > ground.y + player.dy) { // forbid landing, if player's feet are not above ground
-     *         player.canLand = false;
-     *     }
-     * });
-     * ~~~
-     */
-    canLand: true,
 
-    init: function () {
-        this.requires("2D");
-        this.__area = {_x: 0, _y: 0, _w: 0, _h: 0};
-        this.defineField("ground", function() { return this._ground; }, function(newValue) {});
-    },
-    remove: function(destroyed) {
-        this.unbind("EnterFrame", this._detectGroundTick);
-    },
-
-    /*@
-     * #.startGroundDetection
-     * @comp Supportable
-     * @sign private this .startGroundDetection([comp])
-     * @param comp - The name of a component that will be treated as ground
-     *
-     * This method is automatically called by the Gravity component and should not be called by the user.
-     *
-     * Enable ground detection for this entity no matter whether comp parameter is specified or not.
-     * If comp parameter is specified all entities with that component will stop this entity from falling.
-     * For a player entity in a platform game this would be a component that is added to all entities
-     * that the player should be able to walk on.
-     * 
-     * @example
-     * ~~~
-     * Crafty.e("2D, DOM, Color, Gravity")
-     *   .color("red")
-     *   .attr({ w: 100, h: 100 })
-     *   .gravity("platform");
-     * ~~~
-     *
-     * @see Gravity
-     */
-    startGroundDetection: function(ground) {
-        if (ground) this._groundComp = ground;
-        this.uniqueBind("EnterFrame", this._detectGroundTick);
-
-        return this;
-    },
-    /*@
-     * #.stopGroundDetection
-     * @comp Supportable
-     * @sign private this .stopGroundDetection()
-     *
-     * This method is automatically called by the Gravity component and should not be called by the user.
-     *
-     * Disable ground detection for this component. It can be reenabled by calling .startGroundDetection()
-     */
-    stopGroundDetection: function() {
-        this.unbind("EnterFrame", this._detectGroundTick);
-
-        return this;
-    },
-
-    /**@
-     * #.preventGroundTunneling
-     * @comp Supportable
-     * @sign this .preventGroundTunneling([Boolean enable])
-     * @param enable - Boolean indicating whether to enable continous collision detection or not; if omitted defaults to true
-     *
-     * Prevent entity from falling through thin ground entities at high speeds. This setting is disabled by default.
-     * This is performed by approximating continous collision detection, which may impact performance negatively.
-     * For further details, refer to [FAQ#Tunneling](https://github.com/craftyjs/Crafty/wiki/Crafty-FAQ-%28draft%29#why-are-my-bullets-passing-through-other-entities-without-registering-hits).
-     *
-     * @see Motion#.ccdbr
-     */
-    preventGroundTunneling: function(enable) {
-        if (typeof enable === 'undefined')
-            enable = true;
-        if (enable)
-            this.requires("Motion");
-        this._preventGroundTunneling = enable;
-
-        return this;
-    },
-
-    _detectGroundTick: function() {
-        var groundComp = this._groundComp,
-            ground = this._ground,
-            overlap = Crafty.rectManager.overlap,
-            area;
-
-        if (!this._preventGroundTunneling) {
-            var pos = this._cbr || this._mbr || this;
-            area = this.__area;
-            area._x = pos._x;
-            area._y = pos._y;
-            area._w = pos._w;
-            area._h = pos._h;
-        } else {
-            area = this.ccdbr(this.__area);
-        }
-        area._h++; // Increase by 1 to make sure map.search() finds the floor
-        // Decrease width by 1px from left and 1px from right, to fall more gracefully
-        // area._x++; area._w--;
-
-
-        // check if we lift-off
-        if (ground) {
-            var garea = ground._cbr || ground._mbr || ground;
-            if (!(ground.__c[groundComp] && Crafty(ground[0]) === ground && overlap(garea, area))) {
-                this._ground = null;
-                this.trigger("LiftedOffGround", ground); // no collision with ground was detected for first time
-                ground = null;
-            }
-        }
-
-        // check if we land (also possible to land on other ground object in same frame after lift-off from current ground object)
-        if (!ground) {
-            var obj, oarea,
-                results = Crafty.map.search(area, false),
-                i = 0,
-                l = results.length;
-
-            for (; i < l; ++i) {
-                obj = results[i];
-                oarea = obj._cbr || obj._mbr || obj;
-                // check for an intersection with the player
-                if (obj !== this && obj.__c[groundComp] && overlap(oarea, area)) {
-                    this.canLand = true;
-                    this.trigger("CheckLanding", obj); // is entity allowed to land?
-                    if (this.canLand) {
-                        this._ground = ground = obj;
-
-                        // snap entity to ground object
-                        this.y = ground._y - this._h;
-                        if (this._x > ground._x + ground._w)
-                            this.x = ground._x + ground._w - 1;
-                        else if (this._x + this._w < ground._x)
-                            this.x = ground._x - this._w + 1;
-
-                        this.trigger("LandedOnGround", ground); // collision with ground was detected for first time
-                        break;
-                    }
-                }
-            }
-        }
-    }
-});
-
-/**@
- * #GroundAttacher
- * @category 2D
- *
- * Attach the entity to the ground when it lands. Useful for platformers with moving platforms.
- * Remove the component to disable the functionality.
- *
- * Additionally, this component provides the entity with `Supportable` methods & events.
- *
- * @example
- * ~~~
- * Crafty.e("2D, Gravity, GroundAttacher")
- *     .gravity("Platform"); // entity will land on and move with entites that have the "Platform" component
- * ~~~
- *
- * @see Supportable, Gravity
- */
-Crafty.c("GroundAttacher", {
-    _groundAttach: function(ground) {
-        ground.attach(this);
-    },
-    _groundDetach: function(ground) {
-        ground.detach(this);
-    },
-
-    init: function () {
-        this.requires("Supportable");
-
-        this.bind("LandedOnGround", this._groundAttach);
-        this.bind("LiftedOffGround", this._groundDetach);
-    },
-    remove: function(destroyed) {
-        this.unbind("LandedOnGround", this._groundAttach);
-        this.unbind("LiftedOffGround", this._groundDetach);
-    }
-});
-
-
-/**@
- * #Gravity
- * @category 2D
- *
- * Adds gravitational pull to the entity.
- *
- * Additionally, this component provides the entity with `Supportable` and `Motion` methods & events.
- *
- * @see Supportable, Motion
- */
-Crafty.c("Gravity", {
-    _gravityConst: 500,
-    _gravityActive: false,
-
-    init: function () {
-        this.requires("2D, Supportable, Motion");
-
-        this.bind("LiftedOffGround", this._startGravity); // start gravity if we are off ground
-        this.bind("LandedOnGround", this._stopGravity); // stop gravity once landed
-    },
-    remove: function(destroyed) {
-        this.unbind("LiftedOffGround", this._startGravity);
-        this.unbind("LandedOnGround", this._stopGravity);
-    },
-
-    _gravityCheckLanding: function(ground) {
-        if (this._dy < 0) 
-            this.canLand = false;
-    },
-
-    /**@
-     * #.gravity
-     * @comp Gravity
-     * @sign public this .gravity([comp])
-     * @param comp - The name of a component that will stop this entity from falling
-     *
-     * Enable gravity for this entity no matter whether comp parameter is specified or not.
-     * If comp parameter is specified all entities with that component will stop this entity from falling.
-     * For a player entity in a platform game this would be a component that is added to all entities
-     * that the player should be able to walk on.
-     *
-     * @example
-     * ~~~
-     * Crafty.e("2D, DOM, Color, Gravity")
-     *   .color("red")
-     *   .attr({ w: 100, h: 100 })
-     *   .gravity("platform");
-     * ~~~
-     */
-    gravity: function (comp) {
-        this.uniqueBind("CheckLanding", this._gravityCheckLanding);
-        this.startGroundDetection(comp);
-        this._startGravity();
-
-        return this;
-    },
-    /**@
-     * #.antigravity
-     * @comp Gravity
-     * @sign public this .antigravity()
-     * Disable gravity for this component. It can be reenabled by calling .gravity()
-     */
-    antigravity: function () {
-        this._stopGravity();
-        this.stopGroundDetection();
-        this.unbind("CheckLanding", this._gravityCheckLanding);
-
-        return this;
-    },
-
-    /**@
-     * #.gravityConst
-     * @comp Gravity
-     * @sign public this .gravityConst(g)
-     * @param g - gravitational constant in pixels per second squared
-     *
-     * Set the gravitational constant to g for this entity. The default is 500. The greater g, the stronger the downwards acceleration.
-     *
-     * @example
-     * ~~~
-     * Crafty.e("2D, DOM, Color, Gravity")
-     *   .color("red")
-     *   .attr({ w: 100, h: 100 })
-     *   .gravityConst(750)
-     *   .gravity("platform");
-     * ~~~
-     */
-    gravityConst: function (g) {
-        if (this._gravityActive) { // gravity active, change acceleration
-            this.ay -= this._gravityConst;
-            this.ay += g;
-        }
-        this._gravityConst = g;
-
-        return this;
-    },
-
-    _startGravity: function() {
-        if (this._gravityActive) return;
-        this._gravityActive = true;
-        this.ay += this._gravityConst;
-    },
-    _stopGravity: function() {
-        if (!this._gravityActive) return;
-        this._gravityActive = false;
-        this.ay = 0;
-        this.vy = 0;
-    }
-});
-
-// This is used to define getters and setters for Motion properties
-// For instance
-//      __motionProp(entity, "a", "x", true) 
-// will define a getter for `ax` which accesses an underlying private property `_ax`
-// If the `setter` property is false, setting a value will be a null-op
-var __motionProp = function(self, prefix, prop, setter) {
-    var publicProp = prefix + prop;
-    var privateProp = "_" + publicProp;
-
-    var motionEvent = { key: "", oldValue: 0};
-    // getters & setters for public property
-    if (setter) {
-        Crafty.defineField(self, publicProp, function() { return this[privateProp]; }, function(newValue) {
-            var oldValue = this[privateProp];
-            if (newValue !== oldValue) {
-                this[privateProp] = newValue;
-
-                motionEvent.key = publicProp;
-                motionEvent.oldValue = oldValue;
-                this.trigger("MotionChange", motionEvent);
-            }
-        });
-    } else {
-        Crafty.defineField(self, publicProp, function() { return this[privateProp]; }, function(newValue) {});
-    }
-
-    // hide private property
-    Object.defineProperty(self, privateProp, {
-        value : 0,
-        writable : true,
-        enumerable : false,
-        configurable : false
-    });
-};
-
-// This defines an alias for a pair of underlying properties which represent the components of a vector
-// It takes an object with vector methods, and redefines its x/y properties as getters and setters to properties of self
-// This allows you to use the vector's special methods to manipulate the entity's properties, 
-// while still allowing you to manipulate those properties directly if performance matters
-var __motionVector = function(self, prefix, setter, vector) {
-    var publicX = prefix + "x",
-        publicY = prefix + "y",
-        privateX = "_" + publicX,
-        privateY = "_" + publicY;
-
-    if (setter) {
-        Crafty.defineField(vector, "x", function() { return self[privateX]; }, function(v) { self[publicX] = v; });
-        Crafty.defineField(vector, "y", function() { return self[privateY]; }, function(v) { self[publicY] = v; });
-    } else {
-        Crafty.defineField(vector, "x", function() { return self[privateX]; }, function(v) {});
-        Crafty.defineField(vector, "y", function() { return self[privateY]; }, function(v) {});
-    }
-    if (Object.seal) { Object.seal(vector); }
-
-    return vector;
-};
-
-
-/**@
- * #AngularMotion
- * @category 2D
- * @trigger Rotated - When entity has rotated due to angular velocity/acceleration a Rotated event is triggered. - Number - Old rotation
- * @trigger NewRotationDirection - When entity has changed rotational direction due to rotational velocity a NewRotationDirection event is triggered. The event is triggered once, if direction is different from last frame. - -1 | 0 | 1 - New direction
- * @trigger MotionChange - When a motion property has changed a MotionChange event is triggered. - { key: String, oldValue: Number } - Motion property name and old value
- *
- * Component that allows rotating an entity by applying angular velocity and acceleration.
- * All angular motion values are expressed in degrees per second (e.g. an entity with `vrotation` of 10 will rotate 10 degrees each second).
- */
-Crafty.c("AngularMotion", {
-    /**@
-     * #.vrotation
-     * @comp AngularMotion
-     * 
-     * A property for accessing/modifying the angular(rotational) velocity. 
-     * The velocity remains constant over time, unless the acceleration increases the velocity.
-     *
-     * @example
-     * ~~~
-     * var ent = Crafty.e("2D, AngularMotion");
-     *
-     * var vrotation = ent.vrotation; // retrieve the angular velocity
-     * ent.vrotation += 1; // increase the angular velocity
-     * ent.vrotation = 0; // reset the angular velocity
-     * ~~~
-     */
-    _vrotation: 0,
-
-    /**@
-     * #.arotation
-     * @comp AngularMotion
-     * 
-     * A property for accessing/modifying the angular(rotational) acceleration. 
-     * The acceleration increases the velocity over time, resulting in ever increasing speed.
-     *
-     * @example
-     * ~~~
-     * var ent = Crafty.e("2D, AngularMotion");
-     *
-     * var arotation = ent.arotation; // retrieve the angular acceleration
-     * ent.arotation += 1; // increase the angular acceleration
-     * ent.arotation = 0; // reset the angular acceleration
-     * ~~~
-     */
-    _arotation: 0,
-
-    /**@
-     * #.drotation
-     * @comp AngularMotion
-     * 
-     * A number that reflects the change in rotation (difference between the old & new rotation) that was applied in the last frame.
-     *
-     * @example
-     * ~~~
-     * var ent = Crafty.e("2D, AngularMotion");
-     *
-     * var drotation = ent.drotation; // the change of rotation in the last frame
-     * ~~~
-     */
-    _drotation: 0,
-
-    init: function () {
-        this.requires("2D");
-
-        __motionProp(this, "v", "rotation", true);
-        __motionProp(this, "a", "rotation", true);
-        __motionProp(this, "d", "rotation", false);
-
-        this.__oldRotationDirection = 0;
-
-        this.bind("EnterFrame", this._angularMotionTick);
-    },
-    remove: function(destroyed) {
-        this.unbind("EnterFrame", this._angularMotionTick);
-    },
-
-    /**@
-     * #.resetAngularMotion
-     * @comp AngularMotion
-     * @sign public this .resetAngularMotion()
-     * 
-     * Reset all motion (resets velocity, acceleration, motionDelta).
-     */
-    resetAngularMotion: function() {
-        this._drotation = 0;
-        this.vrotation = 0;
-        this.arotation = 0;
-
-        return this;
-    },
-
-    /*
-     * s += v * Δt + (0.5 * a) * Δt * Δt
-     * v += a * Δt
-     */
-    _angularMotionTick: function(frameData) {
-        var dt = frameData.dt / 1000; // Time in s
-        var oldR = this._rotation,
-            vr = this._vrotation,
-            ar = this._arotation;
-
-        // s += v * Δt + (0.5 * a) * Δt * Δt
-        var newR = oldR + vr * dt + 0.5 * ar * dt * dt;
-        // v += a * Δt
-        this.vrotation = vr + ar * dt;
-
-        // Check if direction of velocity has changed
-        var _vr = this._vrotation, dvr = _vr ? (_vr<0 ? -1:1):0; // Quick implementation of Math.sign
-        if (this.__oldRotationDirection !== dvr) {
-            this.__oldRotationDirection = dvr;
-            this.trigger('NewRotationDirection', dvr);
-        }
-
-        // Check if velocity has changed
-        // Δs = s[t] - s[t-1]
-        this._drotation = newR - oldR;
-        if (this._drotation !== 0) {
-            this.rotation = newR;
-            this.trigger('Rotated', oldR);
-        }
-    }
-});
-
-/**@
- * #Motion
- * @category 2D
- * @trigger Moved - When entity has moved due to velocity/acceleration on either x or y axis a Moved event is triggered. If the entity has moved on both axes for diagonal movement the event is triggered twice. - { axis: 'x' | 'y', oldValue: Number } - Old position
- * @trigger NewDirection - When entity has changed direction due to velocity on either x or y axis a NewDirection event is triggered. The event is triggered once, if direction is different from last frame. - { x: -1 | 0 | 1, y: -1 | 0 | 1 } - New direction
- * @trigger MotionChange - When a motion property has changed a MotionChange event is triggered. - { key: String, oldValue: Number } - Motion property name and old value
- *
- * Component that allows moving an entity by applying linear velocity and acceleration.
- * All linear motion values are expressed in pixels per second (e.g. an entity with `vx` of 1 will move 1px on the x axis each second).
- *
- * @note Several methods return Vector2D objects that dynamically reflect the entity's underlying properties.  If you want a static copy instead, use the vector's `clone()` method.
- */
-Crafty.c("Motion", {
-    /**@
-     * #.vx
-     * @comp Motion
-     * 
-     * A property for accessing/modifying the linear velocity in the x axis.
-     * The velocity remains constant over time, unless the acceleration changes the velocity.
-     *
-     * @example
-     * ~~~
-     * var ent = Crafty.e("2D, Motion");
-     *
-     * var vx = ent.vx; // retrieve the linear velocity in the x axis
-     * ent.vx += 1; // increase the linear velocity in the x axis
-     * ent.vx = 0; // reset the linear velocity in the x axis
-     * ~~~
-     */
-    _vx: 0,
-
-    /**@
-     * #.vy
-     * @comp Motion
-     * 
-     * A property for accessing/modifying the linear velocity in the y axis.
-     * The velocity remains constant over time, unless the acceleration changes the velocity.
-     *
-     * @example
-     * ~~~
-     * var ent = Crafty.e("2D, Motion");
-     *
-     * var vy = ent.vy; // retrieve the linear velocity in the y axis
-     * ent.vy += 1; // increase the linear velocity in the y axis
-     * ent.vy = 0; // reset the linear velocity in the y axis
-     * ~~~
-     */
-    _vy: 0,
-
-    /**@
-     * #.ax
-     * @comp Motion
-     * 
-     * A property for accessing/modifying the linear acceleration in the x axis.
-     * The acceleration changes the velocity over time.
-     *
-     * @example
-     * ~~~
-     * var ent = Crafty.e("2D, Motion");
-     *
-     * var ax = ent.ax; // retrieve the linear acceleration in the x axis
-     * ent.ax += 1; // increase the linear acceleration in the x axis
-     * ent.ax = 0; // reset the linear acceleration in the x axis
-     * ~~~
-     */
-    _ax: 0,
-
-    /**@
-     * #.ay
-     * @comp Motion
-     * 
-     * A property for accessing/modifying the linear acceleration in the y axis.
-     * The acceleration changes the velocity over time.
-     *
-     * @example
-     * ~~~
-     * var ent = Crafty.e("2D, Motion");
-     *
-     * var ay = ent.ay; // retrieve the linear acceleration in the y axis
-     * ent.ay += 1; // increase the linear acceleration in the y axis
-     * ent.ay = 0; // reset the linear acceleration in the y axis
-     * ~~~
-     */
-    _ay: 0,
-
-    /**@
-     * #.dx
-     * @comp Motion
-     * 
-     * A number that reflects the change in x (difference between the old & new x) that was applied in the last frame.
-     *
-     * @example
-     * ~~~
-     * var ent = Crafty.e("2D, Motion");
-     *
-     * var dx = ent.dx; // the change of x in the last frame
-     * ~~~
-     */
-    _dx: 0,
-
-    /**@
-     * #.dy
-     * @comp Motion
-     * 
-     * A number that reflects the change in y (difference between the old & new y) that was applied in the last frame.
-     *
-     * @example
-     * ~~~
-     * var ent = Crafty.e("2D, Motion");
-     *
-     * var dy = ent.dy; // the change of y in the last frame
-     * ~~~
-     */
-    _dy: 0,
-
-    init: function () {
-        this.requires("2D");
-
-        __motionProp(this, "v", "x", true);
-        __motionProp(this, "v", "y", true);
-        this._velocity = __motionVector(this, "v", true, new Crafty.math.Vector2D());
-        __motionProp(this, "a", "x", true);
-        __motionProp(this, "a", "y", true);
-        this._acceleration = __motionVector(this, "a", true, new Crafty.math.Vector2D());
-        __motionProp(this, "d", "x", false);
-        __motionProp(this, "d", "y", false);
-        this._motionDelta = __motionVector(this, "d", false, new Crafty.math.Vector2D());
-
-        this.__movedEvent = {axis: '', oldValue: 0};
-        this.__oldDirection = {x: 0, y: 0};
-
-        this.bind("EnterFrame", this._linearMotionTick);
-    },
-    remove: function(destroyed) {
-        this.unbind("EnterFrame", this._linearMotionTick);
-    },
-
-    /**@
-     * #.resetMotion
-     * @comp Motion
-     * @sign public this .resetMotion()
-     * @return this
-     * 
-     * Reset all linear motion (resets velocity, acceleration, motionDelta).
-     */
-    resetMotion: function() {
-        this.vx = 0; this.vy = 0;
-        this.ax = 0; this.ay = 0;
-        this._dx = 0; this._dy = 0;
-
-        return this;
-    },
-
-    /**@
-     * #.motionDelta
-     * @comp Motion
-     * @sign public Vector2D .motionDelta()
-     * @return A Vector2D with the properties {x, y} that reflect the change in x & y.
-     * 
-     * Returns the difference between the old & new position that was applied in the last frame.
-     *
-     * @example
-     * ~~~
-     * var ent = Crafty.e("2D, Motion");
-     *
-     * var deltaY = ent.motionDelta().y; // the change of y in the last frame
-     * ~~~
-     * @see Crafty.math.Vector2D
-     */
-    motionDelta: function() {
-        return this._motionDelta;
-    },
-
-    /**@
-     * #.velocity
-     * @comp Motion
-     * Method for accessing/modifying the linear(x,y) velocity. 
-     * The velocity remains constant over time, unless the acceleration increases the velocity.
-     *
-     * @sign public Vector2D .velocity()
-     * @return The velocity Vector2D with the properties {x, y} that reflect the velocities in the <x, y> direction of the entity.
-     *
-     * Returns the current velocity. You can access/modify the properties in order to retrieve/change the velocity.
-
-     * @example
-     * ~~~
-     * var ent = Crafty.e("2D, Motion");
-     *
-     * var vel = ent.velocity(); //returns the velocity vector
-     * vel.x;       // retrieve the velocity in the x direction
-     * vel.x = 0;   // set the velocity in the x direction
-     * vel.x += 4   // add to the velocity in the x direction
-     * ~~~
-     * @see Crafty.math.Vector2D
-     */
-    velocity: function() {
-        return this._velocity;
-    },
-
-
-    /**@
-     * #.acceleration
-     * @comp Motion
-     * Method for accessing/modifying the linear(x,y) acceleration. 
-     * The acceleration increases the velocity over time, resulting in ever increasing speed.
-     * 
-     * @sign public Vector2D .acceleration()
-     * @return The acceleration Vector2D with the properties {x, y} that reflects the acceleration in the <x, y> direction of the entity.
-     *
-     * Returns the current acceleration. You can access/modify the properties in order to retrieve/change the acceleration.
-     *
-     * @example
-     * ~~~
-     * var ent = Crafty.e("2D, Motion");
-     *
-     * var acc = ent.acceleration(); //returns the acceleration object
-     * acc.x;       // retrieve the acceleration in the x direction
-     * acc.x = 0;   // set the acceleration in the x direction
-     * acc.x += 4   // add to the acceleration in the x direction
-     * ~~~
-     * @see Crafty.math.Vector2D
-     */
-    acceleration: function() {
-        return this._acceleration;
-    },
-
-    /**@
-     * #.ccdbr
-     * @comp Motion
-     * @sign public Object .ccdbr([Object ccdbr])
-     * @param ccdbr - an object to use as output
-     * @returns an object with `_x`, `_y`, `_w`, and `_h` properties; if an object is passed in, it will be reused rather than creating a new object.
-     *
-     * Return an object containing the entity's continuous collision detection bounding rectangle.
-     * The CCDBR encompasses the motion delta of the entity's bounding rectangle since last frame.
-     * The CCDBR is minimal if the entity moved on only one axis since last frame, however it encompasses a non-minimal region if it moved on both axis.
-     * For further details, refer to [FAQ#Tunneling](https://github.com/craftyjs/Crafty/wiki/Crafty-FAQ-%28draft%29#why-are-my-bullets-passing-through-other-entities-without-registering-hits).
-     *
-     * @note The keys have an underscore prefix. This is due to the x, y, w, h properties
-     * being setters and getters that wrap the underlying properties with an underscore (_x, _y, _w, _h).
-     *
-     * @see .motionDelta, Collision#.cbr
-     */
-    ccdbr: function (ccdbr) {
-        var pos = this._cbr || this._mbr || this,
-            dx = this._dx,
-            dy = this._dy,
-            ccdX = 0, ccdY = 0,
-            ccdW = dx > 0 ? (ccdX = dx) : -dx,
-            ccdH = dy > 0 ? (ccdY = dy) : -dy;
-
-        ccdbr = ccdbr || {};
-        ccdbr._x = pos._x - ccdX;
-        ccdbr._y = pos._y - ccdY;
-        ccdbr._w = pos._w + ccdW;
-        ccdbr._h = pos._h + ccdH;
-
-        return ccdbr;
-    },
-
-    /*
-     * s += v * Δt + (0.5 * a) * Δt * Δt
-     * v += a * Δt
-     */
-    _linearMotionTick: function(frameData) {
-        var dt = frameData.dt / 1000; // time in s
-        var oldX = this._x, vx = this._vx, ax = this._ax,
-            oldY = this._y, vy = this._vy, ay = this._ay;
-
-        // s += v * Δt + (0.5 * a) * Δt * Δt
-        var newX = oldX + vx * dt + 0.5 * ax * dt * dt;
-        var newY = oldY + vy * dt + 0.5 * ay * dt * dt;
-        // v += a * Δt
-        this.vx = vx + ax * dt;
-        this.vy = vy + ay * dt;
-
-        // Check if direction of velocity has changed
-        var oldDirection = this.__oldDirection,
-            _vx = this._vx, dvx = _vx ? (_vx<0 ? -1:1):0, // A quick implementation of Math.sign
-            _vy = this._vy, dvy = _vy ? (_vy<0 ? -1:1):0;
-        if (oldDirection.x !== dvx || oldDirection.y !== dvy) {
-            oldDirection.x = dvx;
-            oldDirection.y = dvy;
-            this.trigger('NewDirection', oldDirection);
-        }
-
-        // Check if velocity has changed
-        var movedEvent = this.__movedEvent;
-        // Δs = s[t] - s[t-1]
-        this._dx = newX - oldX;
-        this._dy = newY - oldY;
-        if (this._dx !== 0) {
-            this.x = newX;
-            movedEvent.axis = 'x';
-            movedEvent.oldValue = oldX;
-            this.trigger('Moved', movedEvent);
-        }
-        if (this._dy !== 0) {
-            this.y = newY;
-            movedEvent.axis = 'y';
-            movedEvent.oldValue = oldY;
-            this.trigger('Moved', movedEvent);
-        }
-    }
-});
 
 /**@
  * #Crafty.polygon
  * @category 2D
+ * @kind Class
  *
  * The constructor for a polygon object used for hitboxes and click maps. Takes a set of points as an
  * argument, giving alternately the x and y coordinates of the polygon's vertices in order.
@@ -1716,6 +949,8 @@ Crafty.polygon.prototype = {
     /**@
      * #.containsPoint
      * @comp Crafty.polygon
+     * @kind Method
+     * 
      * @sign public Boolean .containsPoint(Number x, Number y)
      * @param x - X position of the point
      * @param y - Y position of the point
@@ -1745,6 +980,8 @@ Crafty.polygon.prototype = {
     /**@
      * #.shift
      * @comp Crafty.polygon
+     * @kind Method
+     * 
      * @sign public void .shift(Number x, Number y)
      * @param x - Amount to shift the `x` axis
      * @param y - Amount to shift the `y` axis
@@ -1770,6 +1007,8 @@ Crafty.polygon.prototype = {
     /**@
      * #.clone
      * @comp Crafty.polygon
+     * @kind Method
+     * 
      * @sign public void .clone()
      * 
      * Returns a clone of the polygon.
@@ -1804,6 +1043,8 @@ Crafty.polygon.prototype = {
     /**@
      * #.intersectRay
      * @comp Crafty.polygon
+     * @kind Method
+     * 
      * @sign public Number .intersectRay(Object origin, Object direction)
      * @param origin - the point of origin from which the ray will be cast. The object must contain the properties `_x` and `_y`.
      * @param direction - the direction the ray will be cast. It must be normalized. The object must contain the properties `x` and `y`.
@@ -1926,6 +1167,8 @@ Crafty.polygon.prototype = {
 /**@
  * #Crafty.circle
  * @category 2D
+ * @kind Class
+ * 
  * Circle object used for hitboxes and click maps. Must pass a `x`, a `y` and a `radius` value.
  *
  *@example
@@ -1960,6 +1203,8 @@ Crafty.circle.prototype = {
     /**@
      * #.containsPoint
      * @comp Crafty.circle
+     * @kind Method
+     * 
      * @sign public Boolean .containsPoint(Number x, Number y)
      * @param x - X position of the point
      * @param y - Y position of the point
@@ -1984,6 +1229,8 @@ Crafty.circle.prototype = {
     /**@
      * #.shift
      * @comp Crafty.circle
+     * @kind Method
+     * 
      * @sign public void .shift(Number x, Number y)
      * @param x - Amount to shift the `x` axis
      * @param y - Amount to shift the `y` axis

--- a/src/spatial/collision.js
+++ b/src/spatial/collision.js
@@ -6,6 +6,8 @@ Crafty.extend({
     /**@
      * #Crafty.raycast
      * @category 2D
+     * @kind Method
+     * 
      * @sign public Array .raycast(Object origin, Object direction[, Number maxDistance][, String comp][, Boolean sort])
      * @param origin - the point of origin from which the ray will be cast. The object must contain the properties `_x` and `_y`.
      * @param direction - the direction the ray will be cast. It must be normalized. The object must contain the properties `x` and `y`.
@@ -169,6 +171,8 @@ Crafty.extend({
 /**@
  * #Collision
  * @category 2D
+ * @kind Component
+ * 
  * @trigger HitOn - Triggered when collisions occur. Will not trigger again until collisions of this type cease, or an event is requested once more (using `resetHitChecks(component)`). - { hitData }
  * @trigger HitOff - Triggered when collision with a specific component type ceases - String - componentName
  *
@@ -204,6 +208,7 @@ Crafty.c("Collision", {
     /**@
      * #.collision
      * @comp Collision
+     * @kind Method
      *
      * @trigger NewHitbox - when a new hitbox is assigned - Crafty.polygon
      *
@@ -295,6 +300,8 @@ Crafty.c("Collision", {
     /**@
      * #.cbr
      * @comp Collision
+     * @kind Method
+     * 
      * @sign public Object .cbr([Object cbr])
      * @param cbr - an object to use as output
      * @returns an object with `_x`, `_y`, `_w`, and `_h` properties; if an object is passed in, it will be reused rather than creating a new object.
@@ -418,6 +425,8 @@ Crafty.c("Collision", {
     /**@
      * #.hit
      * @comp Collision
+     * @kind Method
+     * 
      * @sign public Array .hit(String component)
      * @param component - Check collision with entities that have this component
      * applied to them.
@@ -529,6 +538,8 @@ Crafty.c("Collision", {
     /**@
      * #.onHit
      * @comp Collision
+     * @kind Method
+     * 
      * @sign public this .onHit(String component, Function callbackOn[, Function callbackOff])
      * @param component - Component to check collisions for.
      * @param callbackOn - Callback method to execute upon collision with the component.
@@ -609,6 +620,8 @@ Crafty.c("Collision", {
     /**@
      * #.checkHits
      * @comp Collision
+     * @kind Method
+     * 
      * @sign public this .checkHits(String componentList)
      * @param componentList - A comma seperated list of components to check for collisions with.
      * @sign public this .checkHits(String component1[, .., String componentN])
@@ -678,6 +691,7 @@ Crafty.c("Collision", {
     /**@
      * #.ignoreHits
      * @comp Collision
+     * @kind Method
      *
      * @sign public this .ignoreHits()
      *
@@ -740,6 +754,8 @@ Crafty.c("Collision", {
     /**@
      * #.resetHitChecks
      * @comp Collision
+     * @kind Method
+     * 
      * @sign public this .resetHitChecks()
      * @sign public this .resetHitChecks(String componentList)
      * @param componentList - A comma seperated list of components to re-check

--- a/src/spatial/math.js
+++ b/src/spatial/math.js
@@ -4,6 +4,7 @@ var Crafty = require('../core/core.js');
 /**@
  * #Crafty.math
  * @category Utilities
+ * @kind CoreObj
  *
  * A set of utility functions for common (and not so common) operations.
  */
@@ -11,6 +12,8 @@ Crafty.math = {
     /**@
      * #Crafty.math.abs
      * @comp Crafty.math
+     * @kind Method
+     * 
      * @sign public this Crafty.math.abs(Number n)
      * @param n - Some value.
      * @return Absolute value.
@@ -24,6 +27,8 @@ Crafty.math = {
     /**@
      * #Crafty.math.amountOf
      * @comp Crafty.math
+     * @kind Method
+     * 
      * @sign public Number Crafty.math.amountOf(Number checkValue, Number minValue, Number maxValue)
      * @param checkValue - Value that should checked with minimum and maximum.
      * @param minValue - Bottom of the range
@@ -43,6 +48,8 @@ Crafty.math = {
     /**@
      * #Crafty.math.clamp
      * @comp Crafty.math
+     * @kind Method
+     * 
      * @sign public Number Crafty.math.clamp(Number value, Number min, Number max)
      * @param value - A value.
      * @param max - Maximum that value can be.
@@ -64,6 +71,8 @@ Crafty.math = {
      * #Crafty.math.degToRad
      * Converts angle from degree to radian.
      * @comp Crafty.math
+     * @kind Method
+     * 
      * @sign public Number degToRad(angleInDeg)
      * @param angleInDeg - The angle in degrees.
      * @return The angle in radians.
@@ -75,6 +84,8 @@ Crafty.math = {
     /**@
      * #Crafty.math.distance
      * @comp Crafty.math
+     * @kind Method
+     * 
      * @sign public Number Crafty.math.distance(Number x1, Number y1, Number x2, Number y2)
      * @param x1 - First x coordinate.
      * @param y1 - First y coordinate.
@@ -92,6 +103,8 @@ Crafty.math = {
     /**@
      * #Crafty.math.lerp
      * @comp Crafty.math
+     * @kind Method
+     * 
      * @sign public Number Crafty.math.lerp(Number value1, Number value2, Number amount)
      * @param value1 - One value.
      * @param value2 - Another value.
@@ -108,6 +121,8 @@ Crafty.math = {
     /**@
      * #Crafty.math.negate
      * @comp Crafty.math
+     * @kind Method
+     * 
      * @sign public Number Crafty.math.negate(Number percent)
      * @param percent - The probability of returning `-1`
      * @return 1 or -1.
@@ -124,6 +139,8 @@ Crafty.math = {
     /**@
      * #Crafty.math.radToDeg
      * @comp Crafty.math
+     * @kind Method
+     * 
      * @sign public Number Crafty.math.radToDeg(Number angle)
      * @param angleInRad - The angle in radian.
      * @return The angle in degree.
@@ -137,6 +154,8 @@ Crafty.math = {
     /**@
      * #Crafty.math.randomElementOfArray
      * @comp Crafty.math
+     * @kind Method
+     * 
      * @sign public Object Crafty.math.randomElementOfArray(Array array)
      * @param array - A specific array.
      * @return A random element of a specific array.
@@ -150,6 +169,8 @@ Crafty.math = {
     /**@
      * #Crafty.math.randomInt
      * @comp Crafty.math
+     * @kind Method
+     * 
      * @sign public Number Crafty.math.randomInt(Number start, Number end)
      * @param start - Smallest int value that can be returned.
      * @param end - Biggest int value that can be returned.
@@ -164,6 +185,8 @@ Crafty.math = {
     /**@
      * #Crafty.math.randomNumber
      * @comp Crafty.math
+     * @kind Method
+     * 
      * @sign public Number Crafty.math.randomNumber(Number start, Number end)
      * @param start - Smallest number value that can be returned.
      * @param end - Biggest number value that can be returned.
@@ -178,6 +201,8 @@ Crafty.math = {
     /**@
      * #Crafty.math.squaredDistance
      * @comp Crafty.math
+     * @kind Method
+     * 
      * @sign public Number Crafty.math.squaredDistance(Number x1, Number y1, Number x2, Number y2)
      * @param x1 - First x coordinate.
      * @param y1 - First y coordinate.
@@ -194,6 +219,8 @@ Crafty.math = {
     /**@
      * #Crafty.math.withinRange
      * @comp Crafty.math
+     * @kind Method
+     * 
      * @sign public Boolean Crafty.math.withinRange(Number value, Number min, Number max)
      * @param value - The specific value.
      * @param min - Minimum value.
@@ -211,6 +238,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #Crafty.math.Vector2D
      * @category 2D
+     * @kind Class
+     * 
      * @class This is a general purpose 2D vector class
      *
      * Vector2D uses the following form:
@@ -241,6 +270,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.add
      * @comp Crafty.math.Vector2D
+     * @kind Method
+     * 
      *
      * Adds the passed vector to this vector
      *
@@ -258,6 +289,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.angleBetween
      * @comp Crafty.math.Vector2D
+     * @kind Method
+     * 
      *
      * Calculates the angle between the passed vector and this vector, using <0,0> as the point of reference.
      * Angles returned have the range (−π, π].
@@ -274,6 +307,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.angleTo
      * @comp Crafty.math.Vector2D
+     * @kind Method
+     * 
      *
      * Calculates the angle to the passed vector from this vector, using this vector as the point of reference.
      *
@@ -289,6 +324,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.clone
      * @comp Crafty.math.Vector2D
+     * @kind Method
+     * 
      *
      * Creates and exact, numeric copy of this vector
      *
@@ -303,6 +340,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.distance
      * @comp Crafty.math.Vector2D
+     * @kind Method
+     * 
      *
      * Calculates the distance from this vector to the passed vector.
      *
@@ -318,6 +357,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.distanceSq
      * @comp Crafty.math.Vector2D
+     * @kind Method
+     * 
      *
      * Calculates the squared distance from this vector to the passed vector.
      * This function avoids calculating the square root, thus being slightly faster than .distance( ).
@@ -335,6 +376,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.divide
      * @comp Crafty.math.Vector2D
+     * @kind Method
+     * 
      *
      * Divides this vector by the passed vector.
      *
@@ -352,6 +395,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.dotProduct
      * @comp Crafty.math.Vector2D
+     * @kind Method
+     * 
      *
      * Calculates the dot product of this and the passed vectors
      *
@@ -367,6 +412,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.crossProduct
      * @comp Crafty.math.Vector2D
+     * @kind Method
+     * 
      *
      * Calculates the z component of the cross product of the two vectors augmented to 3D.
      *
@@ -382,6 +429,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.equals
      * @comp Crafty.math.Vector2D
+     * @kind Method
+     * 
      *
      * Determines if this vector is numerically equivalent to the passed vector.
      *
@@ -398,6 +447,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.perpendicular
      * @comp Crafty.math.Vector2D
+     * @kind Method
+     * 
      *
      * Calculates a new vector that is perpendicular to this vector.
      * The perpendicular vector has the same magnitude as this vector and is obtained by a counter-clockwise rotation of 90° of this vector.
@@ -415,6 +466,7 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.getNormal
      * @comp Crafty.math.Vector2D
+     * @kind Method
      *
      * Calculates a new right-handed unit vector that is perpendicular to the line created by this and the passed vector.
      *
@@ -432,6 +484,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.isZero
      * @comp Crafty.math.Vector2D
+     * @kind Method
+     * 
      *
      * Determines if this vector is equal to <0,0>
      *
@@ -446,6 +500,7 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.magnitude
      * @comp Crafty.math.Vector2D
+     * @kind Method
      *
      * Calculates the magnitude of this vector.
      * Note: Function objects in JavaScript already have a 'length' member, hence the use of magnitude instead.
@@ -461,7 +516,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.magnitudeSq
      * @comp Crafty.math.Vector2D
-     *
+     * @kind Method
+     * 
      * Calculates the square of the magnitude of this vector.
      * This function avoids calculating the square root, thus being slightly faster than .magnitude( ).
      *
@@ -477,7 +533,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.multiply
      * @comp Crafty.math.Vector2D
-     *
+     * @kind Method
+     * 
      * Multiplies this vector by the passed vector
      *
      * @public
@@ -494,7 +551,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.negate
      * @comp Crafty.math.Vector2D
-     *
+     * @kind Method
+     * 
      * Negates this vector (ie. <-x,-y>)
      *
      * @public
@@ -510,7 +568,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.normalize
      * @comp Crafty.math.Vector2D
-     *
+     * @kind Method
+     * 
      * Normalizes this vector (scales the vector so that its new magnitude is 1)
      * For vectors where magnitude is 0, <1,0> is returned.
      *
@@ -536,7 +595,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.scale
      * @comp Crafty.math.Vector2D
-     *
+     * @kind Method
+     * 
      * Scales this vector by the passed amount(s)
      * If scalarY is omitted, scalarX is used for both axes
      *
@@ -559,7 +619,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.scaleToMagnitude
      * @comp Crafty.math.Vector2D
-     *
+     * @kind Method
+     * 
      * Scales this vector such that its new magnitude is equal to the passed value.
      *
      * @public
@@ -577,7 +638,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.setValues
      * @comp Crafty.math.Vector2D
-     *
+     * @kind Method
+     * 
      * Sets the values of this vector using a passed vector or pair of numbers.
      *
      * @public
@@ -602,7 +664,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.subtract
      * @comp Crafty.math.Vector2D
-     *
+     * @kind Method
+     * 
      * Subtracts the passed vector from this vector.
      *
      * @public
@@ -619,7 +682,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.toString
      * @comp Crafty.math.Vector2D
-     *
+     * @kind Method
+     * 
      * Returns a string representation of this vector.
      *
      * @public
@@ -633,7 +697,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.translate
      * @comp Crafty.math.Vector2D
-     *
+     * @kind Method
+     * 
      * Translates (moves) this vector by the passed amounts.
      * If dy is omitted, dx is used for both axes.
      *
@@ -656,7 +721,8 @@ Crafty.math.Vector2D = (function () {
     /**@
      * #.tripleProduct
      * @comp Crafty.math.Vector2D
-     *
+     * @kind Method
+     * 
      * Calculates the triple product of three vectors.
      * triple vector product = b(a•c) - a(b•c)
      *
@@ -683,7 +749,8 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #Crafty.math.Matrix2D
      * @category 2D
-     *
+     * @kind Class
+     * 
      * @class This is a 2D Matrix2D class. It is 3x3 to allow for affine transformations in 2D space.
      * The third row is always assumed to be [0, 0, 1].
      *
@@ -732,7 +799,8 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.apply
      * @comp Crafty.math.Matrix2D
-     *
+     * @kind Method
+     * 
      * Applies the matrix transformations to the passed object
      *
      * @public
@@ -757,7 +825,8 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.clone
      * @comp Crafty.math.Matrix2D
-     *
+     * @kind Method
+     * 
      * Creates an exact, numeric copy of the current matrix
      *
      * @public
@@ -771,6 +840,7 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.combine
      * @comp Crafty.math.Matrix2D
+     * @kind Method
      *
      * Multiplies this matrix with another, overriding the values of this matrix.
      * The passed matrix is assumed to be on the right-hand side.
@@ -796,6 +866,7 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.equals
      * @comp Crafty.math.Matrix2D
+     * @kind Method
      *
      * Checks for the numeric equality of this matrix versus another.
      *
@@ -813,6 +884,7 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.determinant
      * @comp Crafty.math.Matrix2D
+     * @kind Method
      *
      * Calculates the determinant of this matrix
      *
@@ -827,6 +899,7 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.invert
      * @comp Crafty.math.Matrix2D
+     * @kind Method
      *
      * Inverts this matrix if possible
      *
@@ -862,7 +935,8 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.isIdentity
      * @comp Crafty.math.Matrix2D
-     *
+     * @kind Method
+     * 
      * Returns true if this matrix is the identity matrix
      *
      * @public
@@ -876,7 +950,8 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.isInvertible
      * @comp Crafty.math.Matrix2D
-     *
+     * @kind Method
+     * 
      * Determines is this matrix is invertible.
      *
      * @public
@@ -891,7 +966,8 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.preRotate
      * @comp Crafty.math.Matrix2D
-     *
+     * @kind Method
+     * 
      * Applies a counter-clockwise pre-rotation to this matrix
      *
      * @public
@@ -916,7 +992,8 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.preScale
      * @comp Crafty.math.Matrix2D
-     *
+     * @kind Method
+     * 
      * Applies a pre-scaling to this matrix
      *
      * @public
@@ -940,7 +1017,8 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.preTranslate
      * @comp Crafty.math.Matrix2D
-     *
+     * @kind Method
+     * 
      * Applies a pre-translation to this matrix
      *
      * @public
@@ -965,7 +1043,8 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.rotate
      * @comp Crafty.math.Matrix2D
-     *
+     * @kind Method
+     * 
      * Applies a counter-clockwise post-rotation to this matrix
      *
      * @public
@@ -993,7 +1072,8 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.scale
      * @comp Crafty.math.Matrix2D
-     *
+     * @kind Method
+     * 
      * Applies a post-scaling to this matrix
      *
      * @public
@@ -1019,7 +1099,8 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.setValues
      * @comp Crafty.math.Matrix2D
-     *
+     * @kind Method
+     * 
      * Sets the values of this matrix
      *
      * @public
@@ -1056,7 +1137,8 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.toString
      * @comp Crafty.math.Matrix2D
-     *
+     * @kind Method
+     * 
      * Returns the string representation of this matrix.
      *
      * @public
@@ -1071,7 +1153,8 @@ Crafty.math.Matrix2D = (function () {
     /**@
      * #.translate
      * @comp Crafty.math.Matrix2D
-     *
+     * @kind Method
+     * 
      * Applies a post-translation to this matrix
      *
      * @public

--- a/src/spatial/motion.js
+++ b/src/spatial/motion.js
@@ -1,0 +1,515 @@
+var Crafty = require('../core/core.js');
+
+
+
+// This is used to define getters and setters for Motion properties
+// For instance
+//      __motionProp(entity, "a", "x", true) 
+// will define a getter for `ax` which accesses an underlying private property `_ax`
+// If the `setter` property is false, setting a value will be a null-op
+var __motionProp = function(self, prefix, prop, setter) {
+    var publicProp = prefix + prop;
+    var privateProp = "_" + publicProp;
+
+    var motionEvent = { key: "", oldValue: 0};
+    // getters & setters for public property
+    if (setter) {
+        Crafty.defineField(self, publicProp, function() { return this[privateProp]; }, function(newValue) {
+            var oldValue = this[privateProp];
+            if (newValue !== oldValue) {
+                this[privateProp] = newValue;
+
+                motionEvent.key = publicProp;
+                motionEvent.oldValue = oldValue;
+                this.trigger("MotionChange", motionEvent);
+            }
+        });
+    } else {
+        Crafty.defineField(self, publicProp, function() { return this[privateProp]; }, function(newValue) {});
+    }
+
+    // hide private property
+    Object.defineProperty(self, privateProp, {
+        value : 0,
+        writable : true,
+        enumerable : false,
+        configurable : false
+    });
+};
+
+// This defines an alias for a pair of underlying properties which represent the components of a vector
+// It takes an object with vector methods, and redefines its x/y properties as getters and setters to properties of self
+// This allows you to use the vector's special methods to manipulate the entity's properties, 
+// while still allowing you to manipulate those properties directly if performance matters
+var __motionVector = function(self, prefix, setter, vector) {
+    var publicX = prefix + "x",
+        publicY = prefix + "y",
+        privateX = "_" + publicX,
+        privateY = "_" + publicY;
+
+    if (setter) {
+        Crafty.defineField(vector, "x", function() { return self[privateX]; }, function(v) { self[publicX] = v; });
+        Crafty.defineField(vector, "y", function() { return self[privateY]; }, function(v) { self[publicY] = v; });
+    } else {
+        Crafty.defineField(vector, "x", function() { return self[privateX]; }, function(v) {});
+        Crafty.defineField(vector, "y", function() { return self[privateY]; }, function(v) {});
+    }
+    if (Object.seal) { Object.seal(vector); }
+
+    return vector;
+};
+
+/**@
+ * #AngularMotion
+ * @category 2D
+ * @kind Component
+ * 
+ * @trigger Rotated - When entity has rotated due to angular velocity/acceleration a Rotated event is triggered. - Number - Old rotation
+ * @trigger NewRotationDirection - When entity has changed rotational direction due to rotational velocity a NewRotationDirection event is triggered. The event is triggered once, if direction is different from last frame. - -1 | 0 | 1 - New direction
+ * @trigger MotionChange - When a motion property has changed a MotionChange event is triggered. - { key: String, oldValue: Number } - Motion property name and old value
+ *
+ * Component that allows rotating an entity by applying angular velocity and acceleration.
+ * All angular motion values are expressed in degrees per second (e.g. an entity with `vrotation` of 10 will rotate 10 degrees each second).
+ */
+Crafty.c("AngularMotion", {
+    /**@
+     * #.vrotation
+     * @comp AngularMotion
+     * @kind Property
+     * 
+     * A property for accessing/modifying the angular(rotational) velocity. 
+     * The velocity remains constant over time, unless the acceleration increases the velocity.
+     *
+     * @example
+     * ~~~
+     * var ent = Crafty.e("2D, AngularMotion");
+     *
+     * var vrotation = ent.vrotation; // retrieve the angular velocity
+     * ent.vrotation += 1; // increase the angular velocity
+     * ent.vrotation = 0; // reset the angular velocity
+     * ~~~
+     */
+    _vrotation: 0,
+
+    /**@
+     * #.arotation
+     * @comp AngularMotion
+     * @kind Property
+     * 
+     * A property for accessing/modifying the angular(rotational) acceleration. 
+     * The acceleration increases the velocity over time, resulting in ever increasing speed.
+     *
+     * @example
+     * ~~~
+     * var ent = Crafty.e("2D, AngularMotion");
+     *
+     * var arotation = ent.arotation; // retrieve the angular acceleration
+     * ent.arotation += 1; // increase the angular acceleration
+     * ent.arotation = 0; // reset the angular acceleration
+     * ~~~
+     */
+    _arotation: 0,
+
+    /**@
+     * #.drotation
+     * @comp AngularMotion
+     * @kind Property
+     * 
+     * A number that reflects the change in rotation (difference between the old & new rotation) that was applied in the last frame.
+     *
+     * @example
+     * ~~~
+     * var ent = Crafty.e("2D, AngularMotion");
+     *
+     * var drotation = ent.drotation; // the change of rotation in the last frame
+     * ~~~
+     */
+    _drotation: 0,
+
+    init: function () {
+        this.requires("2D");
+
+        __motionProp(this, "v", "rotation", true);
+        __motionProp(this, "a", "rotation", true);
+        __motionProp(this, "d", "rotation", false);
+
+        this.__oldRotationDirection = 0;
+
+        this.bind("EnterFrame", this._angularMotionTick);
+    },
+    remove: function(destroyed) {
+        this.unbind("EnterFrame", this._angularMotionTick);
+    },
+
+    /**@
+     * #.resetAngularMotion
+     * @comp AngularMotion
+     * @kind Method
+     * 
+     * @sign public this .resetAngularMotion()
+     * 
+     * Reset all motion (resets velocity, acceleration, motionDelta).
+     */
+    resetAngularMotion: function() {
+        this._drotation = 0;
+        this.vrotation = 0;
+        this.arotation = 0;
+
+        return this;
+    },
+
+    /*
+     * s += v * Δt + (0.5 * a) * Δt * Δt
+     * v += a * Δt
+     */
+    _angularMotionTick: function(frameData) {
+        var dt = frameData.dt / 1000; // Time in s
+        var oldR = this._rotation,
+            vr = this._vrotation,
+            ar = this._arotation;
+
+        // s += v * Δt + (0.5 * a) * Δt * Δt
+        var newR = oldR + vr * dt + 0.5 * ar * dt * dt;
+        // v += a * Δt
+        this.vrotation = vr + ar * dt;
+
+        // Check if direction of velocity has changed
+        var _vr = this._vrotation, dvr = _vr ? (_vr<0 ? -1:1):0; // Quick implementation of Math.sign
+        if (this.__oldRotationDirection !== dvr) {
+            this.__oldRotationDirection = dvr;
+            this.trigger('NewRotationDirection', dvr);
+        }
+
+        // Check if velocity has changed
+        // Δs = s[t] - s[t-1]
+        this._drotation = newR - oldR;
+        if (this._drotation !== 0) {
+            this.rotation = newR;
+            this.trigger('Rotated', oldR);
+        }
+    }
+});
+
+/**@
+ * #Motion
+ * @category 2D
+ * @kind Component
+ * 
+ * @trigger Moved - When entity has moved due to velocity/acceleration on either x or y axis a Moved event is triggered. If the entity has moved on both axes for diagonal movement the event is triggered twice. - { axis: 'x' | 'y', oldValue: Number } - Old position
+ * @trigger NewDirection - When entity has changed direction due to velocity on either x or y axis a NewDirection event is triggered. The event is triggered once, if direction is different from last frame. - { x: -1 | 0 | 1, y: -1 | 0 | 1 } - New direction
+ * @trigger MotionChange - When a motion property has changed a MotionChange event is triggered. - { key: String, oldValue: Number } - Motion property name and old value
+ *
+ * Component that allows moving an entity by applying linear velocity and acceleration.
+ * All linear motion values are expressed in pixels per second (e.g. an entity with `vx` of 1 will move 1px on the x axis each second).
+ *
+ * @note Several methods return Vector2D objects that dynamically reflect the entity's underlying properties.  If you want a static copy instead, use the vector's `clone()` method.
+ */
+Crafty.c("Motion", {
+    /**@
+     * #.vx
+     * @comp Motion
+     * @kind Property
+     * 
+     * A property for accessing/modifying the linear velocity in the x axis.
+     * The velocity remains constant over time, unless the acceleration changes the velocity.
+     *
+     * @example
+     * ~~~
+     * var ent = Crafty.e("2D, Motion");
+     *
+     * var vx = ent.vx; // retrieve the linear velocity in the x axis
+     * ent.vx += 1; // increase the linear velocity in the x axis
+     * ent.vx = 0; // reset the linear velocity in the x axis
+     * ~~~
+     */
+    _vx: 0,
+
+    /**@
+     * #.vy
+     * @comp Motion
+     * @kind Property
+     * 
+     * A property for accessing/modifying the linear velocity in the y axis.
+     * The velocity remains constant over time, unless the acceleration changes the velocity.
+     *
+     * @example
+     * ~~~
+     * var ent = Crafty.e("2D, Motion");
+     *
+     * var vy = ent.vy; // retrieve the linear velocity in the y axis
+     * ent.vy += 1; // increase the linear velocity in the y axis
+     * ent.vy = 0; // reset the linear velocity in the y axis
+     * ~~~
+     */
+    _vy: 0,
+
+    /**@
+     * #.ax
+     * @comp Motion
+     * @kind Property
+     * 
+     * A property for accessing/modifying the linear acceleration in the x axis.
+     * The acceleration changes the velocity over time.
+     *
+     * @example
+     * ~~~
+     * var ent = Crafty.e("2D, Motion");
+     *
+     * var ax = ent.ax; // retrieve the linear acceleration in the x axis
+     * ent.ax += 1; // increase the linear acceleration in the x axis
+     * ent.ax = 0; // reset the linear acceleration in the x axis
+     * ~~~
+     */
+    _ax: 0,
+
+    /**@
+     * #.ay
+     * @comp Motion
+     * @kind Property
+     * 
+     * A property for accessing/modifying the linear acceleration in the y axis.
+     * The acceleration changes the velocity over time.
+     *
+     * @example
+     * ~~~
+     * var ent = Crafty.e("2D, Motion");
+     *
+     * var ay = ent.ay; // retrieve the linear acceleration in the y axis
+     * ent.ay += 1; // increase the linear acceleration in the y axis
+     * ent.ay = 0; // reset the linear acceleration in the y axis
+     * ~~~
+     */
+    _ay: 0,
+
+    /**@
+     * #.dx
+     * @comp Motion
+     * @kind Property
+     * 
+     * A number that reflects the change in x (difference between the old & new x) that was applied in the last frame.
+     *
+     * @example
+     * ~~~
+     * var ent = Crafty.e("2D, Motion");
+     *
+     * var dx = ent.dx; // the change of x in the last frame
+     * ~~~
+     */
+    _dx: 0,
+
+    /**@
+     * #.dy
+     * @comp Motion
+     * @kind Property
+     * 
+     * A number that reflects the change in y (difference between the old & new y) that was applied in the last frame.
+     *
+     * @example
+     * ~~~
+     * var ent = Crafty.e("2D, Motion");
+     *
+     * var dy = ent.dy; // the change of y in the last frame
+     * ~~~
+     */
+    _dy: 0,
+
+    init: function () {
+        this.requires("2D");
+
+        __motionProp(this, "v", "x", true);
+        __motionProp(this, "v", "y", true);
+        this._velocity = __motionVector(this, "v", true, new Crafty.math.Vector2D());
+        __motionProp(this, "a", "x", true);
+        __motionProp(this, "a", "y", true);
+        this._acceleration = __motionVector(this, "a", true, new Crafty.math.Vector2D());
+        __motionProp(this, "d", "x", false);
+        __motionProp(this, "d", "y", false);
+        this._motionDelta = __motionVector(this, "d", false, new Crafty.math.Vector2D());
+
+        this.__movedEvent = {axis: '', oldValue: 0};
+        this.__oldDirection = {x: 0, y: 0};
+
+        this.bind("EnterFrame", this._linearMotionTick);
+    },
+    remove: function(destroyed) {
+        this.unbind("EnterFrame", this._linearMotionTick);
+    },
+
+    /**@
+     * #.resetMotion
+     * @comp Motion
+     * @kind Method
+     * 
+     * @sign public this .resetMotion()
+     * @return this
+     * 
+     * Reset all linear motion (resets velocity, acceleration, motionDelta).
+     */
+    resetMotion: function() {
+        this.vx = 0; this.vy = 0;
+        this.ax = 0; this.ay = 0;
+        this._dx = 0; this._dy = 0;
+
+        return this;
+    },
+
+    /**@
+     * #.motionDelta
+     * @comp Motion
+     * @kind Method
+     * 
+     * @sign public Vector2D .motionDelta()
+     * @return A Vector2D with the properties {x, y} that reflect the change in x & y.
+     * 
+     * Returns the difference between the old & new position that was applied in the last frame.
+     *
+     * @example
+     * ~~~
+     * var ent = Crafty.e("2D, Motion");
+     *
+     * var deltaY = ent.motionDelta().y; // the change of y in the last frame
+     * ~~~
+     * @see Crafty.math.Vector2D
+     */
+    motionDelta: function() {
+        return this._motionDelta;
+    },
+
+    /**@
+     * #.velocity
+     * @comp Motion
+     * @kind Method
+     * 
+     * Method for accessing/modifying the linear(x,y) velocity. 
+     * The velocity remains constant over time, unless the acceleration increases the velocity.
+     *
+     * @sign public Vector2D .velocity()
+     * @return The velocity Vector2D with the properties {x, y} that reflect the velocities in the <x, y> direction of the entity.
+     *
+     * Returns the current velocity. You can access/modify the properties in order to retrieve/change the velocity.
+
+     * @example
+     * ~~~
+     * var ent = Crafty.e("2D, Motion");
+     *
+     * var vel = ent.velocity(); //returns the velocity vector
+     * vel.x;       // retrieve the velocity in the x direction
+     * vel.x = 0;   // set the velocity in the x direction
+     * vel.x += 4   // add to the velocity in the x direction
+     * ~~~
+     * @see Crafty.math.Vector2D
+     */
+    velocity: function() {
+        return this._velocity;
+    },
+
+
+    /**@
+     * #.acceleration
+     * @comp Motion
+     * @kind Method
+     * 
+     * Method for accessing/modifying the linear(x,y) acceleration. 
+     * The acceleration increases the velocity over time, resulting in ever increasing speed.
+     * 
+     * @sign public Vector2D .acceleration()
+     * @return The acceleration Vector2D with the properties {x, y} that reflects the acceleration in the <x, y> direction of the entity.
+     *
+     * Returns the current acceleration. You can access/modify the properties in order to retrieve/change the acceleration.
+     *
+     * @example
+     * ~~~
+     * var ent = Crafty.e("2D, Motion");
+     *
+     * var acc = ent.acceleration(); //returns the acceleration object
+     * acc.x;       // retrieve the acceleration in the x direction
+     * acc.x = 0;   // set the acceleration in the x direction
+     * acc.x += 4   // add to the acceleration in the x direction
+     * ~~~
+     * @see Crafty.math.Vector2D
+     */
+    acceleration: function() {
+        return this._acceleration;
+    },
+
+    /**@
+     * #.ccdbr
+     * @comp Motion
+     * @kind Method
+     * 
+     * @sign public Object .ccdbr([Object ccdbr])
+     * @param ccdbr - an object to use as output
+     * @returns an object with `_x`, `_y`, `_w`, and `_h` properties; if an object is passed in, it will be reused rather than creating a new object.
+     *
+     * Return an object containing the entity's continuous collision detection bounding rectangle.
+     * The CCDBR encompasses the motion delta of the entity's bounding rectangle since last frame.
+     * The CCDBR is minimal if the entity moved on only one axis since last frame, however it encompasses a non-minimal region if it moved on both axis.
+     * For further details, refer to [FAQ#Tunneling](https://github.com/craftyjs/Crafty/wiki/Crafty-FAQ-%28draft%29#why-are-my-bullets-passing-through-other-entities-without-registering-hits).
+     *
+     * @note The keys have an underscore prefix. This is due to the x, y, w, h properties
+     * being setters and getters that wrap the underlying properties with an underscore (_x, _y, _w, _h).
+     *
+     * @see .motionDelta, Collision#.cbr
+     */
+    ccdbr: function (ccdbr) {
+        var pos = this._cbr || this._mbr || this,
+            dx = this._dx,
+            dy = this._dy,
+            ccdX = 0, ccdY = 0,
+            ccdW = dx > 0 ? (ccdX = dx) : -dx,
+            ccdH = dy > 0 ? (ccdY = dy) : -dy;
+
+        ccdbr = ccdbr || {};
+        ccdbr._x = pos._x - ccdX;
+        ccdbr._y = pos._y - ccdY;
+        ccdbr._w = pos._w + ccdW;
+        ccdbr._h = pos._h + ccdH;
+
+        return ccdbr;
+    },
+
+    /*
+     * s += v * Δt + (0.5 * a) * Δt * Δt
+     * v += a * Δt
+     */
+    _linearMotionTick: function(frameData) {
+        var dt = frameData.dt / 1000; // time in s
+        var oldX = this._x, vx = this._vx, ax = this._ax,
+            oldY = this._y, vy = this._vy, ay = this._ay;
+
+        // s += v * Δt + (0.5 * a) * Δt * Δt
+        var newX = oldX + vx * dt + 0.5 * ax * dt * dt;
+        var newY = oldY + vy * dt + 0.5 * ay * dt * dt;
+        // v += a * Δt
+        this.vx = vx + ax * dt;
+        this.vy = vy + ay * dt;
+
+        // Check if direction of velocity has changed
+        var oldDirection = this.__oldDirection,
+            _vx = this._vx, dvx = _vx ? (_vx<0 ? -1:1):0, // A quick implementation of Math.sign
+            _vy = this._vy, dvy = _vy ? (_vy<0 ? -1:1):0;
+        if (oldDirection.x !== dvx || oldDirection.y !== dvy) {
+            oldDirection.x = dvx;
+            oldDirection.y = dvy;
+            this.trigger('NewDirection', oldDirection);
+        }
+
+        // Check if velocity has changed
+        var movedEvent = this.__movedEvent;
+        // Δs = s[t] - s[t-1]
+        this._dx = newX - oldX;
+        this._dy = newY - oldY;
+        if (this._dx !== 0) {
+            this.x = newX;
+            movedEvent.axis = 'x';
+            movedEvent.oldValue = oldX;
+            this.trigger('Moved', movedEvent);
+        }
+        if (this._dy !== 0) {
+            this.y = newY;
+            movedEvent.axis = 'y';
+            movedEvent.oldValue = oldY;
+            this.trigger('Moved', movedEvent);
+        }
+    }
+});

--- a/src/spatial/platform.js
+++ b/src/spatial/platform.js
@@ -1,0 +1,349 @@
+var Crafty = require('../core/core.js');
+
+/**@
+ * #Supportable
+ * @category 2D
+ * @kind Component
+ * 
+ * @trigger LandedOnGround - When entity has landed. This event is triggered with the object the entity landed on.
+ * @trigger LiftedOffGround - When entity has lifted off. This event is triggered with the object the entity stood on before lift-off.
+ * @trigger CheckLanding - When entity is about to land. This event is triggered with the object the entity is about to land on. Third parties can respond to this event and prevent the entity from being able to land.
+ *
+ * Component that detects if the entity collides with the ground. This component is automatically added and managed by the Gravity component.
+ * The appropriate events are fired when the entity state changes (lands on ground / lifts off ground). The current ground entity can also be accessed with `.ground`.
+ */
+Crafty.c("Supportable", {
+    /**@
+     * #.ground
+     * @comp Supportable
+     * @kind Property
+     *
+     * Access the ground entity (which may be the actual ground entity if it exists, or `null` if it doesn't exist) and thus whether this entity is currently on the ground or not. 
+     * The ground entity is also available through the events, when the ground entity changes.
+     */
+    _ground: null,
+    _groundComp: null,
+    _preventGroundTunneling: false,
+
+    /**@
+     * #.canLand
+     * @comp Supportable
+     * @kind Property
+     *
+     * The canLand boolean determines if the entity is allowed to land or not (e.g. perhaps the entity should not land if it's not falling).
+     * The Supportable component will trigger a "CheckLanding" event. 
+     * Interested parties can listen to this event and prevent the entity from landing by setting `canLand` to false.
+     *
+     * @example
+     * ~~~
+     * var player = Crafty.e("2D, Gravity");
+     * player.bind("CheckLanding", function(ground) {
+     *     if (player.y + player.h > ground.y + player.dy) { // forbid landing, if player's feet are not above ground
+     *         player.canLand = false;
+     *     }
+     * });
+     * ~~~
+     */
+    canLand: true,
+
+    init: function () {
+        this.requires("2D");
+        this.__area = {_x: 0, _y: 0, _w: 0, _h: 0};
+        this.defineField("ground", function() { return this._ground; }, function(newValue) {});
+    },
+    remove: function(destroyed) {
+        this.unbind("EnterFrame", this._detectGroundTick);
+    },
+
+    /*@
+     * #.startGroundDetection
+     * @comp Supportable
+     * @kind Method
+     * 
+     * @sign private this .startGroundDetection([comp])
+     * @param comp - The name of a component that will be treated as ground
+     *
+     * This method is automatically called by the Gravity component and should not be called by the user.
+     *
+     * Enable ground detection for this entity no matter whether comp parameter is specified or not.
+     * If comp parameter is specified all entities with that component will stop this entity from falling.
+     * For a player entity in a platform game this would be a component that is added to all entities
+     * that the player should be able to walk on.
+     * 
+     * @example
+     * ~~~
+     * Crafty.e("2D, DOM, Color, Gravity")
+     *   .color("red")
+     *   .attr({ w: 100, h: 100 })
+     *   .gravity("platform");
+     * ~~~
+     *
+     * @see Gravity
+     */
+    startGroundDetection: function(ground) {
+        if (ground) this._groundComp = ground;
+        this.uniqueBind("EnterFrame", this._detectGroundTick);
+
+        return this;
+    },
+    /*@
+     * #.stopGroundDetection
+     * @comp Supportable
+     * @kind Method
+     * 
+     * @sign private this .stopGroundDetection()
+     *
+     * This method is automatically called by the Gravity component and should not be called by the user.
+     *
+     * Disable ground detection for this component. It can be reenabled by calling .startGroundDetection()
+     */
+    stopGroundDetection: function() {
+        this.unbind("EnterFrame", this._detectGroundTick);
+
+        return this;
+    },
+
+    /**@
+     * #.preventGroundTunneling
+     * @comp Supportable
+     * @kind Method
+     * 
+     * @sign this .preventGroundTunneling([Boolean enable])
+     * @param enable - Boolean indicating whether to enable continous collision detection or not; if omitted defaults to true
+     *
+     * Prevent entity from falling through thin ground entities at high speeds. This setting is disabled by default.
+     * This is performed by approximating continous collision detection, which may impact performance negatively.
+     * For further details, refer to [FAQ#Tunneling](https://github.com/craftyjs/Crafty/wiki/Crafty-FAQ-%28draft%29#why-are-my-bullets-passing-through-other-entities-without-registering-hits).
+     *
+     * @see Motion#.ccdbr
+     */
+    preventGroundTunneling: function(enable) {
+        if (typeof enable === 'undefined')
+            enable = true;
+        if (enable)
+            this.requires("Motion");
+        this._preventGroundTunneling = enable;
+
+        return this;
+    },
+
+    _detectGroundTick: function() {
+        var groundComp = this._groundComp,
+            ground = this._ground,
+            overlap = Crafty.rectManager.overlap,
+            area;
+
+        if (!this._preventGroundTunneling) {
+            var pos = this._cbr || this._mbr || this;
+            area = this.__area;
+            area._x = pos._x;
+            area._y = pos._y;
+            area._w = pos._w;
+            area._h = pos._h;
+        } else {
+            area = this.ccdbr(this.__area);
+        }
+        area._h++; // Increase by 1 to make sure map.search() finds the floor
+        // Decrease width by 1px from left and 1px from right, to fall more gracefully
+        // area._x++; area._w--;
+
+
+        // check if we lift-off
+        if (ground) {
+            var garea = ground._cbr || ground._mbr || ground;
+            if (!(ground.__c[groundComp] && Crafty(ground[0]) === ground && overlap(garea, area))) {
+                this._ground = null;
+                this.trigger("LiftedOffGround", ground); // no collision with ground was detected for first time
+                ground = null;
+            }
+        }
+
+        // check if we land (also possible to land on other ground object in same frame after lift-off from current ground object)
+        if (!ground) {
+            var obj, oarea,
+                results = Crafty.map.search(area, false),
+                i = 0,
+                l = results.length;
+
+            for (; i < l; ++i) {
+                obj = results[i];
+                oarea = obj._cbr || obj._mbr || obj;
+                // check for an intersection with the player
+                if (obj !== this && obj.__c[groundComp] && overlap(oarea, area)) {
+                    this.canLand = true;
+                    this.trigger("CheckLanding", obj); // is entity allowed to land?
+                    if (this.canLand) {
+                        this._ground = ground = obj;
+
+                        // snap entity to ground object
+                        this.y = ground._y - this._h;
+                        if (this._x > ground._x + ground._w)
+                            this.x = ground._x + ground._w - 1;
+                        else if (this._x + this._w < ground._x)
+                            this.x = ground._x - this._w + 1;
+
+                        this.trigger("LandedOnGround", ground); // collision with ground was detected for first time
+                        break;
+                    }
+                }
+            }
+        }
+    }
+});
+
+/**@
+ * #GroundAttacher
+ * @category 2D
+ * @kind Component
+ *
+ * Attach the entity to the ground when it lands. Useful for platformers with moving platforms.
+ * Remove the component to disable the functionality.
+ *
+ * Additionally, this component provides the entity with `Supportable` methods & events.
+ *
+ * @example
+ * ~~~
+ * Crafty.e("2D, Gravity, GroundAttacher")
+ *     .gravity("Platform"); // entity will land on and move with entites that have the "Platform" component
+ * ~~~
+ *
+ * @see Supportable, Gravity
+ */
+Crafty.c("GroundAttacher", {
+    _groundAttach: function(ground) {
+        ground.attach(this);
+    },
+    _groundDetach: function(ground) {
+        ground.detach(this);
+    },
+
+    init: function () {
+        this.requires("Supportable");
+
+        this.bind("LandedOnGround", this._groundAttach);
+        this.bind("LiftedOffGround", this._groundDetach);
+    },
+    remove: function(destroyed) {
+        this.unbind("LandedOnGround", this._groundAttach);
+        this.unbind("LiftedOffGround", this._groundDetach);
+    }
+});
+
+
+/**@
+ * #Gravity
+ * @category 2D
+ * @kind Component
+ * 
+ * Adds gravitational pull to the entity.
+ *
+ * Additionally, this component provides the entity with `Supportable` and `Motion` methods & events.
+ *
+ * @see Supportable, Motion
+ */
+Crafty.c("Gravity", {
+    _gravityConst: 500,
+    _gravityActive: false,
+
+    init: function () {
+        this.requires("2D, Supportable, Motion");
+
+        this.bind("LiftedOffGround", this._startGravity); // start gravity if we are off ground
+        this.bind("LandedOnGround", this._stopGravity); // stop gravity once landed
+    },
+    remove: function(destroyed) {
+        this.unbind("LiftedOffGround", this._startGravity);
+        this.unbind("LandedOnGround", this._stopGravity);
+    },
+
+    _gravityCheckLanding: function(ground) {
+        if (this._dy < 0) 
+            this.canLand = false;
+    },
+
+    /**@
+     * #.gravity
+     * @comp Gravity
+     * @kind Method
+     * 
+     * @sign public this .gravity([comp])
+     * @param comp - The name of a component that will stop this entity from falling
+     *
+     * Enable gravity for this entity no matter whether comp parameter is specified or not.
+     * If comp parameter is specified all entities with that component will stop this entity from falling.
+     * For a player entity in a platform game this would be a component that is added to all entities
+     * that the player should be able to walk on.
+     *
+     * @example
+     * ~~~
+     * Crafty.e("2D, DOM, Color, Gravity")
+     *   .color("red")
+     *   .attr({ w: 100, h: 100 })
+     *   .gravity("platform");
+     * ~~~
+     */
+    gravity: function (comp) {
+        this.uniqueBind("CheckLanding", this._gravityCheckLanding);
+        this.startGroundDetection(comp);
+        this._startGravity();
+
+        return this;
+    },
+    /**@
+     * #.antigravity
+     * @comp Gravity
+     * @kind Method
+     * 
+     * @sign public this .antigravity()
+     * Disable gravity for this component. It can be reenabled by calling .gravity()
+     */
+    antigravity: function () {
+        this._stopGravity();
+        this.stopGroundDetection();
+        this.unbind("CheckLanding", this._gravityCheckLanding);
+
+        return this;
+    },
+
+    /**@
+     * #.gravityConst
+     * @comp Gravity
+     * @kind Method
+     * 
+     * @sign public this .gravityConst(g)
+     * @param g - gravitational constant in pixels per second squared
+     *
+     * Set the gravitational constant to g for this entity. The default is 500. The greater g, the stronger the downwards acceleration.
+     *
+     * @example
+     * ~~~
+     * Crafty.e("2D, DOM, Color, Gravity")
+     *   .color("red")
+     *   .attr({ w: 100, h: 100 })
+     *   .gravityConst(750)
+     *   .gravity("platform");
+     * ~~~
+     */
+    gravityConst: function (g) {
+        if (this._gravityActive) { // gravity active, change acceleration
+            this.ay -= this._gravityConst;
+            this.ay += g;
+        }
+        this._gravityConst = g;
+
+        return this;
+    },
+
+    _startGravity: function() {
+        if (this._gravityActive) return;
+        this._gravityActive = true;
+        this.ay += this._gravityConst;
+    },
+    _stopGravity: function() {
+        if (!this._gravityActive) return;
+        this._gravityActive = false;
+        this.ay = 0;
+        this.vy = 0;
+    }
+});
+

--- a/src/spatial/rect-manager.js
+++ b/src/spatial/rect-manager.js
@@ -4,6 +4,7 @@ var Crafty = require('../core/core.js');
 /**@
  * #Crafty.rectManager
  * @category 2D
+ * @kind CoreObj
  *
  * Collection of methods for handling rectangles
  */
@@ -28,6 +29,8 @@ Crafty.extend({
       /**@
        * #Crafty.rectManager.overlap
        * @comp Crafty.rectManager
+       * @kind Method
+       * 
        * @sign public Boolean Crafty.rectManager.overlap(Object rectA, Object rectA)
        * @param rectA - An object that must have the `_x, _y, _w, _h` values as properties
        * @param rectB - An object that must have the `_x, _y, _w, _h` values as properties
@@ -43,6 +46,8 @@ Crafty.extend({
       /**@
        * #Crafty.rectManager.integerBounds
        * @comp Crafty.rectManager
+       * @kind Method
+       * 
        * @sign public Boolean Crafty.rectManager.integerBounds(Object rect)
        * @param rect - An object that must have the `_x, _y, _w, _h` values as properties
        * @return An enclosing rectangle with integer coordinates
@@ -65,6 +70,8 @@ Crafty.extend({
       /**@
       * #Crafty.rectManager.mergeSet
       * @comp Crafty.rectManager
+      * @kind Method
+      *
       * @sign public Object Crafty.rectManager.mergeSet(Object set)
       * @param set - an array of rectangular regions
       *
@@ -98,6 +105,8 @@ Crafty.extend({
       /**@
        * #Crafty.rectManager.boundingRect
        * @comp Crafty.rectManager
+       * @kind Method
+       * 
        * @sign public Crafty.rectManager.boundingRect(set)
        * @param set - An array of rectangles
        *

--- a/src/spatial/spatial-grid.js
+++ b/src/spatial/spatial-grid.js
@@ -7,6 +7,8 @@
     /**@
      * #Crafty.HashMap.constructor
      * @comp Crafty.HashMap
+     * @kind Class
+     * 
      * @sign public void Crafty.HashMap([cellsize])
      * @param cellsize - the cell size. If omitted, `cellsize` is 64.
      *
@@ -49,6 +51,8 @@
         /**@
          * #Crafty.map.insert
          * @comp Crafty.map
+         * @kind Method
+         * 
          * @sign public Object Crafty.map.insert(Object obj)
          * @param obj - An entity to be inserted.
          * @returns An object representing this object's entry in the HashMap
@@ -88,6 +92,8 @@
         /**@
          * #Crafty.map.search
          * @comp Crafty.map
+         * @kind Method
+         * 
          * @sign public Object Crafty.map.search(Object rect[, Boolean filter])
          * @param rect - the rectangular region to search for entities.
          *               This object must contain the properties `_x`,`_y`,`_w`,`_h`.
@@ -160,6 +166,8 @@
         /**@
          * #Crafty.map.remove
          * @comp Crafty.map
+         * @kind Method
+         * 
          * @sign public void Crafty.map.remove(Entry entry)
          * @param entry - An entry to remove from the hashmap
          *
@@ -200,6 +208,8 @@
         /**@
          * #Crafty.map.refresh
          * @comp Crafty.map
+         * @kind Method
+         * 
          * @sign public void Crafty.map.refresh(Entry entry)
          * @param entry - An entry to update
          *
@@ -251,6 +261,8 @@
         /**@
          * #Crafty.map.boundaries
          * @comp Crafty.map
+         * @kind Method
+         * 
          * @sign public Object Crafty.map.boundaries()
          * @returns An object with the following structure, which represents an MBR which contains all entities
          *
@@ -278,6 +290,8 @@
         /**
          * #Crafty.map._keyBoundaries
          * @comp Crafty.map
+         * @kind Method
+         * 
          * @sign private Object Crafty.map._keyBoundaries()
          * @returns An object with the following structure, which represents an MBR which contains all hash keys
          *
@@ -375,6 +389,8 @@
         /**@
          * #Crafty.map.traverseRay
          * @comp Crafty.map
+         * @kind Method
+         * 
          * @sign public void Crafty.map.traverseRay(Object origin, Object direction, Function callback)
          * @param origin - the point of origin from which the ray will be cast. The object must contain the properties `_x` and `_y`.
          * @param direction - the direction the ray will be cast. It must be normalized. The object must contain the properties `x` and `y`.
@@ -560,6 +576,8 @@
     /**@
      * #Crafty.HashMap
      * @category 2D
+     * @kind Class
+     * 
      * Broad-phase collision detection engine. See background information at
      *
      * - [N Tutorial B - Broad-Phase Collision](http://www.metanetsoftware.com/technique/tutorialB.html)
@@ -570,6 +588,8 @@
     /**@
      * #Crafty.HashMap.key
      * @comp Crafty.HashMap
+     * @kind Method
+     * 
      * @sign public Object Crafty.HashMap.key(Object obj)
      * @param obj - an Object that has .mbr() or _x, _y, _w and _h.
      *


### PR DESCRIPTION
I went through and annotated all documented items with a `@kind` tag.  This could be used by the doc generator to show a little more info/context about items.  This PR just has the minimal modifications so that this attribute is parsed correctly.

The main motivation here is the addition of systems to the documentation.

The values I used were: "Component", "System", "Method", "Property", ~~"Constructor"~~ "Class", and "CoreObject".  (The last used to indicate the "important" objects such as `Crafty.viewport`.)

Class could probably be used instead of Constructor.  Crafty doesn't use very many of these in the public interface, but there are a few (such as the polygon class.)