### PR TITLE
Allow properties to be defined as part of the component definition

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -292,6 +292,13 @@ Crafty.fn = Crafty.prototype = {
             if (comp && "required" in comp) {
                 this.requires( comp.required );
             }
+            // Define properties
+            if (comp && "properties" in comp) {
+                var props = comp.properties;
+                for (var propertyName in props) {
+                    Object.defineProperty(this, propertyName, props[propertyName]);
+                }
+            }
             // Call constructor function
             if (comp && "init" in comp) {
                 comp.init.call(this);
@@ -1720,6 +1727,7 @@ Crafty.extend({
      * - `init`: A function to be called when the component is added to an entity
      * - `remove`: A function which will be called just before a component is removed, or before an entity is destroyed. It is passed a single boolean parameter that is `true` if the entity is being destroyed.
      * - `events`: An object whose properties represent functions bound to events equivalent to the property names.  (See the example below.)  The binding occurs directly after the call to `init`, and will be removed directly before `remove` is called.
+     * - `properties`: A dictionary of properties which will be defined using Object.defineProperty.  Typically used to add setters and getters.
      *
      * In addition to these hardcoded special methods, there are some conventions for writing components.
      *

--- a/src/graphics/renderable.js
+++ b/src/graphics/renderable.js
@@ -48,7 +48,7 @@ Crafty.c("Renderable", {
     },
 
     // Setup all the properties that we need to define
-    _graphics_property_definitions: {
+    properties: {
         alpha: {
             set: function (v) {
                 this._setterRenderable('_alpha', v);
@@ -74,15 +74,7 @@ Crafty.c("Renderable", {
         _visible: {enumerable:false}
     },
 
-    _defineRenderableProperites: function () {
-        for (var prop in this._graphics_property_definitions){
-            Object.defineProperty(this, prop, this._graphics_property_definitions[prop]);
-        }
-    },
-
     init: function () {
-        // create setters and getters that associate properties such as alpha/_alpha
-        this._defineRenderableProperites();
     },
 
     // Renderable assumes that a draw layer has 3 important methods: attach, detach, and dirty

--- a/src/spatial/2d.js
+++ b/src/spatial/2d.js
@@ -139,7 +139,7 @@ Crafty.c("2D", {
     _parent: null,
 
     // Setup   all the properties that we need to define
-    _2D_property_definitions: {
+    properties: {
         x: {
             set: function (v) {
                 this._setter2d('_x', v);
@@ -213,12 +213,6 @@ Crafty.c("2D", {
         _rotation: {enumerable:false}
     },
 
-    _define2DProperties: function () {
-        for (var prop in this._2D_property_definitions){
-            Object.defineProperty(this, prop, this._2D_property_definitions[prop]);
-        }
-    },
-
     init: function () {
         this._globalZ = this[0];
         this._origin = {
@@ -233,11 +227,6 @@ Crafty.c("2D", {
         this._by2 = 0;
 
         this._children = [];
-
-        
-        // create setters and getters that associate properties such as x/_x
-        this._define2DProperties();
-        
 
         //insert self into the HashMap
         this._entry = Crafty.map.insert(this);

--- a/tests/core.js
+++ b/tests/core.js
@@ -76,6 +76,43 @@
     strictEqual(destroyFlag, true, "Destroy flag true on destruction");
   });
 
+  // check the properties attribute of components, especially the pattern used by existing components
+  test("properties", function() {
+    
+    Crafty.c("PropertyTest", {
+      properties: {
+        foo: {
+          set: function(value){
+            this._foo = value;
+          },
+          get: function(){
+            return this._foo;
+          },
+          configurable: true,
+          enumerable: true
+        },
+        _foo: {value: 0, writable: true, enumerable:false}
+      }
+    });
+    var e = Crafty.e("PropertyTest");
+ 
+    strictEqual(e._foo, 0, "Initial value works");
+
+    e.foo = 5;
+    strictEqual(e._foo, 5, "Setter works");
+    
+    e._foo = 10;
+    strictEqual(e.foo, 10, "Getter works");
+    
+    var propList = [];
+    for (var prop in e){
+      propList.push(prop);
+    }
+
+    ok(propList.indexOf("foo") >=0, "Property foo is enumerable");
+    ok(propList.indexOf("_foo") == -1, "Property _foo is not enumerable");
+  });
+
   test("name", function() {
     var counter = 0;
     var player = Crafty.e().bind("NewEntityName", function() {

--- a/tests/core.js
+++ b/tests/core.js
@@ -110,7 +110,7 @@
     }
 
     ok(propList.indexOf("foo") >=0, "Property foo is enumerable");
-    ok(propList.indexOf("_foo") == -1, "Property _foo is not enumerable");
+    ok(propList.indexOf("_foo") === -1, "Property _foo is not enumerable");
   });
 
   test("name", function() {


### PR DESCRIPTION
Add a very simple shortcut for using `Object.defineProperty` when adding a component.  This replaces the existing setup that "2D" and "Renderable" used.