### PR TITLE
Doc improvements related to math library

### DIFF
--- a/build/api-gen/clean-name.js
+++ b/build/api-gen/clean-name.js
@@ -1,5 +1,6 @@
 var re = /[\.-]/g
+var omitRe = /[\(\)]/g
 
 module.exports = function cleanName(raw) {
-  return raw.replace(re, "-");
+  return raw.replace(re, "-").replace(omitRe, "");
 }

--- a/build/api-gen/doc-components.jsx
+++ b/build/api-gen/doc-components.jsx
@@ -298,7 +298,7 @@ var Method = React.createClass({
 var Parameter = React.createClass({
   render: function() {
     var paramSpan = this.props.paramType 
-      ? <span className = 'param-qualifier' style={{color: "#36597d"}}>{this.props.paramType}</span> 
+      ? <span className = 'param-qualifier'>{this.props.paramType}</span> 
       : <span/>
     return (
       <dl className = "parameter">
@@ -360,7 +360,7 @@ var SignatureSeperator = React.createClass({
 var Returns = React.createClass({
   render: function() {
     var typeSpan = this.props.returnType
-      ? <span className = 'returns-qualifier' style={{color: "#36597d"}}> {this.props.returnType}</span> 
+      ? <span className = 'returns-qualifier'> {this.props.returnType}</span> 
       : ""
     return (
       <dl className = "parameter returns"> 

--- a/build/api-gen/doc-components.jsx
+++ b/build/api-gen/doc-components.jsx
@@ -136,7 +136,7 @@ var Node = React.createClass({
       case "method":
         return <Method data={node} page={page}/>
       case "param":
-        return <Parameter paramName={node.name} page={page} paramDescription={node.description} />
+        return <Parameter paramName={node.name} page={page} paramDescription={node.description} paramType={node.paramType} paramDefault={node.paramDefault}/>
       case "triggers":
         return <Events triggers={node.events} page={page}/>
       case "raw":
@@ -297,9 +297,12 @@ var Method = React.createClass({
 
 var Parameter = React.createClass({
   render: function() {
+    var paramSpan = this.props.paramType 
+      ? <span className = 'paramType' style={{color: "#36597d"}}>{this.props.paramType}</span> 
+      : <span/>
     return (
       <dl className = "parameter">
-        <dt> {this.props.paramName} </dt>
+        <dt> {paramSpan} {this.props.paramName} </dt>
         <dd><MarkdownBlock value={this.props.paramDescription} key={1} /></dd>
       </dl>
     )

--- a/build/api-gen/doc-components.jsx
+++ b/build/api-gen/doc-components.jsx
@@ -142,7 +142,7 @@ var Node = React.createClass({
       case "raw":
         return <MarkdownBlock value={node.value} page={page}/>
       case "return":
-        return <Returns value={node.value} page={page}/>
+        return <Returns value={node.value} returnType={node.returnType} page={page}/>
       case "xref":
         return <SeeAlso xrefs = {node.xrefs} page={page} />
       case "example":
@@ -298,7 +298,7 @@ var Method = React.createClass({
 var Parameter = React.createClass({
   render: function() {
     var paramSpan = this.props.paramType 
-      ? <span className = 'paramType' style={{color: "#36597d"}}>{this.props.paramType}</span> 
+      ? <span className = 'param-qualifier' style={{color: "#36597d"}}>{this.props.paramType}</span> 
       : <span/>
     return (
       <dl className = "parameter">
@@ -359,9 +359,12 @@ var SignatureSeperator = React.createClass({
 
 var Returns = React.createClass({
   render: function() {
-       return (
+    var typeSpan = this.props.returnType
+      ? <span className = 'returns-qualifier' style={{color: "#36597d"}}> {this.props.returnType}</span> 
+      : ""
+    return (
       <dl className = "parameter returns"> 
-        <dt className="returns"> [Returns] </dt> 
+        <dt className="returns"> [Returns{typeSpan}] </dt> 
         <dd><MarkdownBlock value={this.props.value} key={2} /></dd> 
       </dl>
     )

--- a/build/api-gen/doc-components.jsx
+++ b/build/api-gen/doc-components.jsx
@@ -1,6 +1,10 @@
 var marked = require("marked");
 var hljs = require("highlight.js");
 var cleanName = require("./clean-name");
+var kindName = function(name, kind) {
+  return kind === "Method" ? name + "()" : name;
+}
+
 var githubRoot = "https://github.com/craftyjs/Crafty/blob/";
 
 
@@ -26,7 +30,8 @@ var MarkdownBlock = React.createClass({
   render: function() {
     var raw = this.props.value;
     var rawHtml = this.convert(raw);
-    return <span className="markdown" dangerouslySetInnerHTML={{__html: rawHtml}} />
+    var key = this.props.key;
+    return <span key={key} className="markdown" dangerouslySetInnerHTML={{__html: rawHtml}} />
   }
 })
 
@@ -45,11 +50,11 @@ var ToC = React.createClass({
       }
     }
     catArray.sort(nameSort);
-    var catElements = catArray.map( function(cat, index){return <Category key={cat.name} catName = {cat.name} pages = {cat.pages} />});
-    return ( 
+    var catElements = catArray.map( function(cat, index){return <Category key={cat.name} catName = {cat.name} pages = {cat.pages}/>});
+    return (
       <ul id = "doc-level-one">
         <li><a href="events.html">List of Events</a></li>
-        <Category catName = {primary} pages = {toc.categories[primary].pages} />
+        <Category catName = {primary} pages = {toc.categories[primary].pages}/>
         {catElements}
       </ul>
     )
@@ -57,11 +62,20 @@ var ToC = React.createClass({
 
 })
 
-// The logic for choosing the link name and target is complicated due to the inconsistent way these are tagged in source
+var TocLink = React.createClass({
+  render: function() {
+    var target = this.props.target;
+    var linkText = kindName(target.name, target.kind);
+    var href = cleanName(target.name) + ".html"; 
+    return <a href={href}>{linkText}</a>
+  }
+  
+
+});
+
 var DocLink = React.createClass({
   render: function() {
     var target = this.props.target;
-    var kind = this.props.kind || "missing";
     var linkText, href;
     var parent = (this.props.parentPage) ? this.props.parentPage.main.name : undefined;
     // If the link target starts with the name of the page, assume it is an internal link
@@ -95,16 +109,14 @@ var DocLink = React.createClass({
       linkText = target;
       href = cleanName(target) + ".html";
     }
-    return <a href={href} className={"kind-" + kind}>{linkText}</a>
+    return <a href={href}>{linkText}</a>
   }
 })
 
 var Category = React.createClass({
   render: function() {
     this.props.pages.sort(nameSort);
-    var dictionary = this.props.dict;
-    var pages = this.props.pages.map(function(page, index){return <li key={page.name}><DocLink target={page.name} kind={page.kind}/></li>});
-
+    var pages = this.props.pages.map(function(page, index){return <li key={page.name}><TocLink target={page}/></li>});
     return ( 
       <li className="category">
         {this.props.catName}
@@ -360,9 +372,11 @@ var Doclet = React.createClass({
   render: function() {
     var contents = this.props.data.contents;
     var pieces =  mapNodes(contents, this.props.page);
+    var partName = kindName(this.props.data.name, this.props.data.kind); 
+    
     if (!this.props.top) {
       var link = <a href='#doc-nav' className='doc-top'>Back to top</a>
-      var header = <h2 className="doclet-header">{this.props.data.name}</h2>
+      var header = <h2 className="doclet-header">{partName}</h2>
     } else {
       var link = "";
       var header = "";
@@ -384,13 +398,21 @@ var SourceLink = React.createClass({
     var start = this.props.data.startLine;
     var end = this.props.data.endLine;
     var commit = this.props.data.commit;
-    var fileLocation = file +"#L" + start + "-" + end;
+    var fileLocation = file +"#L" + start + "-" + "L" + end;
     var target = githubRoot + commit + "/" + fileLocation;
     return <a href={target}>{fileLocation}</a>
   }
 
 })
 
+// properties before methods
+function partSort(a, b) {
+  if (a.kind != b.kind) {
+    return (a.kind == "method") ? 1 : -1
+  } else {
+    return nameSort(a, b);
+  }
+}
 
 
 function nameSort(a, b) {
@@ -416,33 +438,71 @@ var DocPage = React.createClass({
       return <div/>
     }
     var parts = page.parts;
-    parts.sort(nameSort);
+    parts.sort(partSort);
     var partlets = parts.map(function(part, index){return <Doclet key={index} data={part} top={false} page={page}/>});
-    var page_toc = parts.map( function(part, index){ return <li key={index}><InternalLink parent={page.main.name} target={part.name} value={part.name}/></li>});
+    
+
+    var toc_mapper = function(part, index){ return <li key={index}><InternalLink parent={page.main.name} target={part.name} value={part.name} kind={part.kind}/></li>}
+    var method_toc = parts.filter(function(p){return p.kind === "Method"})
+      .map(toc_mapper);
+    var property_toc = parts.filter(function(p){return p.kind !== "Method"})
+      .map( toc_mapper);
+    //var page_toc = parts.map( function(part, index){ return <li key={index}><InternalLink parent={page.main.name} target={part.name} value={part.name} kind={part.kind}/></li>});
     if (!page.main){
       return <div/>
     }
     if (parts.length > 0) {
+      var pageTocPart = [];
+
+
+      if (property_toc.length > 0) {
+        pageTocPart.push(<SubSectionHeader>Properties</SubSectionHeader>);
+        pageTocPart.push(
+          <ul className = "page-toc">
+              {property_toc}
+          </ul>);
+      }
+
+      if (method_toc.length > 0) {
+        pageTocPart.push(<SubSectionHeader>Methods</SubSectionHeader>);
+        pageTocPart.push(
+          <ul className = "page-toc">
+              {method_toc}
+          </ul>);
+      }
+
       var bottomParts = 
         <div>
-          <SubSectionHeader>Methods and Properties</SubSectionHeader>
-          <ul className = "page-toc">
-            {page_toc}
-          </ul>
+          {pageTocPart}
           {partlets}
         </div>
     } else {
       var bottomParts = "";
     }
+    var header;
+    if (page.main.kind) {
+      header = <h1>{page.main.name}</h1> 
+    }
+    var pageName = kindName(page.main.name, page.main.kind);
     return (
       <div className="doc-page">
-        <h1>{page.main.name}</h1>
+        <h1>{pageName} <KindBadge kind={page.main.kind} /></h1>
         <Doclet data={page.main} page={page} top={true}/>
         {bottomParts}
       </div>
     )
   }
 })
+
+var KindBadge = React.createClass({
+  render: function() {
+    var kind = this.props.kind;
+    if (kind == "Component" || kind == "System" || kind == "Class") {
+      return <span className="page-badge">{kind}</span>
+    }
+    return <span/>;
+  }
+});
 
 var EventPage = React.createClass({
   render: function() {
@@ -479,6 +539,10 @@ var InternalLink = React.createClass({
       var linkText = this.props.target;
       if (linkText.indexOf(this.props.parent) == 0 ) {
         linkText = linkText.replace(this.props.parent, "");
+      }
+      var kind = this.props.kind;
+      if (kind === "Method") {
+        linkText += "()";
       }
       return <a href={"#" + cleanTarget}>{linkText}</a>
     }

--- a/build/api-gen/dynamic-server.js
+++ b/build/api-gen/dynamic-server.js
@@ -26,7 +26,11 @@ function startServer(grunt, input){
       } else {
         var title = selector || filename;
       }
-      raw = "<head><title>" + title + "</title><link type='text/css' rel='stylesheet' href='http://craftyjs.com/craftyjs-site.css'/><link type='text/css' rel='stylesheet' href='http://craftyjs.com/github.css'/></head>"
+      raw = "<head><title>" + title + "</title>"
+          + " <link type='text/css' rel='stylesheet' href='http://craftyjs.com/craftyjs-site.css'/>" 
+          + " <link type='text/css' rel='stylesheet' href='http://craftyjs.com/github.css'/>" 
+          + " <link type='text/css' rel='stylesheet' href='dev.css' />"
+          + "</head>"
           + "<body><div id='main'><div id='content' class='container'>" + raw +  "</div></div></body>";
 
       return raw;
@@ -44,6 +48,15 @@ function startServer(grunt, input){
       });
     });
 
+    // Temporary css selectors for dev work
+    router.path(/(.*)dev\.css/, function(){
+      this.get(function () {
+        this.res.writeHead(200, { 'Content-Type': 'text/css' })
+        this.res.end( ".returns-qualifier, .param-qualifier {color: #36597d}" );
+      });
+    })
+    
+    // Actual doc pages
     router.path(/(.+)\.html/, function () {
       this.get(function (id) {
         this.res.writeHead(200, { 'Content-Type': 'text/html' })

--- a/build/api-gen/index-docs.js
+++ b/build/api-gen/index-docs.js
@@ -17,7 +17,7 @@ function createIndex(blocks) {
     if (block.categories) {
       for (var j = 0; j < block.categories.length; j++) {
         if (block.name) {
-          cat(block.categories[j]).pages.push( {name: block.name, kind: block.kind});
+          cat(block.categories[j]).pages.push({name: block.name, kind: block.kind})
         }
         comp(block.name).main = block;
       }

--- a/build/parseSourceDocs.coffee
+++ b/build/parseSourceDocs.coffee
@@ -155,20 +155,26 @@ nodeParsers =
     see: (value)->
         type: "xref"
         xrefs: value.split(/\s*,\s*/)
+
+    # Parse the param with the format `name {type} - descriptipon`, where type and description are optional
     param: (value)-> 
-        split = value.match(/(.+)\s+-\s+(.+)/)
-        if split?
-            return {
-                type: "param"
-                name: split[1]
-                description: split[2]
-            }
-        else
-            return {
-                type: "param"
-                name: value
-                description: ""
-            }
+        # Since we have to parse sets of regex matches that might not exist, provide
+        # default values if the match fails in the form of an array, and use destructuring assignments
+
+        # Parse out `firstPart - description`
+        [..., firstPart, description] = value.match(/(.+)\s-\s+(.+)/) ? [null, value, ""]
+        # Parse out the `{metadata} name` pieces
+        [..., meta, name] = firstPart.match(/\s*({(.+)})\s+(.+)\s*$/) ? [null, null, "", firstPart]
+        # Parse out `type=default` from metadata
+        [..., paramType, paramDefault] = meta.match(/(.+)=(.+)/) ? [null, meta, ""] 
+
+        return {
+            type: "param"
+            name: name
+            paramType: paramType
+            paramDefault: paramDefault
+            description: description
+        }
     category: (value)-> 
         type: "category"
         categories: value.split(/\s*,\s*/)

--- a/build/parseSourceDocs.coffee
+++ b/build/parseSourceDocs.coffee
@@ -134,6 +134,7 @@ cleanName = (name) -> name.replace(".", "-")
 
 
 # Alternate names for some tags
+# Any node names matching a key will be treated as nodes of the value instead
 aliases = {
     "returns": "return"
     "triggers": "trigger"
@@ -175,11 +176,19 @@ nodeParsers =
             paramDefault: paramDefault
             description: description
         }
+    return: (value)->
+        [..., returnType, returnDescription] = value.match(/^\s*({(.+)})\s+(.+)?\s*$/) ? [null, null, "", value]
+        return {
+            type: "return",
+            value: returnDescription,
+            returnType: returnType
+        }
     category: (value)-> 
         type: "category"
         categories: value.split(/\s*,\s*/)
     example: ()->
         type: "example"
+    
 
 
 # Parse the node, calling any defined parser as necessary

--- a/src/spatial/math.js
+++ b/src/spatial/math.js
@@ -239,18 +239,24 @@ Crafty.math.Vector2D = (function () {
      * #Crafty.math.Vector2D
      * @category 2D
      * @kind Class
+     * @public
      * 
      * @class This is a general purpose 2D vector class
      *
-     * Vector2D uses the following form:
-     * <x, y>
+     * Vector2D has the following constructors:
      *
-     * @public
-     * @sign public {Vector2D} Vector2D();
-     * @sign public {Vector2D} Vector2D(Vector2D);
-     * @sign public {Vector2D} Vector2D(Number, Number);
-     * @param {Vector2D|Number=0} x
-     * @param {Number=0} y
+     * @sign public {Vector2D} new Vector2D();
+     * @returns {Vector2D} A new vector with x and y equal to 0 
+     * 
+     * @sign public {Vector2D} new Vector2D(Number x, Number y);
+     * @param {Number} x - The initial x value
+     * @param {Number} y - The initial y value
+     * @returns {Vector2D} - A new vector with the given x and y values
+     * 
+     * @sign public {Vector2D} new Vector2D(Vector2D vector);
+     * @param {Vector2D} vector - A vector to copy
+     * @returns {Vector2D} A new vector with the copied x and y values
+     * 
      */
 
     function Vector2D(x, y) {
@@ -271,14 +277,13 @@ Crafty.math.Vector2D = (function () {
      * #.add
      * @comp Crafty.math.Vector2D
      * @kind Method
-     * 
+     * @public
      *
      * Adds the passed vector to this vector
      *
-     * @public
      * @sign public {Vector2D} add(Vector2D);
-     * @param {vector2D} vecRH
-     * @returns {Vector2D} this after adding
+     * @param {Vector2D} vecRH - The vector to add
+     * @returns {Vector2D} The resulting modified vector
      */
     Vector2D.prototype.add = function (vecRH) {
         this.x += vecRH.x;
@@ -290,31 +295,29 @@ Crafty.math.Vector2D = (function () {
      * #.angleBetween
      * @comp Crafty.math.Vector2D
      * @kind Method
-     * 
+     * @public
      *
      * Calculates the angle between the passed vector and this vector, using <0,0> as the point of reference.
      * Angles returned have the range (−π, π].
      *
-     * @public
-     * @sign public {Number} angleBetween(Vector2D);
-     * @param {Vector2D} vecRH
+     * @sign public {Number} angleBetween(Vector2D vecRH);
+     * @param {Vector2D} vecRH - The vector to compare
      * @returns {Number} the angle between the two vectors in radians
      */
     Vector2D.prototype.angleBetween = function (vecRH) {
         return Math.atan2(this.x * vecRH.y - this.y * vecRH.x, this.x * vecRH.x + this.y * vecRH.y);
-    }; // angleBetween
+    };
 
     /**@
      * #.angleTo
      * @comp Crafty.math.Vector2D
      * @kind Method
-     * 
      *
      * Calculates the angle to the passed vector from this vector, using this vector as the point of reference.
      *
      * @public
-     * @sign public {Number} angleTo(Vector2D);
-     * @param {Vector2D} vecRH
+     * @sign public {Number} angleTo(Vector2D vecRH);
+     * @param {Vector2D} vecRH - The vector to compare
      * @returns {Number} the angle to the passed vector in radians
      */
     Vector2D.prototype.angleTo = function (vecRH) {
@@ -346,8 +349,8 @@ Crafty.math.Vector2D = (function () {
      * Calculates the distance from this vector to the passed vector.
      *
      * @public
-     * @sign public {Number} distance(Vector2D);
-     * @param {Vector2D} vecRH
+     * @sign public {Number} distance(Vector2D vecRH);
+     * @param {Vector2D} vecRH - The passed vector
      * @returns {Number} the distance between the two vectors
      */
     Vector2D.prototype.distance = function (vecRH) {
@@ -364,9 +367,10 @@ Crafty.math.Vector2D = (function () {
      * This function avoids calculating the square root, thus being slightly faster than .distance( ).
      *
      * @public
-     * @sign public {Number} distanceSq(Vector2D);
-     * @param {Vector2D} vecRH
+     * @sign public {Number} distanceSq(Vector2D vecRH);
+     * @param {Vector2D} vecRH - The passed vector
      * @returns {Number} the squared distance between the two vectors
+     * 
      * @see .distance
      */
     Vector2D.prototype.distanceSq = function (vecRH) {
@@ -382,8 +386,8 @@ Crafty.math.Vector2D = (function () {
      * Divides this vector by the passed vector.
      *
      * @public
-     * @sign public {Vector2D} divide(Vector2D);
-     * @param {Vector2D} vecRH
+     * @sign public {Vector2D} divide(Vector2D vecRH);
+     * @param {Vector2D} vecRH - The passed vector
      * @returns {Vector2D} this vector after dividing
      */
     Vector2D.prototype.divide = function (vecRH) {
@@ -401,8 +405,8 @@ Crafty.math.Vector2D = (function () {
      * Calculates the dot product of this and the passed vectors
      *
      * @public
-     * @sign public {Number} dotProduct(Vector2D);
-     * @param {Vector2D} vecRH
+     * @sign public {Number} dotProduct(Vector2D vecRH);
+     * @param {Vector2D} vecRH - The passed vector
      * @returns {Number} the resultant dot product
      */
     Vector2D.prototype.dotProduct = function (vecRH) {
@@ -418,8 +422,8 @@ Crafty.math.Vector2D = (function () {
      * Calculates the z component of the cross product of the two vectors augmented to 3D.
      *
      * @public
-     * @sign public {Number} crossProduct(Vector2D);
-     * @param {Vector2D} vecRH
+     * @sign public {Number} crossProduct(Vector2D vecRH);
+     * @param {Vector2D} vecRH - The passed vector
      * @returns {Number} the resultant cross product
      */
     Vector2D.prototype.crossProduct = function (vecRH) {
@@ -435,8 +439,8 @@ Crafty.math.Vector2D = (function () {
      * Determines if this vector is numerically equivalent to the passed vector.
      *
      * @public
-     * @sign public {Boolean} equals(Vector2D);
-     * @param {Vector2D} vecRH
+     * @sign public {Boolean} equals(Vector2D vecRH);
+     * @param {Vector2D} vecRH - The passed vector
      * @returns {Boolean} true if the vectors are equivalent
      */
     Vector2D.prototype.equals = function (vecRH) {
@@ -454,7 +458,7 @@ Crafty.math.Vector2D = (function () {
      * The perpendicular vector has the same magnitude as this vector and is obtained by a counter-clockwise rotation of 90° of this vector.
      *
      * @public
-     * @sign public {Vector2D} perpendicular([Vector2D]);
+     * @sign public {Vector2D} perpendicular([Vector2D result]);
      * @param {Vector2D} [result] - An optional parameter to save the result in
      * @returns {Vector2D} the perpendicular vector
      */
@@ -471,8 +475,8 @@ Crafty.math.Vector2D = (function () {
      * Calculates a new right-handed unit vector that is perpendicular to the line created by this and the passed vector.
      *
      * @public
-     * @sign public {Vector2D} getNormal(Vector2D[, Vector2D]);
-     * @param {Vector2D} vecRH
+     * @sign public {Vector2D} getNormal(Vector2D vecRH[, Vector2D result]);
+     * @param {Vector2D} vecRH - The passed vector
      * @param {Vector2D} [result] - An optional parameter to save the result in
      * @returns {Vector2D} the new normal vector
      */
@@ -535,11 +539,11 @@ Crafty.math.Vector2D = (function () {
      * @comp Crafty.math.Vector2D
      * @kind Method
      * 
-     * Multiplies this vector by the passed vector
+     * Multiplies this vector by the passed vector, using component-wise multiplciation
      *
      * @public
-     * @sign public {Vector2D} multiply(Vector2D);
-     * @param {Vector2D} vecRH
+     * @sign public {Vector2D} multiply(Vector2D vecRH);
+     * @param {Vector2D} vecRH - The passed vector
      * @returns {Vector2D} this vector after multiplying
      */
     Vector2D.prototype.multiply = function (vecRH) {
@@ -598,12 +602,14 @@ Crafty.math.Vector2D = (function () {
      * @kind Method
      * 
      * Scales this vector by the passed amount(s)
-     * If scalarY is omitted, scalarX is used for both axes
      *
      * @public
-     * @sign public {Vector2D} scale(Number[, Number]);
-     * @param {Number} scalarX
-     * @param {Number} [scalarY]
+     * @sign public {Vector2D} scale(Number scale);
+     * @param {Number} scale - The amount to scale by
+     * 
+     * @sign public {Vector2D} scale(Number scalarX, Number scalarY);
+     * @param {Number} scalarX - The amount to scale x by
+     * @param {Number} [scalarY] - The amount to scale y by
      * @returns {Vector2D} this after scaling
      */
     Vector2D.prototype.scale = function (scalarX, scalarY) {
@@ -624,8 +630,8 @@ Crafty.math.Vector2D = (function () {
      * Scales this vector such that its new magnitude is equal to the passed value.
      *
      * @public
-     * @sign public {Vector2D} scaleToMagnitude(Number);
-     * @param {Number} mag
+     * @sign public {Vector2D} scaleToMagnitude(Number mag);
+     * @param {Number} mag - The desired magnitude
      * @returns {Vector2D} this vector after scaling
      */
     Vector2D.prototype.scaleToMagnitude = function (mag) {
@@ -643,11 +649,14 @@ Crafty.math.Vector2D = (function () {
      * Sets the values of this vector using a passed vector or pair of numbers.
      *
      * @public
-     * @sign public {Vector2D} setValues(Vector2D);
-     * @sign public {Vector2D} setValues(Number, Number);
-     * @param {Number|Vector2D} x
-     * @param {Number} y
-     * @returns {Vector2D} this vector after setting of values
+     * @sign public {Vector2D} setValues(Vector2D vector);
+     * @param {Vector2D} vector - a vector to copy
+     * @returns {Vector2D} this vector after copying the values
+     * 
+     * @sign public {Vector2D} setValues(Number x, Number y);
+     * @param {Number} x - The x value to set
+     * @param {Number} y - The y value to set
+     * @returns {Vector2D} this vector after setting the values
      */
     Vector2D.prototype.setValues = function (x, y) {
         if (x instanceof Vector2D) {
@@ -688,7 +697,7 @@ Crafty.math.Vector2D = (function () {
      *
      * @public
      * @sign public {String} toString();
-     * @returns {String}
+     * @returns {String} A representation like "Vector2D(4, 7)"
      */
     Vector2D.prototype.toString = function () {
         return "Vector2D(" + this.x + ", " + this.y + ")";
@@ -703,9 +712,9 @@ Crafty.math.Vector2D = (function () {
      * If dy is omitted, dx is used for both axes.
      *
      * @public
-     * @sign public {Vector2D} translate(Number[, Number]);
-     * @param {Number} dx
-     * @param {Number} [dy]
+     * @sign public {Vector2D} translate(Number x[, Number y]);
+     * @param {Number} dx - The amount to shift by
+     * @param {Number} [dy] - The amount to shift along the y axis
      * @returns {Vector2D} this vector after translating
      */
     Vector2D.prototype.translate = function (dx, dy) {
@@ -728,7 +737,7 @@ Crafty.math.Vector2D = (function () {
      *
      * @public
      * @static
-     * @sign public {Vector2D} tripleProduct(Vector2D, Vector2D, Vector2D, [Vector2D]);
+     * @sign public {Vector2D} tripleProduct(Vector2D a, Vector2D b, Vector2D c, [Vector2D result]);
      * @param {Vector2D} a
      * @param {Vector2D} b
      * @param {Vector2D} c

--- a/src/spatial/math.js
+++ b/src/spatial/math.js
@@ -281,7 +281,7 @@ Crafty.math.Vector2D = (function () {
      *
      * Adds the passed vector to this vector
      *
-     * @sign public {Vector2D} add(Vector2D);
+     * @sign public {Vector2D} add(Vector2D vecRH);
      * @param {Vector2D} vecRH - The vector to add
      * @returns {Vector2D} The resulting modified vector
      */
@@ -606,6 +606,7 @@ Crafty.math.Vector2D = (function () {
      * @public
      * @sign public {Vector2D} scale(Number scale);
      * @param {Number} scale - The amount to scale by
+     * @returns {Vector2D} this after scaling
      * 
      * @sign public {Vector2D} scale(Number scalarX, Number scalarY);
      * @param {Number} scalarX - The amount to scale x by
@@ -678,8 +679,8 @@ Crafty.math.Vector2D = (function () {
      * Subtracts the passed vector from this vector.
      *
      * @public
-     * @sign public {Vector2D} subtract(Vector2D);
-     * @param {Vector2D} vecRH
+     * @sign public {Vector2D} subtract(Vector2D vecRH);
+     * @param {Vector2D} vecRH - the passed vector to subtract
      * @returns {vector2D} this vector after subtracting
      */
     Vector2D.prototype.subtract = function (vecRH) {
@@ -712,7 +713,7 @@ Crafty.math.Vector2D = (function () {
      * If dy is omitted, dx is used for both axes.
      *
      * @public
-     * @sign public {Vector2D} translate(Number x[, Number y]);
+     * @sign public {Vector2D} translate(Number dx[, Number dy]);
      * @param {Number} dx - The amount to shift by
      * @param {Number} [dy] - The amount to shift along the y axis
      * @returns {Vector2D} this vector after translating
@@ -738,9 +739,9 @@ Crafty.math.Vector2D = (function () {
      * @public
      * @static
      * @sign public {Vector2D} tripleProduct(Vector2D a, Vector2D b, Vector2D c, [Vector2D result]);
-     * @param {Vector2D} a
-     * @param {Vector2D} b
-     * @param {Vector2D} c
+     * @param {Vector2D} a - The first vector
+     * @param {Vector2D} b - The second vector
+     * @param {Vector2D} c - The third vector
      * @param {Vector2D} [result] - An optional parameter to save the result in
      * @return {Vector2D} the triple product as a new vector
      */
@@ -770,14 +771,20 @@ Crafty.math.Matrix2D = (function () {
      *
      * @public
      * @sign public {Matrix2D} new Matrix2D();
-     * @sign public {Matrix2D} new Matrix2D(Matrix2D);
-     * @sign public {Matrix2D} new Matrix2D(Number, Number, Number, Number, Number, Number);
-     * @param {Matrix2D|Number=1} a
-     * @param {Number=0} b
-     * @param {Number=0} c
-     * @param {Number=1} d
-     * @param {Number=0} e
-     * @param {Number=0} f
+     * @returns {Matrix2D} A new identity matrix
+     * 
+     * @sign public {Matrix2D} new Matrix2D(Matrix2D matrix);
+     * @param {Matrix2D} matrix - a matrix to copy
+     * @returns {Matrix2D} A new instance whose entries are copied from the passed matrix
+     * 
+     * @sign public {Matrix2D} new Matrix2D(Number a, Number b, Number c, Number d, Number e, Number f);
+     * @param {Number=1} a - (m11) Horizontal scale
+     * @param {Number=0} b - (m12) Horizontal skew
+     * @param {Number=0} c - (m21) Vertical skew
+     * @param {Number=1} d - (m22) Vertical scale
+     * @param {Number=0} e - (dx) Horizontal translation
+     * @param {Number=0} f - (dy) Vertical translation
+     * @returns {Matrix2D} A new instance whose entries are set from the passed arguments
      */
     function Matrix2D (a, b, c, d, e, f) {
         if (a instanceof Matrix2D) {
@@ -813,7 +820,7 @@ Crafty.math.Matrix2D = (function () {
      * Applies the matrix transformations to the passed object
      *
      * @public
-     * @sign public {Vector2D} apply(Vector2D);
+     * @sign public {Vector2D} apply(Vector2D vecRH);
      * @param {Vector2D} vecRH - vector to be transformed
      * @returns {Vector2D} the passed vector object after transforming
      */
@@ -840,7 +847,7 @@ Crafty.math.Matrix2D = (function () {
      *
      * @public
      * @sign public {Matrix2D} clone();
-     * @returns {Matrix2D}
+     * @returns {Matrix2D} The cloned matrix
      */
     Matrix2D.prototype.clone = function () {
         return new Matrix2D(this);
@@ -855,8 +862,8 @@ Crafty.math.Matrix2D = (function () {
      * The passed matrix is assumed to be on the right-hand side.
      *
      * @public
-     * @sign public {Matrix2D} combine(Matrix2D);
-     * @param {Matrix2D} mtrxRH
+     * @sign public {Matrix2D} combine(Matrix2D mtrxRH);
+     * @param {Matrix2D} mtrxRH - The passed matrix
      * @returns {Matrix2D} this matrix after combination
      */
     Matrix2D.prototype.combine = function (mtrxRH) {
@@ -877,11 +884,11 @@ Crafty.math.Matrix2D = (function () {
      * @comp Crafty.math.Matrix2D
      * @kind Method
      *
-     * Checks for the numeric equality of this matrix versus another.
+     * Checks for the numeric element-wise equality of this matrix versus another.
      *
      * @public
-     * @sign public {Boolean} equals(Matrix2D);
-     * @param {Matrix2D} mtrxRH
+     * @sign public {Boolean} equals(Matrix2D mtrxRH);
+     * @param {Matrix2D} mtrxRH - The matrix to check equality with
      * @returns {Boolean} true if the two matrices are numerically equal
      */
     Matrix2D.prototype.equals = function (mtrxRH) {
@@ -950,7 +957,7 @@ Crafty.math.Matrix2D = (function () {
      *
      * @public
      * @sign public {Boolean} isIdentity();
-     * @returns {Boolean}
+     * @returns {Boolean} true if this matrix is an identity matrix
      */
     Matrix2D.prototype.isIdentity = function () {
         return this.a === 1 && this.b === 0 && this.c === 0 && this.d === 1 && this.e === 0 && this.f === 0;
@@ -980,7 +987,7 @@ Crafty.math.Matrix2D = (function () {
      * Applies a counter-clockwise pre-rotation to this matrix
      *
      * @public
-     * @sign public {Matrix2D} preRotate(Number);
+     * @sign public {Matrix2D} preRotate(Number rads);
      * @param {number} rads - angle to rotate in radians
      * @returns {Matrix2D} this matrix after pre-rotation
      */
@@ -1003,12 +1010,14 @@ Crafty.math.Matrix2D = (function () {
      * @comp Crafty.math.Matrix2D
      * @kind Method
      * 
-     * Applies a pre-scaling to this matrix
+     * Applies a pre-scaling to this matrix, applied to the a, b, c, and d elements.
+     * 
+     * If two arguments are supplied, a and c are multiplied by scalarX, b, and d by scalarY.
      *
      * @public
-     * @sign public {Matrix2D} preScale(Number[, Number]);
-     * @param {Number} scalarX
-     * @param {Number} [scalarY] scalarX is used if scalarY is undefined
+     * @sign public {Matrix2D} preScale(Number scalarX[, Number scalarY]);
+     * @param {Number} scalarX - The amount to scale
+     * @param {Number} [scalarY] - scalarX is used if scalarY is undefined
      * @returns {Matrix2D} this after pre-scaling
      */
     Matrix2D.prototype.preScale = function (scalarX, scalarY) {
@@ -1031,10 +1040,13 @@ Crafty.math.Matrix2D = (function () {
      * Applies a pre-translation to this matrix
      *
      * @public
-     * @sign public {Matrix2D} preTranslate(Vector2D);
-     * @sign public {Matrix2D} preTranslate(Number, Number);
-     * @param {Number|Vector2D} dx
-     * @param {Number} dy
+     * @sign public {Matrix2D} preTranslate(Number dx, Number dy);
+     * @param {Number} dx - The amount to shift the e component
+     * @param {Number} dy - The amount to shift the f component
+     * @returns {Matrix2D} this matrix after pre-translation
+     * 
+     * @sign public {Matrix2D} preTranslate(Vector2D vector);
+     * @param {Vector2D} vector - The vector to shift (e, f) by.
      * @returns {Matrix2D} this matrix after pre-translation
      */
     Matrix2D.prototype.preTranslate = function (dx, dy) {
@@ -1057,7 +1069,7 @@ Crafty.math.Matrix2D = (function () {
      * Applies a counter-clockwise post-rotation to this matrix
      *
      * @public
-     * @sign public {Matrix2D} rotate(Number);
+     * @sign public {Matrix2D} rotate(Number rads);
      * @param {Number} rads - angle to rotate in radians
      * @returns {Matrix2D} this matrix after rotation
      */
@@ -1083,11 +1095,13 @@ Crafty.math.Matrix2D = (function () {
      * @comp Crafty.math.Matrix2D
      * @kind Method
      * 
-     * Applies a post-scaling to this matrix
+     * Applies a post-scaling to this matrix, modifying components a-f.
+     * 
+     * If two arguments are passed, scalarX is used for components a, c, and e; scalarY for b, d, and f.
      *
      * @public
-     * @sign public {Matrix2D} scale(Number[, Number]);
-     * @param {Number} scalarX
+     * @sign public {Matrix2D} scale(Number scalarX[, Number scalarY]);
+     * @param {Number} scalarX The amount to scale by along the x axis
      * @param {Number} [scalarY] scalarX is used if scalarY is undefined
      * @returns {Matrix2D} this after post-scaling
      */
@@ -1110,17 +1124,21 @@ Crafty.math.Matrix2D = (function () {
      * @comp Crafty.math.Matrix2D
      * @kind Method
      * 
-     * Sets the values of this matrix
+     * Sets the values of this matrix.
      *
      * @public
-     * @sign public {Matrix2D} setValues(Matrix2D);
-     * @sign public {Matrix2D} setValues(Number, Number, Number, Number, Number, Number);
-     * @param {Matrix2D|Number} a
-     * @param {Number} b
-     * @param {Number} c
-     * @param {Number} d
-     * @param {Number} e
-     * @param {Number} f
+     * @sign public {Matrix2D} setValues(Matrix2D matrix);
+     * @param {Matrix2D} matrix - A matrix to copy the values from
+     * @returns {Matrix2D} This matrix after copying the values
+     * 
+     * @sign public {Matrix2D} setValues(Number a, Number b, Number c, Number d, Number e, Number f);
+     * When used as a translation matrix, the 6 elements have particular meanings.
+     * @param {Number} a - (m11) Horizontal scale
+     * @param {Number} b - (m12) Horizontal skew
+     * @param {Number} c - (m21) Vertical skew
+     * @param {Number} d - (m22) Vertical scale
+     * @param {Number} e - (dx) Horizontal translation
+     * @param {Number} f - (dy) Vertical translation
      * @returns {Matrix2D} this matrix containing the new values
      */
     Matrix2D.prototype.setValues = function (a, b, c, d, e, f) {
@@ -1152,7 +1170,7 @@ Crafty.math.Matrix2D = (function () {
      *
      * @public
      * @sign public {String} toString();
-     * @returns {String}
+     * @returns {String} A string representation like "Matrix2D([a, c, e], [b, d, f], [0, 0, 1])"
      */
     Matrix2D.prototype.toString = function () {
         return "Matrix2D([" + this.a + ", " + this.c + ", " + this.e +
@@ -1167,10 +1185,13 @@ Crafty.math.Matrix2D = (function () {
      * Applies a post-translation to this matrix
      *
      * @public
-     * @sign public {Matrix2D} translate(Vector2D);
-     * @sign public {Matrix2D} translate(Number, Number);
-     * @param {Number|Vector2D} dx
-     * @param {Number} dy
+     * @sign public {Matrix2D} translate(Vector2D vector);
+     * @param {Vector2D} vector - the vector to translate by
+     * @returns {Matrix2D} this matrix after post-translation
+     * 
+     * @sign public {Matrix2D} translate(Number dx, Number dy);
+     * @param {Number} dx - The shift along the x-axis
+     * @param {Number} dy - The shift along the y-axis
      * @returns {Matrix2D} this matrix after post-translation
      */
     Matrix2D.prototype.translate = function (dx, dy) {


### PR DESCRIPTION
The `vector|matrix2D` documentation was [a bit broken](http://craftyjs.com/api/Crafty-math-Matrix2D.html) -- our doc generation didn't handle the specific syntax it was using.

This PR
- Pulls in some changes that were in the craftyjs repo but hadn't been pulled in to this one
- Updates the doc parser to handle additional metadata about parameter and return tags
- Renders the param/return type if present when previewing docs
- Updates Matrix2D and Vector2D to include param names and description where appropriate

You can see the changes in action if you checkout the branch and run `grunt view-api`.

Related to an item on #675 