### PR TITLE
Fix mouse scroll

### DIFF
--- a/playgrounds/parallax.html
+++ b/playgrounds/parallax.html
@@ -16,10 +16,15 @@
     Crafty.init(200, 200);
     Crafty.c("Bar", {
       init: function() {
-        this.requires('2D, Color, Mouse');
+        this.requires('2D, Color, Keyboard, Mouse, Draggable');
         this.attr({h: 100, w: 30});
-        this.bind("Click", function(){
-          window.alert(this._drawLayer.name);
+        this.bind("Click", function(e){
+          if (this.isDown("SHIFT")) {
+            window.alert(
+              "Clicked " + this._drawLayer.name +
+              " @pos(" + e.realX.toFixed(2) + ", " + e.realY.toFixed(2) + ")"
+            );
+          }
         });
       }
     });
@@ -41,16 +46,19 @@
 
 
       // A player controlled box in the "normal" layer
-      var player = Crafty.e("2D, ActionLayer, Color, Fourway, Mouse")
+      var player = Crafty.e("2D, ActionLayer, Color, Fourway, Mouse, Text")
           .attr({x: 200, y: 120, w: 50, h: 50, z: 30})
           .color("red")
-          .fourway(200);
+          .fourway(200)
+          .textFont({ size: '20px', weight: 'bold' })
+          .text(function () { return "x=" + this._x; })
+          .dynamicTextGeneration(true);
       
       // Scale the viewport up and down when clicking on the "player"
       var toggle = false;
       player.bind("Click", function(){
           if (toggle) {
-              Crafty.viewport.scale(1.5);
+            Crafty.viewport.scale(1.5);
           } else {
             Crafty.viewport.scale(1);
           }
@@ -61,7 +69,7 @@
       // Set up some repeating bars in the other layers
       // Note that the globalZ value determines which item is on the "top" for mouse clicks
       // not the z value of the individual layer -- do we want to change this?
-      for (var i = 0; i < 10; i++){
+      for (var i = -20; i < 20; i++){
         Crafty.e("Background, Bar, Collision, WiredHitBox").color("blue").attr({x: 100*i, y: 10, z: 30});
         Crafty.e("Midground, Bar, Collision, WiredHitBox").color("purple").attr({x: 100*i, y: 20, z: 30});
         Crafty.e("Foreground, Bar, Collision, WiredHitBox").color("yellow").attr({x: 100*i, y: 30, z: 10});

--- a/src/controls/inputs.js
+++ b/src/controls/inputs.js
@@ -450,7 +450,7 @@ Crafty.extend({
      */
     findPointerEventTargetByComponent: function (comp, e, target) {
         var tar = target ? target : Crafty.stage.elem,
-            closest, current, q, l, i, pos, layerPos, maxz = -Infinity;
+            closest, current, q, l, i, pos, maxz = -Infinity;
         var x = e.clientX;
         var y = e.clientY;
 
@@ -463,7 +463,6 @@ Crafty.extend({
             pos = Crafty.domHelper.translate(x, y, ent._drawLayer);
             if (ent.__c[comp] && ent.isAt(pos.x, pos.y)) {
                 closest = ent;
-                layerPos = pos;
             }
         }
 
@@ -492,21 +491,18 @@ Crafty.extend({
                         current.__c[comp] && current.isAt(pos.x, pos.y)) {
                         maxz = current._globalZ;
                         closest = current;
-                        layerPos = pos;
                     }
                 }
             }
         }
         
-        // If the pointer event isn't related to a specific layer, 
-        // find the Crafty position in the default coordinate set
-        if (!layerPos) {
-            layerPos = Crafty.domHelper.translate(x, y);
-        }
+        // Find the Crafty position in the default coordinate set,
+        // disregard the fact that the pointer event was related to a specific layer.
+        pos = Crafty.domHelper.translate(x, y);
 
         // Update the event coordinates and return the event target
-        e.realX = layerPos.x;
-        e.realY = layerPos.y;
+        e.realX = pos.x;
+        e.realY = pos.y;
             
         return closest;
     },

--- a/src/controls/inputs.js
+++ b/src/controls/inputs.js
@@ -520,11 +520,14 @@ Crafty.extend({
      * Internal method which dispatches mouse wheel events received by Crafty.
      * @trigger MouseWheelScroll - is triggered when mouse is scrolled on stage - { direction: +1 | -1} - Scroll direction (up | down)
      *
-     * This method processes a native [`mousewheel` event](https://developer.mozilla.org/en-US/docs/Web/Events/mousewheel) (all browsers except Firefox)
-     * or a native [`DOMMouseScroll` event](https://developer.mozilla.org/en-US/docs/Web/Events/DOMMouseScroll) (Firefox only) received by `Crafty.stage.elem`,
-     * augments it with the additional `.direction` property (see below) and dispatches it to the global Crafty object and thus to every entity.
+     * @note This method processes a native [`wheel` event](https://developer.mozilla.org/en-US/docs/Web/Events/wheel) (all newer browsers),
+     * a native [`mousewheel` event](https://developer.mozilla.org/en-US/docs/Web/Events/mousewheel) (old IE and WebKit browsers) or
+     * a native [`DOMMouseScroll` event](https://developer.mozilla.org/en-US/docs/Web/Events/DOMMouseScroll) (old Firefox browsers)
+     * received by `Crafty.stage.elem`, augments it with the additional `.direction` property (see below) and
+     * dispatches it to the global Crafty object and thus to every entity.
+     * See [mdn details on wheel events](https://developer.mozilla.org/en-US/docs/Web/Events/wheel#Listening_to_this_event_across_browser).
      *
-     * Note that the wheel delta properties of the event vary in magnitude across browsers, thus it is recommended to check for `.direction` instead.
+     * @note The wheel delta properties of the event vary in magnitude across browsers, thus it is recommended to check for `.direction` instead.
      * The `.direction` equals `+1` if wheel was scrolled up, `-1` if wheel was scrolled down
      * (see [details](http://stackoverflow.com/questions/5527601/normalizing-mousewheel-speed-across-browsers)).
      *
@@ -586,8 +589,18 @@ Crafty.extend({
      * ~~~
      */
     mouseWheelDispatch: function (e) {
-        e.direction = (e.detail < 0 || e.wheelDelta > 0) ? 1 : -1;
+        e.direction = (e.detail < 0 || e.wheelDelta > 0 || e.deltaY < 0) ? 1 : -1;
         Crafty.trigger("MouseWheelScroll", e);
+
+        //Don't prevent default actions if target node is input or textarea.
+        if (Crafty.selected && e.target &&
+            e.target.nodeName !== 'INPUT' && e.target.nodeName !== 'TEXTAREA') {
+            if (e.preventDefault) {
+                e.preventDefault();
+            } else {
+                e.returnValue = false;
+            }
+        }
     },
 
     /**@
@@ -686,10 +699,10 @@ Crafty._preBind("Load", function () {
     Crafty.addEvent(this, Crafty.stage.elem, "touchcancel", Crafty.touchDispatch);
     Crafty.addEvent(this, Crafty.stage.elem, "touchleave", Crafty.touchDispatch);
 
-    if (Crafty.support.prefix === "Moz") // mouse wheel event for firefox
-        Crafty.addEvent(this, Crafty.stage.elem, "DOMMouseScroll", Crafty.mouseWheelDispatch);
-    else // mouse wheel event for rest of browsers
-        Crafty.addEvent(this, Crafty.stage.elem, "mousewheel", Crafty.mouseWheelDispatch);
+    var mouseWheelEvent = typeof document.onwheel !== 'undefined' ? 'wheel' : // modern browsers
+                            typeof document.onmousewheel !== 'undefined' ? 'mousewheel' : // old Webkit and IE
+                            'DOMMouseScroll'; // old Firefox
+    Crafty.addEvent(this, Crafty.stage.elem, mouseWheelEvent, Crafty.mouseWheelDispatch);
 });
 
 Crafty._preBind("CraftyStop", function () {
@@ -709,10 +722,10 @@ Crafty._preBind("CraftyStop", function () {
         Crafty.removeEvent(this, Crafty.stage.elem, "touchcancel", Crafty.touchDispatch);
         Crafty.removeEvent(this, Crafty.stage.elem, "touchleave", Crafty.touchDispatch);
 
-        if (Crafty.support.prefix === "Moz") // mouse wheel event for firefox
-            Crafty.removeEvent(this, Crafty.stage.elem, "DOMMouseScroll", Crafty.mouseWheelDispatch);
-        else // mouse wheel event for rest of browsers
-            Crafty.removeEvent(this, Crafty.stage.elem, "mousewheel", Crafty.mouseWheelDispatch);
+        var mouseWheelEvent = typeof document.onwheel !== 'undefined' ? 'wheel' : // modern browsers
+                                typeof document.onmousewheel !== 'undefined' ? 'mousewheel' : // old Webkit and IE
+                                'DOMMouseScroll'; // old Firefox
+        Crafty.removeEvent(this, Crafty.stage.elem, mouseWheelEvent, Crafty.mouseWheelDispatch);
     }
 
     Crafty.removeEvent(this, document.body, "mouseup", Crafty.detectBlur);

--- a/src/graphics/viewport.js
+++ b/src/graphics/viewport.js
@@ -507,8 +507,8 @@ Crafty.extend({
                     lastMouse.x = arg.clientX;
                     lastMouse.y = arg.clientY;
 
-                    Crafty.viewport.x += diff.x;
-                    Crafty.viewport.y += diff.y;
+                    Crafty.viewport.x += diff.x / this._scale;
+                    Crafty.viewport.y += diff.y / this._scale;
                     Crafty.viewport._clamp();
                     break;
                 case 'start':


### PR DESCRIPTION
Adds mouseWheel event listeners for new browsers.
Makes viewport.mouseLook respect zoom factor.
See the [craftyjs/demos/devDemos/example_maplike_zoom.html](https://github.com/craftyjs/demos/blob/master/devDemos/example_maplike_zoom.html).

You can test the functionality by downloading the following file and renaming it to `crafty.js` and including it into the example file.
![crafty.js](https://cloud.githubusercontent.com/assets/3935691/25064937/e4228496-2205-11e7-8d12-34fbb1b03eed.png)

EDIT: Tested on new firefox, edge and chrome versions, seems to work as expected.

