### PR TITLE
Remove code duplication

### DIFF
--- a/src/crafty-common.js
+++ b/src/crafty-common.js
@@ -1,0 +1,34 @@
+// Define common features available in both browser and node
+module.exports = function(requireNew) {
+    if (requireNew) {
+        require = requireNew; // jshint ignore:line
+    }
+
+    var Crafty = require('./core/core');
+
+    Crafty.easing = require('./core/animation');
+    Crafty.extend(require('./core/extensions'));
+    Crafty.c('Model', require('./core/model'));
+    Crafty.extend(require('./core/scenes'));
+    Crafty.storage = require('./core/storage');
+    Crafty.c('Delay', require('./core/time'));
+    Crafty.c('Tween', require('./core/tween'));
+
+    require('./core/systems');
+
+    require('./spatial/2d');
+    require('./spatial/motion');
+    require('./spatial/platform');
+    require('./spatial/collision');
+    require('./spatial/spatial-grid');
+    require('./spatial/rect-manager');
+    require('./spatial/math');
+
+    require('./controls/controls-system');
+    require('./controls/controls');
+    require('./controls/keycodes');
+
+    require('./debug/logging');
+
+    return Crafty;
+};

--- a/src/crafty-headless.js
+++ b/src/crafty-headless.js
@@ -4,35 +4,11 @@ function requireNew (id) {
 }
 
 module.exports = function() {
-    var Crafty = requireNew('./core/core');
-
-    Crafty.easing = requireNew('./core/animation');
-    requireNew('./core/extensions');
-    Crafty.c('Model', requireNew('./core/model'));
-    Crafty.extend(requireNew('./core/scenes'));
-    Crafty.storage = requireNew('./core/storage');
-    Crafty.c('Delay', requireNew('./core/time'));
-    Crafty.c('Tween', requireNew('./core/tween'));
-
-    requireNew('./core/systems');
-    requireNew('./core/version');
-
-    requireNew('./spatial/2d');
-    require('./spatial/motion');
-    require('./spatial/platform');
-    requireNew('./spatial/collision');
-    requireNew('./spatial/spatial-grid');
-    requireNew('./spatial/rect-manager');
-    requireNew('./spatial/math');
-
-    require('./controls/controls-system');
-    requireNew('./controls/controls');
-    requireNew('./controls/keycodes');
-
-    requireNew('./debug/logging');
+    // Define common features
+    var Crafty = require('./crafty-common.js')(requireNew);
 
     // Define some aliases for renamed properties
-    require('./aliases').defineAliases(Crafty);
+    requireNew('./aliases').defineAliases(Crafty);
 
     // add dummys - TODO remove this in future
     Crafty.viewport = {

--- a/src/crafty.js
+++ b/src/crafty.js
@@ -1,23 +1,8 @@
-var Crafty = require('./core/core');
+// Define common features
+var Crafty = require('./crafty-common.js')();
 
-Crafty.easing = require('./core/animation');
-Crafty.extend(require('./core/extensions'));
+// Define features only available in browser environment
 Crafty.extend(require('./core/loader'));
-Crafty.c('Model', require('./core/model'));
-Crafty.extend(require('./core/scenes'));
-Crafty.storage = require('./core/storage');
-Crafty.c('Delay', require('./core/time'));
-Crafty.c('Tween', require('./core/tween'));
-
-require('./core/systems');
-
-require('./spatial/2d');
-require('./spatial/motion');
-require('./spatial/platform');
-require('./spatial/collision');
-require('./spatial/spatial-grid');
-require('./spatial/rect-manager');
-require('./spatial/math');
 
 // Needs to be required before any specific layers are
 require('./graphics/layers');
@@ -46,15 +31,11 @@ require('./isometric/diamond-iso');
 require('./isometric/isometric');
 
 require('./controls/inputs');
-require('./controls/controls-system');
-require('./controls/controls');
 require('./controls/device');
-require('./controls/keycodes');
 
 require('./sound/sound');
 
 require('./debug/debug-layer');
-require('./debug/logging');
 
 // Define some aliases for renamed properties
 require('./aliases').defineAliases(Crafty);

--- a/tests/unit/index-common.js
+++ b/tests/unit/index-common.js
@@ -1,0 +1,30 @@
+var files = [
+    /** HELPER FUNCTIONS **/
+    './common.js',
+    /** COMMON TEST CODE THAT RUNS IN BROWSER AND NODE **/
+    './core/core.js',
+    './spatial/2d.js',
+    './debug/logging.js',
+    './controls/controls.js',
+    './core/events.js',
+    './spatial/math.js',
+    './core/model.js',
+    './core/storage.js',
+    './core/systems.js',
+    './core/time.js',
+    './core/tween.js',
+    './spatial/collision.js',
+    './spatial/sat.js',
+    './spatial/spatial-grid.js',
+    './spatial/raycast.js'
+];
+
+if (typeof require === 'function') {
+    files.forEach(function (file) {
+        require(file);
+    });
+}
+
+if (typeof window !== 'undefined') {
+    window.COMMON_TEST_FILES = files;
+}

--- a/tests/unit/index-headless.js
+++ b/tests/unit/index-headless.js
@@ -2,22 +2,5 @@
 global.Crafty = require('../../src/crafty-headless.js')();
 Crafty.init();
 
-/** COMMON TEST CODE **/
-require('./common.js');
-
-/** ALL THE TESTS **/
-require('./core/core.js');
-require('./spatial/2d.js');
-require('./debug/logging.js');
-require('./controls/controls.js');
-require('./core/events.js');
-require('./spatial/math.js');
-require('./core/model.js');
-require('./core/storage.js');
-require('./core/systems.js');
-require('./core/time.js');
-require('./core/tween.js');
-require('./spatial/collision.js');
-require('./spatial/sat.js');
-require('./spatial/spatial-grid.js');
-require('./spatial/raycast.js');
+/** COMMON TEST CODE THAT RUNS IN BROWSER AND NODE **/
+require('./index-common.js');

--- a/tests/unit/index.html
+++ b/tests/unit/index.html
@@ -24,10 +24,8 @@
     <script type="text/javascript" src="./lib/qunit.js"></script>
     <script type="text/javascript" src="./lib/modernizr-2.7.1.min.js"></script>
     <script type="text/javascript" src="./lib/mockTouchEvents.js"></script>
-
-
-
   </head>
+
   <body>
     <h1 id="qunit-header">Crafty.js Test Suite</h1>
     <h2 id="qunit-banner"></h2>
@@ -39,39 +37,47 @@
     <!-- CRAFTY.JS -->
     <script type="text/javascript" src="../../crafty.js"></script>
     <script type="text/javascript">
-      Crafty.init(500,500);
+        Crafty.init();
     </script>
 
-    <!-- COMMON TEST CODE -->
-    <script type="text/javascript" src="./common.js"></script>
+    <!-- DISABLE AUTOMATIC TEST START -->
+    <script type="text/javascript">
+        QUnit.config.autostart = false;
+    </script>
 
-    <!-- ALL THE TESTS -->
-    <script type="text/javascript" src="./graphics/color.js"></script>
-    <script type="text/javascript" src="./core/core.js"></script>
-    <script type="text/javascript" src="./debug/debug.js"></script>
-    <script type="text/javascript" src="./debug/logging.js"></script>
-    <script type="text/javascript" src="./spatial/2d.js"></script>
-    <script type="text/javascript" src="./sound/audio.js"></script>
-    <script type="text/javascript" src="./controls/inputs.js"></script>
-    <script type="text/javascript" src="./controls/controls.js"></script>
-    <script type="text/javascript" src="./graphics/dom.js"></script>
-    <script type="text/javascript" src="./graphics/dom-helper.js"></script>
-    <script type="text/javascript" src="./core/events.js"></script>
-    <script type="text/javascript" src="./core/systems.js"></script>
-    <script type="text/javascript" src="./isometric/isometric.js"></script>
-    <script type="text/javascript" src="./core/loader.js"></script>
-    <script type="text/javascript" src="./spatial/math.js"></script>
-    <script type="text/javascript" src="./graphics/viewport.js"></script>
-    <script type="text/javascript" src="./graphics/text.js"></script>
-    <script type="text/javascript" src="./core/tween.js"></script>
-    <script type="text/javascript" src="./core/storage.js"></script>
-    <script type="text/javascript" src="./core/model.js"></script>
-    <script type="text/javascript" src="./core/time.js"></script>
-    <script type="text/javascript" src="./graphics/sprite-animation.js"></script>
-    <script type="text/javascript" src="./spatial/collision.js"></script>
-    <script type="text/javascript" src="./spatial/sat.js"></script>
-    <script type="text/javascript" src="./spatial/spatial-grid.js"></script>
-    <script type="text/javascript" src="./spatial/raycast.js"></script>
+    <!-- GET COMMON TEST FILES THAT RUN IN BROWSER AND NODE -->
+    <script type="text/javascript" src="./index-common.js"></script>
 
+    <!-- GET TEST FILES THAT ONLY RUN IN BROWSER -->
+    <script type="text/javascript" src="./index.js"></script>
+
+    <!-- LOAD TESTS AS SCRIPTS -->
+    <!-- see https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement -->
+    <script type="text/javascript">
+        function loadScript (src, onload) {
+            var script = document.createElement("script");
+            script.type = "text\/javascript";
+            script.onerror = function(error) {
+                throw new URIError("The script " + error.target.src + " is not accessible!");
+            };
+            script.onload = onload;
+            (document.body || document.getElementsByTagName("body")[0]).appendChild(script);
+            script.src = src;
+        }
+
+        var totalFiles = window.COMMON_TEST_FILES.length + window.BROWSER_TEST_FILES.length;
+        var loadedFiles = 0;
+        /** START LOADED QUNIT TESTS ONCE ALL FILES LOADED **/
+        var callback = function() {
+            if (++loadedFiles === totalFiles) {
+                QUnit.start();
+            }
+        };
+
+        /** LOAD TEST FILES **/
+        window.COMMON_TEST_FILES.concat(window.BROWSER_TEST_FILES).forEach(function (file) {
+            loadScript(file, callback);
+        });
+    </script>
   </body>
 </html>

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -1,0 +1,18 @@
+/** BROWSER-SPECIFIC TEST CODE **/
+var files = [
+    './graphics/color.js',
+    './debug/debug.js',
+    './sound/audio.js',
+    './controls/inputs.js',
+    './graphics/dom.js',
+    './graphics/dom-helper.js',
+    './isometric/isometric.js',
+    './core/loader.js',
+    './graphics/viewport.js',
+    './graphics/text.js',
+    './graphics/sprite-animation.js',
+];
+
+if (typeof window !== 'undefined') {
+    window.BROWSER_TEST_FILES = files;
+}


### PR DESCRIPTION
Extract common source modules and test files into crafty-common.js and index-common.js respectively.   
No more copy-pasting between those two.
Additionally, fixes #1097.