### PR TITLE
Create a 'Centered' component for assigning position by origin

### DIFF
--- a/src/crafty-headless.js
+++ b/src/crafty-headless.js
@@ -18,6 +18,7 @@ module.exports = function() {
     requireNew('./core/version');
 
     requireNew('./spatial/2d');
+    require('./spatial/centered');
     require('./spatial/motion');
     require('./spatial/platform');
     requireNew('./spatial/collision');

--- a/src/crafty.js
+++ b/src/crafty.js
@@ -12,6 +12,7 @@ Crafty.c('Tween', require('./core/tween'));
 require('./core/systems');
 
 require('./spatial/2d');
+require('./spatial/centered');
 require('./spatial/motion');
 require('./spatial/platform');
 require('./spatial/collision');

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -770,6 +770,8 @@ Crafty.c("2D", {
      *
      * Set the origin point of an entity for it to rotate around.
      *
+     * @triggers OriginSet -- after the new origin is assigned
+     * 
      * @example
      * ~~~
      * this.origin("top left")
@@ -814,7 +816,7 @@ Crafty.c("2D", {
 
         this._origin.x = x;
         this._origin.y = y;
-
+        this.trigger("OriginChanged");
         return this;
     },
 

--- a/src/spatial/centered.js
+++ b/src/spatial/centered.js
@@ -1,0 +1,121 @@
+var Crafty = require('../core/core.js');
+
+/**@
+ * #Centered
+ * @category 2D
+ * @kind Component
+ * 
+ * A component for setting an entities position by its origin, rather than the top left corner.
+ * 
+ * Setting `cx` and `cy` will move the entity such that its origin is at that location. 
+ * This will fire the same events that setting `x` and `y` directly would.
+ * 
+ * The origin of an entity defaults to the top left corner.  To set it explicitly, call the `origin()` method
+ * of the 2D component.  To center the origin, you can also use the `centerOrigin()` method of this component.
+ * 
+ * @trigger Move - when the entity has moved - { _x:Number, _y:Number, _w:Number, _h:Number } - Old position
+ * @trigger Invalidate - when the entity needs to be redrawn
+ * 
+ * @see 2D#.origin
+ */
+Crafty.c("Centered", {
+    properties: {
+        /**@
+         * #.cx
+         * @comp Centered
+         * @kind Property
+         * 
+         * The `x` position on the stage of the origin. When modified, will set the underlying `x` value of the entity.
+         */
+        cx: {
+            set: function (v) {
+                var x = v - this._origin.x;
+                this._setter2d('_x', x);
+            },
+            get: function () {
+                return this._x + this._origin.x;
+            },
+            configurable: true,
+            enumerable: true
+        },
+
+        /**@
+         * #.cy
+         * @comp Centered
+         * @kind Property
+         * 
+         * The `y` position on the stage of the origin. When modified, will set the underlying `y` value of the entity.
+         */
+        cy: {
+            set: function (v) {
+                var y = v - this._origin.y;
+                this._setter2d('_y', y);
+            },
+            get: function () {
+                return this._y + this._origin.y;
+            },
+            configurable: true,
+            enumerable: true
+        }
+    },
+
+    required: "2D",
+
+    /**@
+     * #.centerOrigin
+     * @comp Centered
+     * @kind Method
+     * 
+     * @sign public this .centerOrigin(bool roundCoordinates)
+     * @param roundCoordinates - If truthy, will round the resulting position to integral coordinates.
+     *
+     * Adjusts the origin to be in the center of the entity.
+     * 
+     * @example
+     * ~~~
+     * var e = Crafty.e("2D, Centered");
+     * e.attr({x: 10, y:10, w: 50, h:50});
+     * 
+     * // Whenever the entity resizes, keep it's origin and center fixed on the stage
+     * e.bind("Resize", function(){
+     *  var oldX = this.cx;
+     *  var oldY = this.cy;
+     *  this.centerOrigin();
+     *  this.cx = oldX;
+     *  this.cy = oldY;
+     * }); 
+     * ~~~
+     */
+    centerOrigin: function (roundCoordinates) {
+        var ox = this._w/2;
+        var oy = this._h/2;
+        if (roundCoordinates) {
+            ox = Math.round(ox);
+            oy = Math.round(oy);
+        }
+        this.origin(ox, oy);
+        return this;
+    },
+
+    /**@
+     * #.shiftAroundOrigin
+     * @comp Centered
+     * @kind Method
+     * 
+     * @sign public this .shiftAroundOrigin(dx, dy)
+     * @param dx - Shift the entity by this amount along the x axis
+     * @param dy - Shift the entity by this amount along the y axis
+     *
+     * Moves the entity while keeping the origin fixed on the stage.
+     */
+    shiftAroundOrigin: function(dx, dy) {
+        var currentX = this.cx;
+        var currentY = this.cy;
+        this.origin(this._origin.x - dx, this._origin.y - dy);
+        this.cx = currentX;
+        this.cy = currentY;
+    }
+});
+
+
+

--- a/tests/centered.js
+++ b/tests/centered.js
@@ -1,0 +1,111 @@
+(function() {
+  var module = QUnit.module;
+
+    module("Centered");
+    test("centered properties", function() {
+        var player = Crafty.e("2D, Centered").attr({
+            x: 0,
+            y: 0,
+            w: 50,
+            h: 50
+        });
+        player.origin(10, 10);
+        
+        
+        player.cx = 20;
+        strictEqual(player.x, 10, "X set such that origin is at cx");
+        strictEqual(player.cx, 20, "CX set to 20");
+        
+        
+        player.cy = 30;
+        strictEqual(player.y, 20, "X set such that origin is at cy");
+        strictEqual(player.cy, 30, "CY set to 20");
+    });
+
+    test("centerOrigin", function() {
+        var player = Crafty.e("2D, Centered").attr({
+            x: 10,
+            y: 10,
+            w: 12,
+            h: 12
+        });
+        player.origin(10, 10);
+        
+        strictEqual(player.cx, 20, "initial cx at 10");
+        strictEqual(player.cy, 20, "initial cy at 10");
+        
+        player.centerOrigin();
+        strictEqual(player.cx, 16, "centered origin x at 6");
+        strictEqual(player.cy, 16, "centered origin y at 6");
+    });
+
+    test("centerOrigin with rounding", function() {
+        var player = Crafty.e("2D, Centered").attr({
+            x: 0,
+            y: 0,
+            w: 10.5,
+            h: 10.5
+        });
+        player.origin(10, 10);
+        
+        strictEqual(player.cx, 10, "initial cx at 10");
+        strictEqual(player.cy, 10, "initial cy at 10");
+        
+        player.centerOrigin(false);
+        strictEqual(player.cx, 5.25, "centered origin x at 5.25");
+        strictEqual(player.cy, 5.25, "centered origin y at 5.25");
+
+        player.centerOrigin(true);
+        strictEqual(player.cx, 5, "with rounding, centered origin x at 5");
+        strictEqual(player.cy, 5, "with rounding, centered origin y at 5");
+    });
+
+    test("shiftAroundOrigin", function() {
+        var player = Crafty.e("2D, Centered").attr({
+            x: 5,
+            y: 5,
+            w: 10,
+            h: 10
+        });
+        player.origin(10, 10);
+        
+        strictEqual(player.cx, 15, "cx starts at 15");
+        strictEqual(player.cy, 15, "cy starts at 15");
+
+        // Move the player +10, +10 while keeping the origin point fixed relative to the stage
+        player.shiftAroundOrigin(10, -10);
+
+        strictEqual(player.x, 15, "player moves +10 along the x direction");
+        strictEqual(player.y, -5, "player moves -10 along the y direction");
+
+        strictEqual(player.cx, 15, "cx remains fixed");
+        strictEqual(player.cy, 15, "cy remains fixed");
+    });
+
+    // Might be good practice to add non-trivial examples to our tests
+    test("centerOrigin test example code", function() {
+        var e = Crafty.e("2D, Centered");
+        e.attr({x: 10, y:10, w: 50, h:50});
+        e.centerOrigin();
+        // Whenever the entity resizes, keep it's origin and center fixed on the stage
+        e.bind("Resize", function(){
+            var oldX = this.cx;
+            var oldY = this.cy;
+            this.centerOrigin();
+            this.cx = oldX;
+            this.cy = oldY;
+        });
+        strictEqual(e.cx, 35, "cx starts at 35");
+        strictEqual(e.cy, 35, "cy starts at 35");
+        
+        e.w = 10;
+        strictEqual(e.cx, 35, "cx remains fixed");
+        strictEqual(e.x, 30, "entity moved to maintain center");
+
+        e.h = 10;
+        strictEqual(e.cy, 35, "cy remains fixed");
+        strictEqual(e.y, 30, "entity moved to maintain center");
+
+    });
+
+})();

--- a/tests/index.html
+++ b/tests/index.html
@@ -72,6 +72,7 @@
     <script type="text/javascript" src="./2D/collision/sat.js"></script>
     <script type="text/javascript" src="./2D/spatial-grid.js"></script>
     <script type="text/javascript" src="./2D/raycast.js"></script>
+    <script type="text/javascript" src="./centered.js"></script>
 
   </body>
 </html>


### PR DESCRIPTION
It's been a somewhat common request to be able to assign a position based on an entities origin, rather than it's top left corner.

This PR adds a `"Centered"` component that adds `cx` and `cy` properties for this, as well as a couple of helper methods: 
- `centerOrigin`  for moving the origin to the center of an entity
- `shiftAroundOrigin` for moving an entity while keeping its origin fixed to its current stage position.

It's possible that `cx` and `cy` are slightly misleading, since it's not necessarily the center of the entity.  Another option might be decouple the notion of center and origin, and use  `ox` and `oy` for the origin's position, while `cx` and `cy` provide the true center.