### PR TITLE
Keep saucelabs credentials on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
   directories:
   - node_modules
 
-before_install: if [ "$TRAVIS_BRANCH" != $SAUCE_BRANCH ]; then unset SAUCE_USERNAME && unset SAUCE_ACCESS_KEY; fi
 before_script: npm install -g grunt-cli
 after_success: "./travis-nightly.sh"
 after_failure: if [ "$GH_TOKEN" ]; then grunt gh-pages:crafty-distro-regression-tests; fi


### PR DESCRIPTION
Currently we remove sauce-labs credentials when not running Travis on the testing branch.  This used to work, in that if the credentials were missing, Travis wouldn't try to open the connection.  This might just be a config change on their end, but this no longer works -- it fails the test if the credentials aren't present.

We only run the sauce tests on a single branch to avoid a collision -- the open source deal only lets you run a single set of tests at once.  I've checked, and it doesn't look like there's any real issue with the *connection* happening multiple times, so this PR seems safe.

The *right* thing to do is to not even try to connect on branches where we're not going to use the tunnel, but weirdly that doesn't seem possible using Travis's built-in options.  We'd have to manually setup the connection instead of using the travis addon.