### PR TITLE
Trigger style events, and have Text listen to them

### DIFF
--- a/src/core/scenes.js
+++ b/src/core/scenes.js
@@ -44,7 +44,7 @@ module.exports = {
      *     Crafty.e("2D, DOM, Text")
      *           .attr({ w: 100, h: 20, x: 150, y: 120 })
      *           .text("Loading")
-     *           .css({ "border": "1px solid red"})
+     *           .textAlign("center")
      *           .textColor("#FFFFFF");
      * });
      *

--- a/src/graphics/dom.js
+++ b/src/graphics/dom.js
@@ -247,13 +247,15 @@ Crafty.c("DOM", {
      * To return a value, pass the property.
      *
      * Note: For entities with "Text" component, some css properties are controlled by separate functions
-     * `.textFont()` and `.textColor()`, and ignore `.css()` settings. See Text component for details.
+     * `.textFont()`, `.textAlign()` and `.textColor()`.  When possible, prefer text-specific methods, since
+     * they will work for non-DOM text.
+     * See the Text component for details.
      *
      * @example
      * ~~~
-     * this.css({'border-radius': '5px', 'text-decoration': 'line-through'});
-     * this.css("borderRadius", "10px");
-     * this.css("border-radius"); //returns 10px
+     * this.css({'border': '1px solid black', 'text-decoration': 'line-through'});
+     * this.css("textDecoration", "line-through");
+     * this.css("text-Decoration"); //returns line-through
      * ~~~
      */
     css: function (obj, value) {

--- a/src/graphics/dom.js
+++ b/src/graphics/dom.js
@@ -216,10 +216,18 @@ Crafty.c("DOM", {
         return this;
     },
 
+    _setCssProperty: function(style, key, val) {
+        key = Crafty.domHelper.camelize(key);
+        if (typeof val === "number") val += 'px';
+        style[key] = val;
+        this.trigger("SetStyle", key);
+    },
+
     /**@
      * #.css
      * @comp DOM
      * @kind Method
+     * @trigger SetStyle - for each style that is set - string - propertyName
      * 
      * @sign public css(String property, String value)
      * @param property - CSS property to modify
@@ -259,21 +267,19 @@ Crafty.c("DOM", {
             for (key in obj) {
                 if (!obj.hasOwnProperty(key)) continue;
                 val = obj[key];
-                if (typeof val === "number") val += 'px';
-
-                style[Crafty.domHelper.camelize(key)] = val;
+                this._setCssProperty(style, key, val);
             }
         } else {
             //if a value is passed, set the property
             if (value) {
-                if (typeof value === "number") value += 'px';
-                style[Crafty.domHelper.camelize(obj)] = value;
+                this._setCssProperty(style, obj, value);
             } else { //otherwise return the computed property
                 return Crafty.domHelper.getStyle(elem, obj);
             }
         }
 
         this.trigger("Invalidate");
+        
 
         return this;
     }

--- a/src/graphics/text.js
+++ b/src/graphics/text.js
@@ -20,9 +20,10 @@ var Crafty = require('../core/core.js');
  * rotate together.
  *
  * @note For DOM (but not canvas) text entities, various font settings (such as
- * text-decoration) can be set using `.css()` (see DOM component). But
- * you cannot use `.css()` to set the properties which are controlled by `.textFont()`,
- *  `.textColor()`, or `.textAlign()` -- the settings will be ignored.
+ * text-decoration) can be set using `.css()` (see DOM component). If you 
+ * use `.css()` to set the *individual* properties which are controlled by `.textFont()`,
+ *  `.textColor()`, or `.textAlign()`, the text component will set these properties internally as well.
+ * However, if you use `.css()` to set shorthand properties such as `font`, these will be ignored by the text component.
  *
  * @note If you use canvas text with glyphs that are taller than standard letters, portions of the glyphs might be cut off.
  */
@@ -74,6 +75,41 @@ Crafty.c("Text", {
 
                 context.restore();
             }
+        },
+
+        // type, weight, size, family, lineHeight, and variant.
+        // For a few hardcoded css properties, set the internal definitions
+        "SetStyle": function(propertyName) {
+            // could check for DOM component, but this event should only be fired by such an entity!
+            // Rather than triggering Invalidate on each of these, we rely on css() triggering that event 
+            switch(propertyName) {
+                case "textAlign": 
+                    this._textAlign = this._element.style.textAlign;
+                    break;
+                case "color":
+                    // Need to set individual color components, so use method
+                    this.textColor(this._element.style.color);
+                    break;
+                case "fontType":
+                    this._textFont.type = this._element.style.fontType;
+                    break;
+                case "fontWeight":
+                    this._textFont.weight = this._element.style.fontWeight;
+                    break;
+                case "fontSize":
+                    this._textFont.size = this._element.style.fontSize;
+                    break;
+                case "fontFamily":
+                    this._textFont.family = this._element.style.fontFamily;
+                    break;
+                case "fontVariant":
+                    this._textFont.variant = this._element.style.fontVariant;
+                    break;
+                case "lineHeight":
+                    this._textFont.lineHeight = this._element.style.lineHeight;
+                    break;
+            }
+           
         }
     },
 

--- a/tests/text.js
+++ b/tests/text.js
@@ -106,6 +106,29 @@
     checkAlignment();
   });
 
+  test("Listen to style events for DOM Text", function(){
+    var e = Crafty.e("2D, DOM, Text");
+    
+    
+    e.text("hey how are you")
+      .textColor('#00FF00')
+      .textFont("size", "50px")
+      .textAlign("center");
+    equal(e._textColor, "rgba(0, 255, 0, 1)", "Color should be green.");
+    equal(e._textFont.size, "50px", "Size should be 50px.");
+    equal(e._textAlign, "center", "Alignment should be centered.");
+
+    e.css({
+      color: "red",
+      fontSize: "30px",
+      textAlign: "right"
+    });
+
+    equal(e._textColor, "rgba(255, 0, 0, 1)", "Color should be red.");
+    equal(e._textFont.size, "30px", "Size should be 30px.");
+    equal(e._textAlign, "right", "Alignment should be right.");
+  });
+
   test("MBR after alignment change", function() {
     var e = Crafty.e("2D, Canvas, Text");
     e.text("a");


### PR DESCRIPTION
This has two pieces:
- Trigger an event (per property) when setting CSS properties through the `.css()` method
- Bind to those events in the Text component, and use them to set related internal properties when possible.

The goal here isn't 100% perfection, since if you set font properties directly through the `font` shorthand we won't try to parse them.   (e.g. `css("font", "italic 2em ans-serif")` ).  But it should cause Crafty to behave as expected in a larger number of cases!

@matthijsgroen  This makes the addition of `textAlign()` more backwards compatible. 

Also updated docs to avoid using css to set text-align.

