### PR TITLE
Allow entities to be "frozen"

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -1041,6 +1041,93 @@ Crafty.fn = Crafty.prototype = {
             this._unbindAll();
             delete entities[this[0]];
         });
+    },
+
+    /**@
+     * #.freeze
+     * @comp Crafty Core
+     * @kind Method
+     * 
+     * @sign public this .freeze()
+     * 
+     * @triggers Freeze - Directly before the entity is frozen
+     * 
+     * Freezes the entity.  A frozen entity will not receive events or be displayed by graphics systems. 
+     * It is also removed from the spatial map, which means it will not be found by collisions, 
+     * raycasting, or similar functions.
+     * 
+     * This method may be called upon a collection of entities.
+     * 
+     * @note Because the entity no longer listens to events, modifying its properties can result in an inconsistent state.
+     * 
+     * If custom components need to handle frozen entities, they can listen to the "Freeze" event, which will be triggered before the event system is disabled.
+     * 
+     * @example
+     * 
+     * ```
+     * // Freeze all entities with the Dead component
+     * Crafty("Dead").freeze();
+     * ```
+     * 
+     * @see .unfreeze
+     */
+    freeze: function () {
+        if (this.length === 1 && !this.__frozen) {
+            this.trigger("Freeze", this);
+            this._freezeCallbacks();
+            this.__frozen = true;
+        } else {
+            for (var i = 0; i < this.length; i++) {
+                var e = entities[this[i]];
+                if (e && !e.__frozen) {
+                    e.trigger("Freeze", e);
+                    e._freezeCallbacks();
+                    // Set a frozen flag.  (This is distinct from the __callbackFrozen flag)
+                    e.__frozen = true;
+                }
+            }
+        }
+        return this;
+    },
+
+    /**#
+     * #.unfreeze
+     * @comp Crafty Core
+     * @kind Method
+     * 
+     * @sign public this .unfreeze()
+     * 
+     * @triggers Unfreeze - While the entity is being unfrozen
+     * 
+     * Unfreezes the entity, allowing it to receive events, inserting it back into the spatial map, 
+     * and restoring it to its previous visibility.
+     * 
+     * This method may be called upon a collection of entities.
+     * 
+     * If a custom component needs to know when an entity is unfrozen, they can listen to the "Unfreeze"" event.
+     * 
+     * @example
+     * ```
+     * // Bring the dead back to life!
+     * Crafty("Dead").unfreeze().addComponent("Undead");
+     * ```
+     */
+    unfreeze: function () {
+        if (this.length === 1 && this.__frozen) {
+            this.__frozen = false;
+            this._unfreezeCallbacks();
+            this.trigger("Unfreeze", this);
+        } else {
+            for (var i = 0; i < this.length; i++) {
+                var e = entities[this[i]];
+                if (e && e.__frozen) {
+                    e.__frozen = false;
+                    e._unfreezeCallbacks();
+                    e.trigger("Unfreeze", e);
+                }
+            }
+        }
+        return this;
     }
 };
 
