### PR TITLE
Default selected to true

### DIFF
--- a/src/controls/inputs.js
+++ b/src/controls/inputs.js
@@ -58,10 +58,12 @@ Crafty.extend({
      *
      * After a click occurs inside Crafty's stage, this property is set to `true`.
      * After a click occurs outside Crafty's stage, this property is set to `false`.
+     * 
+     * Defaults to true.
      *
      * @see Crafty.stage#Crafty.stage.elem
      */
-    selected: false,
+    selected: true,
 
     detectBlur: function (e) {
         var selected = ((e.clientX > Crafty.stage.x && e.clientX < Crafty.stage.x + Crafty.viewport.width) &&


### PR DESCRIPTION
From #1081 it would probably be more useful to set Crafty to 'selected' by default.