### PR TITLE
Update EOL'ed open sauce targets

### DIFF
--- a/supported-browsers.json
+++ b/supported-browsers.json
@@ -6,7 +6,7 @@
   },
   {
     "browserName": "MicrosoftEdge",
-    "version": "20",
+    "version": "latest",
     "platform": "Windows 10"
   },
   {
@@ -36,7 +36,7 @@
   },
   {
     "browserName": "firefox",
-    "version": "beta",
+    "version": "latest",
     "platform": "Linux"
   },
   {
@@ -46,9 +46,9 @@
   },
   {
     "browserName": "android",
-    "version": "4.1",
+    "version": "4.4",
     "deviceName": "Android Emulator",
-    "platform": "Linux",
+    "platform": "linux",
     "deviceOrientation": "landscape"
   },
   {
@@ -60,7 +60,7 @@
   },
   {
     "browserName": "iphone",
-    "version": "5.1",
+    "version": "8.1",
     "deviceName": "iPhone Simulator",
     "platform": "OS X 10.10",
     "deviceOrientation": "landscape"


### PR DESCRIPTION
I believe this should fix the open sauce errors.  
- Some targets were EOL'ed (android/iphone versions)
- Something apparently broke firefox/selenium integration in a beta version recently
- IE Edge seems to not have a version 20

Merging into the testing branch first, since the tests only work there -- if that passes, I'll open up a new PR into develop.

Tagging @mucaho in case he has any input!  :)