@@ -1138,7 +1225,7 @@ Crafty._callbackMethods = {
 
     // Process for running all callbacks for the given event
     _runCallbacks: function(event, data) {
-        if (!this._callbacks[event]) {
+        if (!this._callbacks[event] || this.__callbacksFrozen) {
             return;
         }
         var callbacks = this._callbacks[event];
@@ -1186,6 +1273,7 @@ Crafty._callbackMethods = {
     // Completely all callbacks for every event, such as on object destruction
     _unbindAll: function() {
         if (!this._callbacks) return;
+        this.__callbacksFrozen = false;
         for (var event in this._callbacks) {
             if (this._callbacks[event]) {
                 // Remove the normal way, in case we've got a nested loop
@@ -1194,6 +1282,30 @@ Crafty._callbackMethods = {
                 delete handlers[event][this[0]];
             }
         }
+    },
+
+    _freezeCallbacks: function() {
+        if (!this._callbacks) return;
+        for (var event in this._callbacks) {
+            if (this._callbacks[event]) {
+                // Remove the callbacks from the global list of handlers
+                delete handlers[event][this[0]];
+            }
+        }
+        // Mark this callback list as frozen
+        this.__callbacksFrozen = true;
+    },
+
+     _unfreezeCallbacks: function() {
+        if (!this._callbacks) return;
+        this.__callbacksFrozen = false;
+        for (var event in this._callbacks) {
+            if (this._callbacks[event]) {
+                // Add the callbacks back to the global list of handlers
+                 handlers[event][this[0]] = this._callbacks[event];
+            }
+        }
+        
     }
 };
 

--- a/src/graphics/renderable.js
+++ b/src/graphics/renderable.js
@@ -77,6 +77,20 @@ Crafty.c("Renderable", {
     init: function () {
     },
 
+    // Need to store visibility before being frozen
+    _hideOnUnfreeze: false,
+    events: {
+        "Freeze":function(){
+            this._hideOnUnfreeze = !this._visible;
+            this._visible = false;
+            this.trigger("Invalidate");
+        },
+        "Unfreeze":function(){
+            this._visible = !this._hideOnUnfreeze;
+            this.trigger("Invalidate");
+        }
+    },
+
     // Renderable assumes that a draw layer has 3 important methods: attach, detach, and dirty
 
     // Dirty the entity when it's invalidated

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -230,6 +230,7 @@ Crafty.c("2D", {
 
         //insert self into the HashMap
         this._entry = Crafty.map.insert(this);
+        
 
         //when object changes, update HashMap
         this.bind("Move", function (e) {
@@ -279,6 +280,14 @@ Crafty.c("2D", {
         });
     },
 
+    events: {
+        "Freeze":function(){
+            Crafty.map.remove(this._entry);
+        },
+        "Unfreeze":function(){
+            this._entry = Crafty.map.insert(this, this._entry);
+        }
+    }, 
 
     /**@
      * #.offsetBoundary
@@ -670,6 +679,7 @@ Crafty.c("2D", {
         if (("cos" in e) || ("sin" in e)) {
             for (; i < l; ++i) {
                 obj = children[i];
+                if (obj.__frozen) continue;
                 if ('rotate' in obj) obj.rotate(e);
             }
         } else {
@@ -681,6 +691,7 @@ Crafty.c("2D", {
 
             for (; i < l; ++i) {
                 obj = children[i];
+                if (obj.__frozen) continue;
                 obj.shift(dx, dy, dw, dh);
             }
         }

--- a/src/spatial/spatial-grid.js
+++ b/src/spatial/spatial-grid.js
@@ -53,8 +53,9 @@
          * @comp Crafty.map
          * @kind Method
          * 
-         * @sign public Object Crafty.map.insert(Object obj)
+         * @sign public Object Crafty.map.insert(Object obj[, Object entry])
          * @param obj - An entity to be inserted.
+         * @param entry - An existing entry object to reuse.  (Optional)
          * @returns An object representing this object's entry in the HashMap
          * 
          * `obj` is inserted in '.map' of the corresponding broad phase cells. An object of the following fields is returned.
@@ -66,12 +67,10 @@
          * }
          * ~~~
          */
-        insert: function (obj) {
-            var keys = HashMap.key(obj),
-                entry = new Entry(keys, obj, this),
-                i = 0,
-                j,
-                hash;
+        insert: function (obj, entry) {
+            var i, j, hash;
+            var keys = HashMap.key(obj, entry && entry.keys);
+            entry = entry || new Entry(keys, obj, this);
 
             //insert into all x buckets
             for (i = keys.x1; i <= keys.x2; i++) {


### PR DESCRIPTION
For various reasons, you might want to essentially remove an entity from the game, but preserve it's current state.   Two example use-cases:

- The entity is temporarily removed from the stage, but will be restored later.
- A large number of similar entities are quickly being created and destroyed; you might want to recycle them instead

This PR introduces basic support for `freeze()` and `unfreeze()` methods on entities.  A frozen entity:
- No longer responds to events
- Will not be rendered by a graphics layer (in the current implementation, it is still considered attached to the layer itself)
- Is removed from the spatial hash map

The current implementation has a couple of caveats that might need to be fixed:
- Entities are still returned by the Crafty() selectors
- Since events are frozen, it might be possible for entities to get into inconsistent states.  I need to make sure that this is handled in a friendly manner for existing entities.