### PR TITLE
Change partial canvas redrawing

### DIFF
--- a/src/graphics/canvas-layer.js
+++ b/src/graphics/canvas-layer.js
@@ -1,6 +1,5 @@
 var Crafty = require('../core/core.js');
 
-
 /**@
  * #CanvasLayer
  * @category Graphics
@@ -13,9 +12,15 @@ var Crafty = require('../core/core.js');
 Crafty._registerLayerTemplate("Canvas", {
     type: "Canvas",
     
-    _dirtyRects: [],
-    _changedObjs: [],
     layerCount: 0,
+    _changedObjs: null,
+
+    _dirtyRects: null,
+    _dirtyCells: null,
+    _viewKeys: null,
+    __tempRect: null,
+    __tempSearchRect: null,
+    __tempScreenRect: null,
 
 
     /**@
@@ -99,8 +104,13 @@ Crafty._registerLayerTemplate("Canvas", {
         }
 
         // set referenced objects to initial values -- necessary to avoid shared state between systems
-        this._dirtyRects = [];
         this._changedObjs = [];
+        this._dirtyRects = [];
+        this._dirtyCells = {};
+        this._viewKeys = { x1: 0, y1: 0, x2: 0, y2: 0 };
+        this.__tempRect = { _x: 0, _y: 0, _w: 0, _h: 0 };
+        this.__tempSearchRect = { _x: 0, _y: 0, _w: 0, _h: 0 };
+        this.__tempScreenRect = { _x: 0, _y: 0, _w: 0, _h: 0 };
 
         //create an empty canvas element
         var c;
@@ -134,7 +144,7 @@ Crafty._registerLayerTemplate("Canvas", {
         if (!l && !dirtyViewport) {
             return;
         }
-        
+
         // Set the camera transforms from the combination of the current viewport parameters and this layers 
         var cameraOptions = this.options;
         if (dirtyViewport && cameraOptions) {
@@ -145,119 +155,77 @@ Crafty._registerLayerTemplate("Canvas", {
             ctx.setTransform(scale, 0, 0, scale, Math.round(dx), Math.round(dy) );
         }
 
-        //if the amount of changed objects is over 60% of the total objects
-        //do the naive method redrawing
-        // TODO: I'm not sure this condition really makes that much sense!
+        // TODO: check if these conditions really make that much sense!
+        // if the amount of changed objects is over 60% of the total objects, do the naive method redrawing
         if (l / this.layerCount > 0.6 || dirtyViewport) {
             this._drawAll();
+        // otherwise draw dirty cell grid regions
         } else {
-            this._drawDirty();
+            this._drawDirtyCells();
         }
+
         //Clean up lists etc
         this._clean();
     },
 
     /**@
-     * #._drawDirty
+     * #._drawDirtyCells
      * @comp CanvasLayer
      * @kind Method
      * @private
-     * 
-     * @sign public ._drawDirty()
+     *
+     * @sign public ._drawDirtyCells([Object rect])
+     * @param rect - a rectangular region {_x: x_val, _y: y_val, _w: w_val, _h: h_val}
+     *
+     * - If rect is omitted, redraw within the viewport
+     * - If rect is provided, redraw within the rect.
      *
      * - Triggered by the "RenderScene" event
-     * - If the number of rects is over 60% of the total number of objects
-     *  do the naive method redrawing `CanvasLayer.drawAll` instead
-     * - Otherwise, clear the dirty regions, and redraw entities overlapping the dirty regions.
+     * - This method is invoked if the number of rects is under 60% of the total number of objects
+     *  and the total number of objects is greater than 16.
+     * - Clear the dirty spatial grid cells, and redraw entities overlapping the dirty spatial grid cells.
      *
      * @see Canvas#.draw
      */
-    _drawDirty: function (view) {
-        view = view || this._viewportRect();
-        var i, j, q, rect,len, obj,
-            changed = this._changedObjs,
-            l = changed.length,
-            dirty = this._dirtyRects,
-            rectManager = Crafty.rectManager,
-            overlap = rectManager.overlap,
-            ctx = this.context,
-            dupes = [],
-            objs = [];
-        
+    _drawDirtyCells: function (view) {
+        var viewportRect = this._viewportRect(), // this updates the viewportRect for later cached use
+            rect = this.__tempRect,
+            dirtyRects = this._dirtyRects,
+            integerBounds = Crafty.rectManager.integerBounds,
+            ctx = this.context;
+        var i, l;
+
         // Canvas works better with integral coordinates where possible
-        view = rectManager.integerBounds(view);
-        
-        // Calculate _dirtyRects from all changed objects, then merge some overlapping regions together
-        for (i = 0; i < l; i++) {
-            this._createDirty(changed[i]);
-        }
-        rectManager.mergeSet(dirty);
+        view = integerBounds(view || viewportRect);
 
-
-        l = dirty.length;
+        // Calculate dirty spatial map cells from all changed objects
+        // Don't include cells outside rect to be drawn (e.g. viewport)
+        this._createDirtyCells(view);
+        // Afterwards, calculate dirty rectangles from dirty spatial map cells
+        this._createDirtyRects();
 
         // For each dirty rectangle, find entities near it, and draw the overlapping ones
-        for (i = 0; i < l; ++i) { //loop over every dirty rect
-            rect = dirty[i];
-            dupes.length = 0;
-            objs.length = 0;
-            if (!rect) continue;
+        for (i = 0, l = dirtyRects.length; i < l; i += 4) { //loop over every dirty rect
+            rect._x = dirtyRects[i + 0];
+            rect._y = dirtyRects[i + 1];
+            rect._w = dirtyRects[i + 2];
+            rect._h = dirtyRects[i + 3];
 
-            // Find the smallest rectangle with integer coordinates that encloses rect
-            rect = rectManager.integerBounds(rect);
-
-            // If a dirty rect doesn't overlap with the viewport, skip to the next one
-            if (!overlap(rect, view)) continue;
-
-            //search for ents under dirty rect
-            q = Crafty.map.search(rect, false);
-
-            //clear the rect from the main canvas
-            ctx.clearRect(rect._x, rect._y, rect._w, rect._h);
-
-            //Then clip drawing region to dirty rectangle
-            ctx.save();
-            ctx.beginPath();
-            ctx.rect(rect._x, rect._y, rect._w, rect._h);
-            ctx.clip();
-
-            // Loop over found objects removing dupes and adding visible canvas objects to array
-            for (j = 0, len = q.length; j < len; ++j) {
-                obj = q[j];
-
-                if (dupes[obj[0]] || !obj._visible || (obj._drawLayer !== this) )
-                    continue;
-                dupes[obj[0]] = true;
-                objs.push(obj);
-            }
-
-            // Sort objects by z level
-            objs.sort(this._sort);
-
-            // Then draw each object in that order
-            for (j = 0, len = objs.length; j < len; ++j) {
-                obj = objs[j];
-                var area = obj._mbr || obj;
-                if (overlap(area, rect))
-                    obj.draw();
-                obj._changed = false;
-            }
-
-            // Close rectangle clipping
-            ctx.closePath();
-            ctx.restore();
-
+            // Draw the rectangle, collision search doesn't need to check for duplicates
+            this._drawRect(rect, false);
         }
 
         // Draw dirty rectangles for debugging, if that flag is set
         if (this.debugDirty === true) {
-            ctx.strokeStyle = 'red';
-            for (i = 0, l = dirty.length; i < l; ++i) {
-                rect = dirty[i];
-                ctx.strokeRect(rect._x, rect._y, rect._w, rect._h);
+            var frame = Crafty.frame(),
+                r = (6 * frame + 0) % 255,
+                g = (6 * frame + 85) % 255,
+                b = (6 * frame + 170) % 255;
+            ctx.strokeStyle = "rgb(" + r + ", " + g + ", " + b + ")";
+            for (i = 0, l = dirtyRects.length; i < l; i += 4) {
+                ctx.strokeRect(dirtyRects[i + 0], dirtyRects[i + 1], dirtyRects[i + 2], dirtyRects[i + 3]);
             }
         }
-
     },
 
     /**@
@@ -266,32 +234,91 @@ Crafty._registerLayerTemplate("Canvas", {
      * @kind Method
      * @private
      * 
-     * @sign public CanvasLayer.drawAll([Object rect])
+     * @sign public ._drawAll([Object rect])
      * @param rect - a rectangular region {_x: x_val, _y: y_val, _w: w_val, _h: h_val}
      *
      * - If rect is omitted, redraw within the viewport
-     * - If rect is provided, redraw within the rect
+     * - If rect is provided, redraw within the rect.
+     *
+     * - Triggered by the "RenderScene" event
+     * - This method is invoked if the number of rects is over 60% of the total number of objects.
+     * - Clear the whole viewport, and redraw entities overlapping it by default.
+     *
+     * @see Canvas#.draw
      */
-    _drawAll: function (rect) {
-        rect = rect || this._viewportRect();
-        rect = Crafty.rectManager.integerBounds(rect);
-        var q = Crafty.map.search(rect),
-            i = 0,
-            l = q.length,
+    _drawAll: function (view) {
+        var viewportRect = this._viewportRect(); // this updates the viewportRect for later cached use
+
+        // Draw the whole layer rectangle, collision search should check for duplicates
+        this._drawRect(view || viewportRect, true);
+    },
+
+    _drawRect: function(rect, checkDupes) {
+        var i, l, q, obj, previousGlobalZ,
+            integerBounds = Crafty.rectManager.integerBounds,
             ctx = this.context,
-            current;
+            searchRect = this.__tempSearchRect,
+            screenRect = this.__tempScreenRect;
 
-        ctx.clearRect(rect._x, rect._y, rect._w, rect._h);
+        // Compute the final screen coordinates for the rectangle
+        screenRect = this._viewTransformRect(rect, screenRect, true); // use cached viewportRect
+        // Find the smallest rectangle with integer coordinates that encloses screenRect
+        screenRect = integerBounds(screenRect);
 
-        //sort the objects by the global Z
+        // Find the smallest rectangle with integer coordinates that encloses rect
+        rect = integerBounds(rect);
+
+        // Search for ents under dirty rect.
+        //
+        // Don't need to search for full entity dimensions!
+        // If coordinates are integers, the search area with default _w and _h is (1 px - Number.Epsilon px) too big.
+        // Thus trim the search area accordingly.
+        // Otherwise unecessary neighboring grid cells would be searched for entities,
+        // these additional entities would later be removed because of failing condition rectManager.overlap
+        // This is a performance optimization for dirty cell drawing, to only search one grid cell for each rect,
+        // else three additional cells would be searched unnecessarily.
+        searchRect._x = rect._x;
+        searchRect._y = rect._y;
+        searchRect._w = rect._w - 1;
+        searchRect._h = rect._h - 1;
+        q = Crafty.map.search(searchRect, checkDupes);
+        // Sort objects by z level, duplicate objs will be ordered next to each other due to same _globalZ
         q.sort(this._sort);
-        for (; i < l; i++) {
-            current = q[i];
-            if (current._visible && current._drawContext === this.context) {
-                current.draw(this.context);
-                current._changed = false;
+
+
+        // save context before drawing, saves e.g. infinite clip region
+        ctx.save();
+
+        // Clip and clear works best with default identity transform,
+        // but do the actual clipping after restoring viewport transform,
+        // as the clipping region would be disgarded otherwise
+        ctx.save();
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        // Clip drawing region to dirty rectangle
+        ctx.beginPath();
+        ctx.rect(screenRect._x, screenRect._y, screenRect._w, screenRect._h);
+        // Clear the rect from the main canvas
+        ctx.clearRect(screenRect._x, screenRect._y, screenRect._w, screenRect._h);
+        ctx.restore();
+        ctx.clip();
+
+        // Then draw each visible canvas object from this layer in that order, avoiding duplicates
+        // No need to check for overlap with drawing area, as it's a single grid cell or the entire viewport
+        // -> in both cases all entities returned from collision search overlap that drawing area
+        previousGlobalZ = -Infinity;
+        for (i = 0, l = q.length; i < l; ++i) {
+            obj = q[i];
+
+            if (obj._globalZ > previousGlobalZ && obj._visible && obj._drawLayer === this) {
+                obj.draw(ctx);
+                obj._changed = false;
+
+                previousGlobalZ = obj._globalZ;
             }
         }
+
+        // restore context after drawing, restores e.g. clip regions
+        ctx.restore();
     },
 
     debug: function() {
@@ -300,53 +327,93 @@ Crafty._registerLayerTemplate("Canvas", {
 
     /** cleans up current dirty state, stores stale state for future passes */
     _clean: function () {
-        var rect, obj, i, l,
-            changed = this._changedObjs;
-         for (i = 0, l = changed.length; i < l; i++) {
-             obj = changed[i];
-             rect = obj._mbr || obj;
-             if (typeof obj.staleRect === 'undefined')
-                 obj.staleRect = {};
-             obj.staleRect._x = rect._x;
-             obj.staleRect._y = rect._y;
-             obj.staleRect._w = rect._w;
-             obj.staleRect._h = rect._h;
+        var dirtyKeys, staleKeys, obj, i, l;
 
-             obj._changed = false;
-         }
-         changed.length = 0;
-         this._dirtyRects.length = 0;
-         this._dirtyViewport = false;
+        var changed = this._changedObjs;
+        for (i = 0, l = changed.length; i < l; i++) {
+            obj = changed[i];
 
+            // we need to keep track of all stale states, because drawing method can change dynamically
+            // track stale grid cell keys for dirty grid cell drawing
+            dirtyKeys = obj._entry.keys; // cached computation of Crafty.HashMap.key(obj)
+            staleKeys = obj.staleKeys;
+            if (staleKeys === undefined) obj.staleKeys = staleKeys = { x1: 0, y1: 0, x2: 0, y2: 0 };
+            staleKeys.x1 = dirtyKeys.x1;
+            staleKeys.y1 = dirtyKeys.y1;
+            staleKeys.x2 = dirtyKeys.x2;
+            staleKeys.y2 = dirtyKeys.y2;
+
+            obj._changed = false;
+        }
+        changed.length = 0;
+
+        this._dirtyCells = {};
+        this._dirtyRects.length = 0;
+
+        this._dirtyViewport = false;
     },
 
-     /** Takes the current and previous position of an object, and pushes the dirty regions onto the stack
-      *  If the entity has only moved/changed a little bit, the regions are squashed together */
-    _createDirty: function (obj) {
+    // Takes the current and previous position of changed objects and
+    // adds the dirty spatial map cells they are contained in to a set.
+    //
+    // If a dirty cell doesn't overlap with the area to be drawn (e.g. viewport),
+    // don't include it
+    //
+    _createDirtyCells: function (view) {
+        var changed = this._changedObjs,
+            dirtyCells = this._dirtyCells;
+        var viewKeys = Crafty.HashMap.key(view, this._viewKeys);
 
-        var rect = obj._mbr || obj,
-            dirty = this._dirtyRects,
-            rectManager = Crafty.rectManager;
+        var i, l, j, k, obj, keys;
+        for (i = 0, l = changed.length; i < l; i++) {
+            obj = changed[i];
 
-        if (obj.staleRect) {
-            //If overlap, merge stale and current position together, then return
-            //Otherwise just push stale rectangle
-            if (rectManager.overlap(obj.staleRect, rect)) {
-                rectManager.merge(obj.staleRect, rect, obj.staleRect);
-                dirty.push(obj.staleRect);
-                return;
-            } else {
-              dirty.push(obj.staleRect);
+            // if object was previously drawn it's old position needs to be redrawn (cleared)
+            if ((keys = obj.staleKeys)) { // cached computation of stale keys
+                for (j = keys.x1; j <= keys.x2; j++) {
+                    for (k = keys.y1; k <= keys.y2; k++) {
+                        // if stale cell is inside area to be drawn
+                        if (viewKeys.x1 <= j && j <= viewKeys.x2 &&
+                            viewKeys.y1 <= k && k <= viewKeys.y2) {
+
+                            // combine two 16 bit unsigned numbers into a unique 32 bit unsigned number
+                            dirtyCells[(j << 16) ^ k] = true;
+                        }
+                    }
+                }
+            }
+
+            keys = obj._entry.keys; // cached computation of Crafty.HashMap.key(obj)
+            for (j = keys.x1; j <= keys.x2; j++) {
+                for (k = keys.y1; k <= keys.y2; k++) {
+                    // if dirty cell is inside area to be drawn
+                    if (viewKeys.x1 <= j && j <= viewKeys.x2 &&
+                        viewKeys.y1 <= k && k <= viewKeys.y2) {
+
+                        // combine two 16 bit unsigned numbers into a unique 32 bit unsigned number
+                        dirtyCells[(j << 16) ^ k] = true;
+                    }
+                }
             }
         }
+    },
 
-        // We use the intermediate "currentRect" so it can be modified without messing with obj
-        obj.currentRect._x = rect._x;
-        obj.currentRect._y = rect._y;
-        obj.currentRect._w = rect._w;
-        obj.currentRect._h = rect._h;
-        dirty.push(obj.currentRect);
+    // Takes all dirty spatial map cells and
+    // pushes the corresponding dirty rectangles onto the stack.
+    //
+    _createDirtyRects: function() {
+        var cellsize = Crafty.HashMap.cellsize(),
+            dirtyCells = this._dirtyCells,
+            dirtyRects = this._dirtyRects;
 
+        var hash, j, k;
+        for (var strHash in dirtyCells) {
+            hash = +strHash;
+            // deconstruct a 32 bit unsigned number into a unique pair of 16 bit unsigned numbers
+            k = (hash << 16) >> 16;
+            j = (k < 0) ? ~(hash >> 16) : hash >> 16;
+            dirtyRects.push(j * cellsize, k * cellsize, cellsize, cellsize);
+        }
     },
 
 

--- a/src/spatial/rect-manager.js
+++ b/src/spatial/rect-manager.js
@@ -55,15 +55,13 @@ Crafty.extend({
        * Calculate the smallest rectangle with integer coordinates that encloses the specified rectangle,
        * modifying the passed object to have those bounds.
        */
-      integerBounds: function(rect){
-        rect._w = rect._x + rect._w;
-        rect._h = rect._y + rect._h;
-        rect._x = (rect._x > 0) ? (rect._x|0) : (rect._x|0) - 1;
-        rect._y = (rect._y > 0) ? (rect._y|0) : (rect._y|0) - 1;
-        rect._w -= rect._x;
-        rect._h -= rect._y;
-        rect._w = (rect._w === (rect._w|0)) ? rect._w : (rect._w|0) + 1;
-        rect._h = (rect._h === (rect._h|0)) ? rect._h : (rect._h|0) + 1;
+      integerBounds: function(rect) {
+        // Truncate to next, lower integer, but don't modify if already integer
+        rect._x = Math.floor(rect._x);
+        rect._y = Math.floor(rect._y);
+        // Ceil to next, higher integer, but don't modify if already integer
+        rect._w = Math.ceil(rect._w);
+        rect._h = Math.ceil(rect._h);
         return rect;
       },
 


### PR DESCRIPTION
Instead of merging all changed entity rectangles, add spatial map cells of changed entities to a set.
Compute rectangles that represent the bounds of this cells.
Clear and redraw those rectangles.

## [Motivation ](https://github.com/craftyjs/Crafty/pull/1021#issuecomment-195820201):
> I wonder if the best approach for Canvas redrawing would be to have it flag cells of the hashmap as dirty, rather than carefully keeping track of the bounding areas of individual entities.

## Performance
Ran two variants. See [example_partial_redraw.html](https://github.com/craftyjs/demos/blob/master/devDemos/example_partial_redraw.html) for the test code. Toggle the boolean flag to switch between entity distributions.

### Worst-case for new implementation
Worst case for new implementation is when small entities are positioned at the border of two spatial map cells, which triggers a redraw of two grid cells, whereas only a small area for the entity would be redrawn with old implementation.
**Performance of new implementation is in this case ~30% worse than of old implementation.**

#### Old impl chromium profile
![canvas-old-old_bc](https://cloud.githubusercontent.com/assets/3935691/25718183/66bb178e-3105-11e7-945f-26392ea9cbfc.png)
#### New impl chromium profile
![canvas-new-old_bc](https://cloud.githubusercontent.com/assets/3935691/25718203/7a5f5570-3105-11e7-997a-e88fc48320cc.png)

### Best-case for new implementation
Best-case for new implementation is a lot of entities near each other, but not overlapping. In this case a redraw of a grid cell redraws all those entities. It's bad for old implementation, since the entity's rectangles are not overlapping, so nothing can be merged and each entity rect needs to be redrawn separately.
**Performance of new implementation is in this case ~20% better than of old implementation.**

#### Old impl chromium profile
![canvas-old-new_bc](https://cloud.githubusercontent.com/assets/3935691/25718221/8d3d4954-3105-11e7-84c7-5e436759e670.png)
#### New impl chromium profile
![canvas-new-new_bc](https://cloud.githubusercontent.com/assets/3935691/25718233/9c79d8ec-3105-11e7-8b9b-e1373c9bc0e4.png)

### Conclusion


It's hard to say which implementation is better, but intuitively the new impl scales better. Within a more complex scene, I'd argue that better performance is more important than in an already smooth running trivial scene.   
There might be a way to squeeze out a bit more performance in `_createDirtyCell` by creating a number-indexed sparse array instead of a hash-string indexed object. Otherwise I'm not aware of any other things that could be done to improve it even further.   
On top of that, the partial canvas clear bug looks a bit more acceptable, but a fix for that is coming soon (if this impl is chosen, then on top of this, maybe in next PR?)




