### PR TITLE
New input implementation: Part 2

### DIFF
--- a/src/aliases.js
+++ b/src/aliases.js
@@ -23,6 +23,8 @@ module.exports = {
 
         createDeprecatedAlias(Crafty, "touchDispatch", Crafty, "_touchDispatch");
         createDeprecatedAlias(Crafty, "touchObjs", Crafty.s('Touch'), "touchObjs");
+        Crafty.touchHandler = {};
+        createDeprecatedAlias(Crafty.touchHandler, "fingers", Crafty.s('Touch'), "touchPoints");
     }
 };
 

--- a/src/controls/keyboard.js
+++ b/src/controls/keyboard.js
@@ -5,18 +5,18 @@ var Crafty = require('../core/core.js');
  * @category Input
  * @kind Component
  *
- * Provides valid key related events and key states for the entity.
+ * Handles valid key related events and key states for the entity.
+ * @note This is an internally used component, automatically included in the `KeyboardSystem`.
  *
- * @trigger KeyDown - is triggered when the DOM 'keydown' event is triggered. - { key: `Crafty.keys` keyCode (Number), originalEvent: original KeyboardEvent } - Crafty's KeyboardEvent
- * @trigger KeyUp - is triggered when the DOM 'keyup' event is triggered. - { key: `Crafty.keys` keyCode (Number), originalEvent: original KeyboardEvent } - Crafty's KeyboardEvent
+ * @trigger KeyDown - when a key is pressed - KeyboardEvent
+ * @trigger KeyUp - when a key is released - KeyboardEvent
  *
- * The event callbacks are triggered with a native [`KeyboardEvent`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent) received by `window.document`,
- * which is wrapped in a standard Crafty event object consisting of additional properties:
+ * The standard Crafty `KeyboardEvent` object:
  * ~~~
  * // event name of key event
  * e.eventName
  *
- * // Normalized keyCode according to Crafty.keys
+ * // Normalized keyCode number according to `Crafty.keys`
  * e.key
  *
  * // Original keyboard event, containing additional native properties
@@ -108,7 +108,7 @@ Crafty.__keyboardStateTemplate = {
      * @param eventName - Name of the key event to trigger ("KeyDown" or "KeyUp")
      * @param eventData - The key event to trigger
      *
-     * Try to trigger a key event on this entity.
+     * Try to trigger a key event on this entity and persist the key state.
      * This method prevents inconsistent key state.
      * e.g. If this entity didn't receive a "KeyDown" previously, it won't fire a "KeyUp" event.
      *

--- a/src/controls/mouse.js
+++ b/src/controls/mouse.js
@@ -5,18 +5,14 @@ var Crafty = require('../core/core.js');
  * @category Input
  * @kind Component
  *
- * Provides valid mouse related events and button states for the entity.
+ * Handles valid mouse related events and button states for the entity.
+ * @note This is an internally used component, automatically included in the `MouseSystem`.
  *
- * @trigger MouseOver - when the mouse enters - MouseEvent
- * @trigger MouseOut - when the mouse leaves - MouseEvent
- * @trigger MouseDown - when the mouse button is pressed on - MouseEvent
- * @trigger MouseUp - when the mouse button is released on - MouseEvent
- * @trigger Click - when the user clicks - MouseEvent
- * @trigger DoubleClick - when the user double clicks - MouseEvent
- * @trigger MouseMove - when the mouse is over and moves - MouseEvent
+ * @trigger MouseDown - when a mouse button is pressed - MouseEvent
+ * @trigger MouseMove - when the mouse moves - MouseEvent
+ * @trigger MouseUp - when a mouse button is released - MouseEvent
  *
- * The event callbacks are triggered with a native [`MouseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent),
- * which is wrapped in a standard Crafty event object consisting of additional properties:
+ * The standard Crafty `MouseEvent` object:
  * ~~~
  * // event name of mouse event
  * e.eventName
@@ -25,34 +21,18 @@ var Crafty = require('../core/core.js');
  * // Crafty.mouseButtons.LEFT, Crafty.mouseButtons.RIGHT or Crafty.mouseButtons.MIDDLE
  * e.mouseButton
  *
+ * // the closest (visible & Mouse-enhanced) entity to the source of the event (if available), otherwise null
+ * e.target
+ *
  * // (x,y) coordinates of mouse event in world (default viewport) space
  * e.realX
  * e.realY
- *
- * // (x,y) coordinates of mouse event in web-browser (screen) space
- * e.clientX
- * e.clientY
  *
  * // Original mouse event, containing additional native properties
  * e.originalEvent
  * ~~~
  *
  * In addition to binding to these events, the current state (pressed/released) of a mouse button can also be queried using the `.isButtonDown` method.
- *
- * @example
- * ~~~
- * var myEntity = Crafty.e('2D, Canvas, Color, Mouse')
- * .attr({x: 10, y: 10, w: 40, h: 40})
- * .color('red')
- * .bind('Click', function(MouseEvent){
- *   alert('clicked', MouseEvent);
- * });
- *
- * myEntity.bind('MouseUp', function(e) {
- *    if( e.mouseButton == Crafty.mouseButtons.RIGHT )
- *        Crafty.log("Clicked right button");
- * })
- * ~~~
  *
  * @see Mouse, MouseSystem
  * @see Crafty.mouseButtons
@@ -78,10 +58,11 @@ Crafty.__mouseStateTemplate = {
         this.lastMouseEvent = {
             eventName: '',
             mouseButton: -1,
+            target: null,
             realX: 0,
             realY: 0,
-            clientX: 0,
-            clientY: 0,
+            clientX: 0, // DEPRECATED: remove in upcoming release
+            clientY: 0, // DEPRECATED: remove in upcoming release
             originalEvent: null
         };
     },
@@ -158,7 +139,7 @@ Crafty.__mouseStateTemplate = {
      * @param eventName - Name of the mouse event to trigger ("MouseDown", "MouseUp", "MouseMove", ...)
      * @param eventData - The mouse event to trigger
      *
-     * Try to trigger a mouse event on this entity.
+     * Try to trigger a mouse event on this entity and persist the button state.
      * This method prevents inconsistent button state.
      * e.g. If this entity didn't receive a "MouseDown" previously, it won't fire a "MouseUp" event.
      *
@@ -184,10 +165,11 @@ Crafty.__mouseStateTemplate = {
         var lastEvent = this.lastMouseEvent;
         lastEvent.eventName = eventName;
         lastEvent.mouseButton = eventData.mouseButton;
+        lastEvent.target = eventData.target;
         lastEvent.realX = eventData.realX;
         lastEvent.realY = eventData.realY;
-        lastEvent.clientX = eventData.clientX;
-        lastEvent.clientY = eventData.clientY;
+        lastEvent.clientX = eventData.clientX; // DEPRECATED: remove in upcoming release
+        lastEvent.clientY = eventData.clientY; // DEPRECATED: remove in upcoming release
         lastEvent.originalEvent = eventData.originalEvent;
 
         // trigger event only if valid state

--- a/src/controls/touch.js
+++ b/src/controls/touch.js
@@ -1,0 +1,211 @@
+var Crafty = require('../core/core.js');
+
+/**@
+ * #TouchState
+ * @category Input
+ * @kind Component
+ *
+ * Handles valid touch related events and touch points for the entity.
+ * @note This is an internally used component, automatically included in the `TouchSystem`.
+ *
+ * @trigger TouchStart - when a finger is pressed - TouchPointEvent
+ * @trigger TouchMove - when a pressed finger is moved - TouchPointEvent
+ * @trigger TouchEnd - when a finger is raised - TouchPointEvent
+ * @trigger TouchCancel - when a touch event has been disrupted in some way - TouchPointEvent
+ *
+ * The standard Crafty `TouchPointEvent` object:
+ * ~~~
+ * // event name of touch event
+ * e.eventName
+ *
+ * // identifier for this touch point, unique over the duration the finger is on the touch surface
+ * e.identifier
+ *
+ * // the closest (visible & Touch-enhanced) entity to the source of the event (if available), otherwise null
+ * e.target
+ *
+ * // (x,y) coordinates of the touch point in world (default viewport) space
+ * e.realX
+ * e.realY
+ *
+ * // Original touch event, containing additional native properties
+ * e.originalEvent
+ * ~~~
+ *
+ * In addition to binding to these events, the current touch points can also be queried using the `.touchPoints` property.
+ *
+ * @see Touch, TouchSystem
+ */
+Crafty.__touchStateTemplate = {
+    /**@
+     * #.touchPoints
+     * @comp TouchState
+     * @kind Property
+     *
+     * Holds data of all currently pressed touch points (useful for determining positions of fingers in every frame).
+     * Data of a touch point is lost when the respective finger is raised.
+     *
+     * @example
+     * ~~~
+     * var touchPoint, touchPoints = Crafty.s('Touch').touchPoints;
+     * for (var i = 0, l = touchPoints.length; i < l; i++) {
+     *   touchPoint = touchPoints[i];
+     *   Crafty.log(touchPoint.realX, touchPoint.realY); // logs coordinates in Crafty's world space
+     * }
+     * ~~~
+     *
+     * @see .resetTouchPoints
+     */
+    touchPoints: null,
+
+    _touchPointsPool: null,
+
+    init: function() {
+        this.touchPoints = [];
+        this._touchPointsPool = [];
+        // use custom trigger method if specified
+        this.triggerTouchEvent = this.triggerTouchEvent || this.trigger;
+    },
+
+    /**@
+     * #.resetTouchPoints
+     * @comp TouchState
+     * @kind Method
+     *
+     * @sign public this .resetTouchPoints()
+     *
+     * Reset all current touch points. Triggers appropriate "TouchCancel" events.
+     *
+     * This method is called internally, but may be useful when running Crafty in headless mode.
+     *
+     * @see .touchPoints
+     */
+    resetTouchPoints: function () {
+        // Tell all touch points they're no longer held down
+        var touchPoints = this.touchPoints, touchPoint,
+            i = touchPoints.length;
+        while (i--) { // iterate backwards to avoid conflicts with removal of array elements
+            touchPoint = touchPoints[i];
+            touchPoint.eventName = "TouchCancel";
+            this.triggerTouch("TouchCancel", touchPoint);
+        }
+
+        return this;
+    },
+
+    /**@
+     * #.triggerTouch
+     * @comp TouchState
+     * @kind Method
+     *
+     * @sign public this triggerTouch(String eventName, Object eventData)
+     * @param eventName - Name of the touch event to trigger ("TouchStart", "TouchMove", "TouchEnd", "TouchCancel", ...)
+     * @param eventData - The touch event to trigger
+     *
+     * Try to trigger a touch event on this entity and persist the touch point.
+     * This method prevents inconsistent touch state.
+     * e.g. If this entity didn't receive a "TouchStart" of a identifier previously, it won't fire a "TouchEnd" event for that identifier.
+     *
+     * This method is called internally, but may be useful when running Crafty in headless mode.
+     *
+     * @example
+     * ~~~
+     * var wasTriggered = false;
+     *
+     * ent.requires('TouchState')
+     *    .bind('TouchEnd', function(evt) {
+     *       wasTriggered = true;
+     *    })
+     *    .triggerTouch('TouchEnd', { identifier: 0 });
+     *
+     * Crafty.log(wasTriggered); // prints false
+     * ~~~
+     */
+    triggerTouch: function (eventName, eventData) {
+        switch (eventName) {
+            case "TouchStart":
+                this._handleStart(eventData);
+                break;
+            case "TouchMove":
+                this._handleMove(eventData);
+                break;
+            case "TouchCancel":
+            case "TouchEnd":
+                this._handleEnd(eventData);
+                break;
+            default:
+                this.triggerTouchEvent(eventName, eventData); // trigger the event otherwise
+        }
+        return this;
+    },
+
+    _indexOfTouchPoint: function (identifier) {
+        var touchPoints = this.touchPoints;
+        for (var i = 0, l = touchPoints.length; i < l; i++) {
+            if (touchPoints[i].identifier === identifier) {
+                return i;
+            }
+        }
+        return -1;
+    },
+
+    _setTouchPoint: function (touchPointDest, touchPointSrc) {
+        touchPointDest.eventName = touchPointSrc.eventName;
+        touchPointDest.identifier = touchPointSrc.identifier;
+        touchPointDest.target = touchPointSrc.target;
+        touchPointDest.entity = touchPointSrc.entity; // DEPRECATED: remove this in upcoming release
+        touchPointDest.realX = touchPointSrc.realX;
+        touchPointDest.realY = touchPointSrc.realY;
+        touchPointDest.originalEvent = touchPointSrc.originalEvent;
+    },
+
+    _handleStart: function (touchPoint) {
+        var oldIndex = this._indexOfTouchPoint(touchPoint.identifier),
+            oldTouchPoint = oldIndex >= 0 ? this.touchPoints[oldIndex] : null;
+        if (!oldTouchPoint) { // ignore TouchStart due to inconsistent state caused by loosing focus
+            // allocate touch point
+            var newTouchPoint = this._touchPointsPool.pop() || {};
+            this._setTouchPoint(newTouchPoint, touchPoint);
+            this.touchPoints.push(newTouchPoint);
+
+            this.triggerTouchEvent(newTouchPoint.eventName, newTouchPoint);
+        }
+    },
+
+    _handleMove: function (touchPoint) {
+        var oldIndex = this._indexOfTouchPoint(touchPoint.identifier),
+            oldTouchPoint = oldIndex >= 0 ? this.touchPoints[oldIndex] : null;
+        if (oldTouchPoint) { // ignore TouchMove due to inconsistent state caused by loosing focus
+            // update touch point
+            this._setTouchPoint(oldTouchPoint, touchPoint);
+
+            this.triggerTouchEvent(oldTouchPoint.eventName, oldTouchPoint);
+        }
+    },
+
+    _handleEnd: function (touchPoint) {
+        var oldIndex = this._indexOfTouchPoint(touchPoint.identifier),
+            oldTouchPoint = oldIndex >= 0 ? this.touchPoints[oldIndex] : null;
+        if (oldTouchPoint) { // ignore TouchEnd due to inconsistent state caused by loosing focus
+            this._setTouchPoint(oldTouchPoint, touchPoint);
+            this.triggerTouchEvent(oldTouchPoint.eventName, oldTouchPoint);
+
+            // free touch point
+            this.touchPoints.splice(oldIndex, 1);
+            oldTouchPoint.target = null; // release reference for possible GC
+            oldTouchPoint.entity = null; // DEPRECATED: remove this in upcoming release
+            oldTouchPoint.originalEvent = null; // release reference for possible GC
+            this._touchPointsPool.push(oldTouchPoint);
+        }
+    }
+};
+Crafty.c("TouchState", Crafty.__touchStateTemplate);
+
+// define a basic Touch system for headless mode
+// will be substituted with proper one in browser mode
+Crafty.s("Touch", Crafty.extend.call({
+    // this method will be called by TouchState iff triggerTouch event was valid
+    triggerTouchEvent: function (eventName, e) {
+        Crafty.trigger(eventName, e);
+    }
+}, Crafty.__touchStateTemplate), {}, false);

--- a/src/crafty-common.js
+++ b/src/crafty-common.js
@@ -32,6 +32,7 @@ module.exports = function(requireNew) {
     require('./controls/keyboard');
     require('./controls/keycodes');
     require('./controls/mouse');
+    require('./controls/touch');
 
     require('./debug/logging');
 

--- a/src/graphics/viewport.js
+++ b/src/graphics/viewport.js
@@ -488,9 +488,10 @@ Crafty.extend({
                 diff = {x: 0, y: 0};
 
             function startFn (e) {
-                if (dragging) return;
+                if (dragging || e.target) return;
 
                 Crafty.trigger("StopCamera");
+                // DEPRECATED: switch computation to use e.realX, e.realY
                 lastMouse.x = e.clientX;
                 lastMouse.y = e.clientY;
                 dragging = true;
@@ -516,8 +517,7 @@ Crafty.extend({
             }
 
             return function (op) {
-                // FIXME: mouseLook is incompatible with Draggable entities
-                // TODO: lock pointer events on controls system
+                // TODO: lock pointer events on controls system in future
                 mouseSystem = Crafty.s('Mouse');
 
                 if (op && !active) {

--- a/src/inputs/keyboard.js
+++ b/src/inputs/keyboard.js
@@ -6,8 +6,11 @@ var Crafty = require('../core/core.js');
  * @kind System
  *
  * Provides access to key events.
+ * @note Events and methods are inherited from the `KeyboardState` component.
  *
- * Events and methods are inherited from the `KeyboardState` component.
+ * The event callbacks are triggered with a native [`KeyboardEvent`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent)
+ * received by `window.document`, which is wrapped in a standard Crafty event object (as described in `KeyboardState`).
+ *
  * These key events are triggered globally, thus on the global Crafty instance, every entity and system.
  *
  * @example
@@ -75,7 +78,9 @@ Crafty.s("Keyboard", Crafty.extend.call(Crafty.extend.call(new Crafty.__eventDis
  * Keyboard events get dispatched to all entities that have the Keyboard component.
  * @note If you do not add this component, key events will not be triggered on the entity.
  *
- * Triggers all events described in the `KeyboardState` component.
+ * Triggers all events described in the `KeyboardState` component, these are:
+ * @trigger KeyDown - when a key is pressed - KeyboardEvent
+ * @trigger KeyUp - when a key is released - KeyboardEvent
  *
  * @example
  * ~~~

--- a/src/inputs/lifecycle.js
+++ b/src/inputs/lifecycle.js
@@ -9,8 +9,10 @@ var mouseWheelEvent = typeof document.onwheel !== 'undefined' ? 'wheel' : // mod
 //initialize the input events onload
 Crafty._preBind("Load", function () {
     Crafty.addEvent(this, document.body, "mouseup", Crafty.detectBlur);
-    Crafty.addEvent(this, window, "blur", Crafty.s('Keyboard').resetKeyDown);
-    Crafty.addEvent(this, window, "mouseup", Crafty.s('Mouse').resetButtonDown);
+    Crafty.addEvent(Crafty.s('Keyboard'), window, "blur", Crafty.s('Keyboard').resetKeyDown);
+    Crafty.addEvent(Crafty.s('Mouse'), window, "mouseup", Crafty.s('Mouse').resetButtonDown);
+    Crafty.addEvent(Crafty.s('Touch'), window, "touchend", Crafty.s('Touch').resetTouchPoints);
+    Crafty.addEvent(Crafty.s('Touch'), window, "touchcancel", Crafty.s('Touch').resetTouchPoints);
 
     Crafty.addEvent(Crafty.s('Keyboard'), "keydown", Crafty.s('Keyboard').processEvent);
     Crafty.addEvent(Crafty.s('Keyboard'), "keyup", Crafty.s('Keyboard').processEvent);
@@ -44,8 +46,10 @@ Crafty._preBind("CraftyStop", function () {
 
 Crafty._preBind("CraftyStop", function () {
     Crafty.removeEvent(this, document.body, "mouseup", Crafty.detectBlur);
-    Crafty.removeEvent(this, window, "blur", Crafty.s('Keyboard').resetKeyDown);
-    Crafty.removeEvent(this, window, "mouseup", Crafty.s('Mouse').resetButtonDown);
+    Crafty.removeEvent(Crafty.s('Keyboard'), window, "blur", Crafty.s('Keyboard').resetKeyDown);
+    Crafty.removeEvent(Crafty.s('Mouse'), window, "mouseup", Crafty.s('Mouse').resetButtonDown);
+    Crafty.removeEvent(Crafty.s('Touch'), window, "touchend", Crafty.s('Touch').resetTouchPoints);
+    Crafty.removeEvent(Crafty.s('Touch'), window, "touchcancel", Crafty.s('Touch').resetTouchPoints);
 
     Crafty.removeEvent(Crafty.s('Keyboard'), "keydown", Crafty.s('Keyboard').processEvent);
     Crafty.removeEvent(Crafty.s('Keyboard'), "keyup", Crafty.s('Keyboard').processEvent);

--- a/src/inputs/pointer.js
+++ b/src/inputs/pointer.js
@@ -11,13 +11,13 @@ Crafty.extend({
      * @param comp - Component name
      * @param clientX - x coordinate in client space, usually taken from a pointer event
      * @param clientY - y coordinate in client space, usually taken from a pointer event
-     * @returns The found entity, or undefined if no entity was found.
+     * @returns The found entity, or null if no entity was found.
      *
      * @sign public Object .findPointerEventTargetByComponent(String comp, Event e)
      * Finds closest entity with certain component at a given event.
      * @param comp - Component name
      * @param e - The pointer event, containing the target and the required properties `clientX` & `clientY`, which will be used as the query point
-     * @returns The found entity, or undefined if no entity was found.
+     * @returns The found entity, or null if no entity was found.
      *
      * This method is used internally by the .mouseDispatch and .touchDispatch methods, but can be used otherwise for
      * Canvas entities.
@@ -31,7 +31,7 @@ Crafty.extend({
         y = typeof y !== 'undefined' ? y : x.clientY;
         x = typeof x.clientX !== 'undefined' ? x.clientX : x;
 
-        var closest, current, q, l, i, pos, maxz = -Infinity;
+        var closest = null, current, q, l, i, pos, maxz = -Infinity;
 
         //if it's a DOM element with component we are done
         if (tar.nodeName !== "CANVAS") {
@@ -79,13 +79,14 @@ Crafty.extend({
     },
 
     /**@
-     * #Crafty.augmentPointerEvent
+     * #Crafty.translatePointerEventCoordinates
      * @category Input
      * @kind Method
      *
-     * @sign public Object .augmentPointerEvent(PointerEvent e)
+     * @sign public Object .translatePointerEventCoordinates(PointerEvent e[, PointerEvent out])
      * @param e - Any pointer event with `clientX` and `clientY` properties, usually a `MouseEvent` or `Touch` object
-     * @returns The same event object, augmented with additional `realX` and `realY` properties
+     * @param out - Optional pointer event to augment with coordinates instead
+     * @returns The pointer event, augmented with additional `realX` and `realY` properties
      *
      * Updates the passed event object to have two additional properties, `realX` and `realY`,
      * which correspond to the point in actual world space the event happened.
@@ -93,17 +94,20 @@ Crafty.extend({
      * This method is used internally by the .mouseDispatch and .touchDispatch methods,
      * but may be used for custom events.
      *
-     * @see Crafty.domHelper.translate
+     * @see Crafty.domHelper#Crafty.domHelper.translate
      */
-    augmentPointerEvent: function (e) {
+    translatePointerEventCoordinates: function (e, out) {
+        out = out || e;
+
         // Find the Crafty position in the default coordinate set,
         // disregard the fact that the pointer event was related to a specific layer.
-        var pos = Crafty.domHelper.translate(e.clientX, e.clientY);
+        var pos = Crafty.domHelper.translate(e.clientX, e.clientY, undefined, this.__pointerPos);
 
         // Set the mouse position based on standard viewport coordinates
-        e.realX = pos.x;
-        e.realY = pos.y;
-    }
+        out.realX = pos.x;
+        out.realY = pos.y;
+    },
+    __pointerPos: {x: 0, y: 0} // object to reuse
 });
 
 /**@

--- a/src/inputs/touch.js
+++ b/src/inputs/touch.js
@@ -5,42 +5,44 @@ Crafty.extend({
      * #Crafty.multitouch
      * @category Input
      * @kind Method
+     *
+     * Enables/disables support for multitouch feature.
      * @sign public this .multitouch(Boolean bool)
      * @param bool - Turns multitouch on and off.  The initial state is off (false).
      *
+     * Query whether multitouch is on or off.
      * @sign public Boolean .multitouch()
-     * @returns Whether multitouch is currently enabled;
+     * @returns Whether multitouch is currently enabled
      *
-     * Enables/disables support for multitouch feature.
+     * By default, touch events are treated as mouse events and are handled by the `MouseSystem`.
+     * To change this behaviour and handle events by the `TouchSystem`, enable multitouch.
      *
-     * If this is set to true, it is expected that your entities have the Touch component instead of Mouse component.
+     * If this is set to true, it is expected that your entities have the `Touch` component instead of the `Mouse` component.
      * If false (default), then only entities with the Mouse component will respond to touch.
+     * It's recommended to add the `Button` component instead, which requires the proper component depending on this feature.
      *
-     * If no boolean is passed to the function call, it will just return whether multitouch is on or not.
-     *
-     * @note The Touch component (and thus the multitouch feature) is currently incompatible with the Draggable component.
+     * @note The multitouch feature is currently incompatible with the `Draggable` component and `Crafty.viewport.mouselook`.
      *
      * @example
      * ~~~
      * Crafty.multitouch(true);
+     * Crafty.log("multitouch is " + Crafty.multitouch());
      *
-     * var myEntity1 = Crafty.e('2D, Canvas, Color, Touch')
-     *    .attr({x: 100, y: 100, w:200, h:200, z:1 })
+     * Crafty.e('2D, Canvas, Color, Button')
+     *    .attr({ x: 100, y: 100, w:200, h:200, z:1 })
      *    .color('black')
-     *    .bind('TouchStart',function(e){ alert('big black box was touched', e); }),
-     *  myEntity2 = Crafty.e('2D, Canvas, Color, Touch')
-     *    .attr({x: 40, y: 150, w:90, h:300, z:2 })
-     *    .color('green')
-     *    .bind('TouchStart',function(e){ alert('big GREEN box was touched', e); });
-     *
-     * Crafty.log("multitouch is "+Crafty.multitouch());
+     *    .bind('TouchStart', function(e) { this.color('green'); });
      * ~~~
      * @see TouchSystem
+     * @see MouseSystem
+     * @see Button
      * @see Touch
+     * @see Mouse
      */
     multitouch: function (bool) {
         if (typeof bool !== "boolean") return this._multitouch;
         this._multitouch = bool;
+        return this;
     },
      _multitouch: false,
 
@@ -115,188 +117,182 @@ Crafty.extend({
  * @category Input
  * @kind System
  *
- * Provides access to touch events.
+ * Provides access to touch point events.
+ * @note Additional events and methods are inherited from the `TouchState` component.
  *
- * This system dispatches touch events received by Crafty (crafty.stage.elem).
- * The touch events get dispatched to the closest entity to the source of the event (if available).
+ * @trigger TouchOver - when a finger enters an entity - TouchPointEvent
+ * @trigger TouchOut - when a finger leaves an entity - TouchPointEvent
  *
- * By default, touch events are treated as mouse events. To change this behaviour (and enable multitouch)
- * you must use Crafty.multitouch.
+ * The event callbacks are triggered with the native [`TouchEvent`](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent)
+ * received by Crafty's stage (`Crafty.stage.elem`), which is wrapped in a standard Crafty event object (see `TouchState`).
+ * Note that for each changed [`Touch` point](https://developer.mozilla.org/en-US/docs/Web/API/Touch)) a separate
+ * Crafty TouchPointEvent event is triggered.
  *
- * If using multitouch feature, this method sets the array Crafty.touchHandler.fingers, which holds data
- * of the most recent touches that occured (useful for determining positions of fingers in every frame)
- * as well as last entity touched by each finger. Data is lost as soon as the finger is raised.
+ * These touch point events are triggered on the TouchSystem itself.
+ * Additionally, they are dispatched to the closest (visible & `Touch`-enhanced) entity to the source of the event (if available).
  *
- * You can read about the MouseEvent, which is the parameter passed to the Mouse entity's callback.
- * https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent
+ * @note By default, touch events are treated as mouse events and are not triggered by this system.
+ * To change this behaviour (and enable multitouch) use `Crafty.multitouch`.
  *
- * You can also read about the TouchEvent.
- * https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent
- *
- * And about the touch point interface, which is the parameter passed to the Touch entity's callback.
- * http://www.w3.org/TR/touch-events/#dfn-active-touch-point
- *
+ * @see TouchState, Touch
  * @see Crafty.multitouch
- * @see Touch
  */
-Crafty.s("Touch", Crafty.extend.call(new Crafty.__eventDispatcher(), {
+Crafty.s("Touch", Crafty.extend.call(Crafty.extend.call(new Crafty.__eventDispatcher(), {
+    normedEventNames: {
+        "touchstart": "TouchStart",
+        "touchmove": "TouchMove",
+        "touchend": "TouchEnd",
+        "touchcancel": "TouchCancel" // touchcancel is treated as touchend, but triggers a TouchCancel event
+    },
+
+    _evt: { // evt object to reuse
+        eventName:'',
+        identifier: -1,
+        target: null,
+        entity: null, // DEPRECATED: remove this in upcoming release
+        realX: 0,
+        realY: 0,
+        originalEvent: null
+    },
+
     // Indicates how many entities have the Touch component, for performance optimization
+    // Touch events are still routed to Crafty.s('Touch') even if there are no entities with Touch component
     touchObjs: 0,
 
-    // TODO: move routing of events in future to controls system
-    // and change it so that touch events are always triggered on TouchSystem
-    dispatchEvent: function (e) {
-        if (!this.touchObjs) return;
+    // current entites that are pointed at
+    overs: {},
 
-        switch (e.type) {
-            case "touchstart":
-                this._touchHandler.handleStart(e);
-                break;
-            case "touchmove":
-                this._touchHandler.handleMove(e);
-                break;
-            case "touchleave": // touchleave is treated as touchend
-            case "touchcancel": // touchcancel is treated as touchend, but triggers a TouchCancel event
-            case "touchend":
-                this._touchHandler.handleEnd(e);
-                break;
+    prepareEvent: function (e, type) {
+        var evt = this._evt;
+
+        // Normalize event name
+        evt.eventName = this.normedEventNames[type] || type;
+
+        // copy identifier
+        evt.identifier = e.identifier;
+
+        // augment touch event with real coordinates
+        Crafty.translatePointerEventCoordinates(e, evt);
+
+        // augment touch event with target entity
+        evt.target = this.touchObjs ? Crafty.findPointerEventTargetByComponent("Touch", e) : null;
+        // DEPRECATED: remove this in upcoming release
+        evt.entity = evt.target;
+
+        return evt;
+    },
+
+    // this method will be called by TouchState iff triggerTouch event was valid
+    triggerTouchEvent: function(eventName, e) {
+        // trigger event on TouchSystem itself
+        this.trigger(eventName, e);
+
+        var identifier = e.identifier,
+            closest = e.target,
+            over = this.overs[identifier];
+
+        if (over) { // if old TouchOver target wasn't null, send TouchOut
+            if ((eventName === "TouchMove" && over !== closest) || // if TouchOver target changed
+                eventName === "TouchEnd" || eventName === "TouchCancel") { // or TouchEnd occurred
+
+                e.eventName = "TouchOut";
+                e.target = over;
+                e.entity = over; // DEPRECATED: remove this in upcoming release
+                over.trigger("TouchOut", e);
+                e.eventName = eventName;
+                e.target = closest;
+                e.entity = closest; // DEPRECATED: remove this in upcoming release
+
+                // delete old over entity
+                delete this.overs[identifier];
+            }
+        }
+
+        // TODO: move routing of events in future to controls system, make it similar to KeyboardSystem
+        // try to find closest element that will also receive touch event, whatever the event is
+        if (closest) {
+            closest.trigger(eventName, e);
+        }
+
+        if (closest) { // if new TouchOver target isn't null, send TouchOver
+            if (eventName === "TouchStart" || // if TouchStart occurred
+                (eventName === "TouchMove" && over !== closest)) { // or TouchOver target changed
+
+                e.eventName = "TouchOver";
+                closest.trigger("TouchOver", e);
+                e.eventName = eventName;
+
+                // save new over entity
+                this.overs[identifier] = closest;
+            }
         }
     },
 
-    _touchHandler: {
-        fingers: [], // keeps track of touching fingers
-
-        handleStart: function (e) {
-            var touches = e.changedTouches;
-            for (var i = 0, l = touches.length; i < l; i++) {
-                var idx = false,
-                    closest;
-                closest = this.findClosestTouchEntity(touches[i]);
-
-                if (closest) {
-                    closest.trigger("TouchStart", touches[i]);
-                    // In case the entity was already being pressed, get the finger index
-                    idx = this.fingerDownIndexByEntity(closest);
-                }
-                var touch = this.setTouch(touches[i], closest);
-                if (idx !== false && idx >= 0) {
-                    // Recycling finger...
-                    this.fingers[idx] = touch;
-                } else {
-                    this.fingers.push(touch);
-                }
-            }
-        },
-
-        handleMove: function (e) {
-            var touches = e.changedTouches;
-            for (var i = 0, l = touches.length; i < l; i++) {
-                var idx = this.fingerDownIndexById(touches[i].identifier);
-                var closest = this.findClosestTouchEntity(touches[i]);
-
-                if (idx >= 0) {
-                    var finger = this.fingers[idx];
-                    if(typeof finger.entity !== "undefined")
-                        if (finger.entity === closest) {
-                            finger.entity.trigger("TouchMove", touches[i]);
-                        } else {
-                            if (typeof closest === "object") closest.trigger("TouchStart", touches[i]);
-                            finger.entity.trigger("TouchEnd");
-                        }
-                    finger.entity = closest;
-                    finger.realX = touches[i].realX;
-                    finger.realY = touches[i].realY;
-                }
-            }
-        },
-
-        handleEnd: function (e) {
-            var touches = e.changedTouches,
-                eventName = e.type === "touchcancel" ? "TouchCancel" : "TouchEnd";
-            for (var i = 0, l = touches.length; i < l; i++) {
-                var idx = this.fingerDownIndexById(touches[i].identifier);
-
-                if (idx >= 0) {
-                    if (this.fingers[idx].entity)
-                        this.fingers[idx].entity.trigger(eventName);
-                    this.fingers.splice(idx, 1);
-                }
-            }
-        },
-
-        setTouch: function (touch, entity) {
-            return { identifier: touch.identifier, realX: touch.realX, realY: touch.realY, entity: entity };
-        },
-
-        findClosestTouchEntity: function (touchEvent) {
-            Crafty.augmentPointerEvent(touchEvent);
-            return Crafty.findPointerEventTargetByComponent("Touch", touchEvent);
-        },
-
-        fingerDownIndexById: function (idToFind) {
-            for (var i = 0, l = this.fingers.length; i < l; i++) {
-                var id = this.fingers[i].identifier;
-                if (id === idToFind) {
-                    return i;
-                }
-            }
-            return -1;
-        },
-
-        fingerDownIndexByEntity: function (entityToFind) {
-            for (var i = 0, l = this.fingers.length; i < l; i++) {
-                var ent = this.fingers[i].entity;
-
-                if (ent === entityToFind) {
-                    return i;
-                }
-            }
-            return -1;
+    dispatchEvent: function (e) {
+        var evt, touches = e.changedTouches;
+        for (var i = 0, l = touches.length; i < l; i++) {
+            evt = this.prepareEvent(touches[i], e.type);
+            // wrap original event into standard Crafty event object
+            evt.originalEvent = e;
+            this.triggerTouch(evt.eventName, evt);
         }
     }
-}), {}, false);
+}), Crafty.__touchStateTemplate), {}, false);
 
 /**@
  * #Touch
  * @category Input
  * @kind Component
  *
- * Provides the entity with touch related events
+ * Provides the entity with touch point events.
+ * Touch point events get dispatched to the closest (visible & `Touch`-enhanced) entity to the source of the event (if available).
  * @note If you do not add this component, touch events will not be triggered on the entity.
  *
- * @trigger TouchStart - when entity is touched - TouchPoint
- * @trigger TouchMove - when finger is moved over entity - TouchPoint
- * @trigger TouchCancel - when a touch event has been disrupted in some way - TouchPoint
- * @trigger TouchEnd - when the finger is raised over the entity, or when finger leaves entity.  (Passes no data) - null
+ * Triggers all events described in `TouchSystem` and `TouchState`, these are:
+ * @trigger TouchOver - when a finger enters the entity - TouchPointEvent
+ * @trigger TouchMove - when a finger is over the entity and moves - TouchPointEvent
+ * @trigger TouchOut - when a finger leaves the entity - TouchPointEvent
+ * @trigger TouchStart - when a finger is pressed on the entity - TouchPointEvent
+ * @trigger TouchEnd - when a finger is raised over the entity - TouchPointEvent
+ * @trigger TouchCancel - when a touch event has been disrupted in some way whilst over the entity - TouchPointEvent
  *
- * To be able to use multitouch, you must enable it with  `Crafty.multitouch(true)`.
- *
- * If you don't need multitouch, you can probably use the Mouse component instead, since by default Crafty will trigger mouse events for touch input.
- *
- * You can read more about the TouchEvent.
- * - [TouchEvent.touches and TouchEvent.changedTouches](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent)
- * - [TouchPoint](http://www.w3.org/TR/touch-events/#dfn-active-touch-point) is the parameter passed to the event callback in the related touch.
- *
- * The passed TouchPoints are augmented by properties which correspond to the coordinates of the TouchEvent in world (default viewport) space,
- * namely `TouchPoint.realX` and `TouchPoint.realY`.
+ * @note By default, touch events are treated as mouse events and are not triggered by this component.
+ * To change this behaviour (and enable multitouch) use `Crafty.multitouch`.
  *
  * @example
  * ~~~
  * Crafty.multitouch(true);
  *
- * var myEntity = Crafty.e('2D, Canvas, Color, Touch')
- * .attr({x: 10, y: 10, w: 40, h: 40})
- * .color('green')
- * .bind('TouchStart', function(TouchPoint){
- *   Crafty.log('myEntity has been touched', TouchPoint);
- * }).bind('TouchMove', function(TouchPoint) {
- *   Crafty.log('Finger moved over myEntity at the { x: ' + TouchPoint.realX + ', y: ' + TouchPoint.realY + ' } coordinates.');
- * }).bind('TouchEnd', function() {
- *   Crafty.log('Touch over myEntity has finished.');
- * });
+ * Crafty.e('2D, Canvas, Color, Touch')
+ *   .attr({x: 10, y: 10, w: 40, h: 40})
+ *   .color('green')
+ *   .bind('TouchOver', function(TouchPoint){
+ *     Crafty.log('A finger is over the entity', TouchPoint.identifier);
+ *   })
+ *   .bind('TouchMove', function(TouchPoint) {
+ *     Crafty.log('A finger moves over the entity at { x: ' + TouchPoint.realX + ', y: ' + TouchPoint.realY + ' } coordinates.');
+ *   })
+ *   .bind('TouchOut', function(TouchPoint){
+ *     Crafty.log('A finger is no longer over the entity', TouchPoint.identifier);
+ *   });
  * ~~~
+ *
+ * @example
+ * ~~~
+ * Crafty.multitouch(true);
+ *
+ * var myEntity1 = Crafty.e('2D, Canvas, Color, Touch')
+ *    .attr({x: 100, y: 100, w:200, h:200, z:1 })
+ *    .color('black')
+ *    .bind('TouchStart',function(e){ alert('big black box was touched', e); }),
+ *  myEntity2 = Crafty.e('2D, Canvas, Color, Touch')
+ *    .attr({x: 40, y: 150, w:90, h:300, z:2 })
+ *    .color('green')
+ *    .bind('TouchStart',function(e){ alert('big green box was touched', e); });
+ * ~~~
+ *
+ * @see TouchState, TouchSystem
  * @see Crafty.multitouch
- * @see TouchSystem
  */
 Crafty.c("Touch", {
     required: "AreaMap",

--- a/tests/unit/controls/controls.js
+++ b/tests/unit/controls/controls.js
@@ -276,6 +276,362 @@
     originalEventA = lastMouseEventA.originalEvent;
   });
 
+  test("TouchState", function(_) {
+    var finger0Starts = 0, finger0Moves = 0, finger0Ends = 0, finger0Cancels = 0,
+        finger1Starts = 0, finger1Moves = 0, finger1Ends = 0, finger1Cancels = 0;
+    var e = Crafty.e("TouchState")
+        .bind('TouchStart', function(evt) {
+            if (evt.identifier === 0) finger0Starts++;
+            else if (evt.identifier === 1) finger1Starts++;
+            else _.ok(false, "Unexpected touch identifier event received.");
+        })
+        .bind('TouchMove', function(evt) {
+            if (evt.identifier === 0) finger0Moves++;
+            else if (evt.identifier === 1) finger1Moves++;
+            else _.ok(false, "Unexpected touch identifier event received.");
+        })
+        .bind('TouchEnd', function(evt) {
+            if (evt.identifier === 0) finger0Ends++;
+            else if (evt.identifier === 1) finger1Ends++;
+            else _.ok(false, "Unexpected touch identifier event received.");
+        })
+        .bind('TouchCancel', function(evt) {
+            if (evt.identifier === 0) finger0Cancels++;
+            else if (evt.identifier === 1) finger1Cancels++;
+            else _.ok(false, "Unexpected touch identifier event received.");
+        });
+
+    // check that TouchState doesn't cause conflicts between entities
+    Crafty.e("TouchState")
+        .bind('TouchStart', function(evt) {
+            _.ok(false, "Unexpected touch identifier event received.");
+        })
+        .bind('TouchMove', function(evt) {
+            _.ok(false, "Unexpected touch identifier event received.");
+        })
+        .bind('TouchEnd', function(evt) {
+            _.ok(false, "Unexpected touch identifier event received.");
+        })
+        .bind('TouchCancel', function(evt) {
+            _.ok(false, "Unexpected touch identifier event received.");
+        });
+
+    // initial
+    _.strictEqual(e.touchPoints.length, 0, "no current touch points");
+    _.strictEqual(e._touchPointsPool.length, 0, "no current reusable touch points");
+    _.strictEqual(finger0Starts, 0);
+    _.strictEqual(finger0Moves, 0);
+    _.strictEqual(finger0Ends, 0);
+    _.strictEqual(finger0Cancels, 0);
+    _.strictEqual(finger1Starts, 0);
+    _.strictEqual(finger1Moves, 0);
+    _.strictEqual(finger1Ends, 0);
+    _.strictEqual(finger1Cancels, 0);
+
+    // after e receives invalid TouchMove for finger 0
+    e.triggerTouch("TouchMove", { eventName: "TouchMove", identifier: 0 });
+    _.strictEqual(e.touchPoints.length, 0, "no current touch points");
+    _.strictEqual(e._touchPointsPool.length, 0, "no current reusable touch points");
+    _.strictEqual(finger0Starts, 0);
+    _.strictEqual(finger0Moves, 0);
+    _.strictEqual(finger0Ends, 0);
+    _.strictEqual(finger0Cancels, 0);
+    _.strictEqual(finger1Starts, 0);
+    _.strictEqual(finger1Moves, 0);
+    _.strictEqual(finger1Ends, 0);
+    _.strictEqual(finger1Cancels, 0);
+
+    // after e receives valid TouchStart for finger 0
+    e.triggerTouch("TouchStart", { eventName: "TouchStart", identifier: 0 });
+    _.strictEqual(e.touchPoints.length, 1);
+    _.strictEqual(e.touchPoints[0].identifier, 0);
+    _.strictEqual(e.touchPoints[0].eventName, "TouchStart");
+    _.strictEqual(e._touchPointsPool.length, 0);
+    _.strictEqual(finger0Starts, 1);
+    _.strictEqual(finger0Moves, 0);
+    _.strictEqual(finger0Ends, 0);
+    _.strictEqual(finger0Cancels, 0);
+    _.strictEqual(finger1Starts, 0);
+    _.strictEqual(finger1Moves, 0);
+    _.strictEqual(finger1Ends, 0);
+    _.strictEqual(finger1Cancels, 0);
+
+    // after e receives invalid TouchStart for finger 0
+    e.triggerTouch("TouchStart", { eventName: "TouchStart", identifier: 0 });
+    _.strictEqual(e.touchPoints.length, 1);
+    _.strictEqual(e.touchPoints[0].identifier, 0);
+    _.strictEqual(e.touchPoints[0].eventName, "TouchStart");
+    _.strictEqual(e._touchPointsPool.length, 0);
+    _.strictEqual(finger0Starts, 1);
+    _.strictEqual(finger0Moves, 0);
+    _.strictEqual(finger0Ends, 0);
+    _.strictEqual(finger0Cancels, 0);
+    _.strictEqual(finger1Starts, 0);
+    _.strictEqual(finger1Moves, 0);
+    _.strictEqual(finger1Ends, 0);
+    _.strictEqual(finger1Cancels, 0);
+
+    // after e receives valid TouchStart for finger 1
+    e.triggerTouch("TouchStart", { eventName: "TouchStart", identifier: 1 });
+    _.strictEqual(e.touchPoints.length, 2);
+    _.strictEqual(e.touchPoints[0].identifier, 0);
+    _.strictEqual(e.touchPoints[0].eventName, "TouchStart");
+    _.strictEqual(e.touchPoints[1].identifier, 1);
+    _.strictEqual(e.touchPoints[1].eventName, "TouchStart");
+    _.strictEqual(e._touchPointsPool.length, 0);
+    _.strictEqual(finger0Starts, 1);
+    _.strictEqual(finger0Moves, 0);
+    _.strictEqual(finger0Ends, 0);
+    _.strictEqual(finger0Cancels, 0);
+    _.strictEqual(finger1Starts, 1);
+    _.strictEqual(finger1Moves, 0);
+    _.strictEqual(finger1Ends, 0);
+    _.strictEqual(finger1Cancels, 0);
+
+    // after e receives invalid TouchEnd for unrelated finger
+    e.triggerTouch("TouchEnd", { eventName: "TouchEnd", identifier: -1 });
+    _.strictEqual(e.touchPoints.length, 2);
+    _.strictEqual(e.touchPoints[0].identifier, 0);
+    _.strictEqual(e.touchPoints[0].eventName, "TouchStart");
+    _.strictEqual(e.touchPoints[1].identifier, 1);
+    _.strictEqual(e.touchPoints[1].eventName, "TouchStart");
+    _.strictEqual(e._touchPointsPool.length, 0);
+    _.strictEqual(finger0Starts, 1);
+    _.strictEqual(finger0Moves, 0);
+    _.strictEqual(finger0Ends, 0);
+    _.strictEqual(finger0Cancels, 0);
+    _.strictEqual(finger1Starts, 1);
+    _.strictEqual(finger1Moves, 0);
+    _.strictEqual(finger1Ends, 0);
+    _.strictEqual(finger1Cancels, 0);
+
+    // after e receives valid TouchMove for finger 0
+    e.triggerTouch("TouchMove", { eventName: "TouchMove", identifier: 0 });
+    _.strictEqual(e.touchPoints.length, 2);
+    _.strictEqual(e.touchPoints[0].identifier, 0);
+    _.strictEqual(e.touchPoints[0].eventName, "TouchMove");
+    _.strictEqual(e.touchPoints[1].identifier, 1);
+    _.strictEqual(e.touchPoints[1].eventName, "TouchStart");
+    _.strictEqual(e._touchPointsPool.length, 0);
+    _.strictEqual(finger0Starts, 1);
+    _.strictEqual(finger0Moves, 1);
+    _.strictEqual(finger0Ends, 0);
+    _.strictEqual(finger0Cancels, 0);
+    _.strictEqual(finger1Starts, 1);
+    _.strictEqual(finger1Moves, 0);
+    _.strictEqual(finger1Ends, 0);
+    _.strictEqual(finger1Cancels, 0);
+
+    // after e receives valid TouchMove for finger 1
+    e.triggerTouch("TouchMove", { eventName: "TouchMove", identifier: 1 });
+    _.strictEqual(e.touchPoints.length, 2);
+    _.strictEqual(e.touchPoints[0].identifier, 0);
+    _.strictEqual(e.touchPoints[0].eventName, "TouchMove");
+    _.strictEqual(e.touchPoints[1].identifier, 1);
+    _.strictEqual(e.touchPoints[1].eventName, "TouchMove");
+    _.strictEqual(e._touchPointsPool.length, 0);
+    _.strictEqual(finger0Starts, 1);
+    _.strictEqual(finger0Moves, 1);
+    _.strictEqual(finger0Ends, 0);
+    _.strictEqual(finger0Cancels, 0);
+    _.strictEqual(finger1Starts, 1);
+    _.strictEqual(finger1Moves, 1);
+    _.strictEqual(finger1Ends, 0);
+    _.strictEqual(finger1Cancels, 0);
+
+    // after e receives valid TouchEnd for finger 1
+    e.triggerTouch("TouchEnd", { eventName: "TouchEnd", identifier: 1 });
+    _.strictEqual(e.touchPoints.length, 1);
+    _.strictEqual(e.touchPoints[0].identifier, 0);
+    _.strictEqual(e.touchPoints[0].eventName, "TouchMove");
+    _.strictEqual(e._touchPointsPool.length, 1);
+    _.strictEqual(e._touchPointsPool[0].identifier, 1);
+    _.strictEqual(e._touchPointsPool[0].eventName, "TouchEnd");
+    _.strictEqual(finger0Starts, 1);
+    _.strictEqual(finger0Moves, 1);
+    _.strictEqual(finger0Ends, 0);
+    _.strictEqual(finger0Cancels, 0);
+    _.strictEqual(finger1Starts, 1);
+    _.strictEqual(finger1Moves, 1);
+    _.strictEqual(finger1Ends, 1);
+    _.strictEqual(finger1Cancels, 0);
+
+    // after e receives valid TouchCancel for finger 0
+    e.triggerTouch("TouchCancel", { eventName: "TouchCancel", identifier: 0 });
+    _.strictEqual(e.touchPoints.length, 0);
+    _.strictEqual(e._touchPointsPool.length, 2);
+    _.strictEqual(e._touchPointsPool[0].identifier, 1);
+    _.strictEqual(e._touchPointsPool[0].eventName, "TouchEnd");
+    _.strictEqual(e._touchPointsPool[1].identifier, 0);
+    _.strictEqual(e._touchPointsPool[1].eventName, "TouchCancel");
+    _.strictEqual(finger0Starts, 1);
+    _.strictEqual(finger0Moves, 1);
+    _.strictEqual(finger0Ends, 0);
+    _.strictEqual(finger0Cancels, 1);
+    _.strictEqual(finger1Starts, 1);
+    _.strictEqual(finger1Moves, 1);
+    _.strictEqual(finger1Ends, 1);
+    _.strictEqual(finger1Cancels, 0);
+
+    // check that e reuses touchPool
+    e.triggerTouch("TouchStart", { eventName: "TouchStart", identifier: 1 });
+    e.triggerTouch("TouchStart", { eventName: "TouchStart", identifier: 0 });
+    _.strictEqual(e.touchPoints.length, 2);
+    _.strictEqual(e.touchPoints[0].identifier, 1);
+    _.strictEqual(e.touchPoints[0].eventName, "TouchStart");
+    _.strictEqual(e.touchPoints[1].identifier, 0);
+    _.strictEqual(e.touchPoints[1].eventName, "TouchStart");
+    _.strictEqual(e._touchPointsPool.length, 0);
+    _.strictEqual(finger0Starts, 2);
+    _.strictEqual(finger0Moves, 1);
+    _.strictEqual(finger0Ends, 0);
+    _.strictEqual(finger0Cancels, 1);
+    _.strictEqual(finger1Starts, 2);
+    _.strictEqual(finger1Moves, 1);
+    _.strictEqual(finger1Ends, 1);
+    _.strictEqual(finger1Cancels, 0);
+
+    // check that resetTouchPoints fires TouchCancel events in reverse chronological order
+    e.resetTouchPoints();
+    _.strictEqual(e.touchPoints.length, 0);
+    _.strictEqual(e._touchPointsPool.length, 2);
+    _.strictEqual(e._touchPointsPool[0].identifier, 0);
+    _.strictEqual(e._touchPointsPool[0].eventName, "TouchCancel");
+    _.strictEqual(e._touchPointsPool[1].identifier, 1);
+    _.strictEqual(e._touchPointsPool[1].eventName, "TouchCancel");
+    _.strictEqual(finger0Starts, 2);
+    _.strictEqual(finger0Moves, 1);
+    _.strictEqual(finger0Ends, 0);
+    _.strictEqual(finger0Cancels, 2);
+    _.strictEqual(finger1Starts, 2);
+    _.strictEqual(finger1Moves, 1);
+    _.strictEqual(finger1Ends, 1);
+    _.strictEqual(finger1Cancels, 1);
+  });
+
+  test("TouchState - touchPoints", function(_) {
+    var e = Crafty.e("TouchState"),
+        touchPointA, touchPointB,
+        originalEventA, originalEventB;
+
+    // initial state
+    touchPointA = e.touchPoints[0];
+    originalEventA = touchPointA && touchPointA.originalEvent;
+    _.strictEqual(touchPointA, undefined, "no initial touchPoint");
+    _.strictEqual(originalEventA, undefined, "no initial originalEvent");
+
+   // after e receives valid TouchStart, touchPoint persisted
+    e.triggerTouch("TouchStart", {
+      eventName: "TouchStart",
+      identifier: -3,
+      target: 'a',
+      entity: 'a', // DEPRECATED: remove in upcoming release
+      realX: 1, realY: 2,
+      originalEvent: { prop1: true }
+    });
+    touchPointB = e.touchPoints[0];
+    originalEventB = touchPointB.originalEvent;
+    _.strictEqual(e.touchPoints.length, 1, "One touchPoint exists");
+    _.ok(touchPointB, "new touchPoint created");
+    _.ok(originalEventB, "new originalEvent created");
+    _.strictEqual(touchPointB.originalEvent.prop1, true);
+    _.strictEqual(touchPointB.eventName, "TouchStart");
+    _.strictEqual(touchPointB.identifier, -3);
+    _.strictEqual(touchPointB.target, 'a');
+    _.strictEqual(touchPointB.entity, 'a');
+    _.strictEqual(touchPointB.realX, 1);
+    _.strictEqual(touchPointB.realY, 2);
+    touchPointA = touchPointB;
+    originalEventA = touchPointA.originalEvent;
+
+    // after e receives invalid TouchStart, touchPoint shouldn't change
+    e.triggerTouch("TouchStart", {
+      eventName: "TouchStart",
+      identifier: -3,
+      target: 'b',
+      entity: 'b', // DEPRECATED: remove in upcoming release
+      realX: 3, realY: 4,
+      originalEvent: { prop2: true }
+    });
+    touchPointB = e.touchPoints[0];
+    originalEventB = touchPointB.originalEvent;
+    _.strictEqual(e.touchPoints.length, 1, "One touchPoint exists");
+    _.strictEqual(touchPointB, touchPointA, "touchPoint objects are reused");
+    _.deepEqual(touchPointB, touchPointA, "touchPoint objects have same content");
+    touchPointA = touchPointB;
+    originalEventA = touchPointA.originalEvent;
+
+    // after e receives valid TouchMove, touchPoint should change
+    e.triggerTouch("TouchMove", {
+      eventName: "TouchMove",
+      identifier: -3,
+      target: 'c',
+      entity: 'c', // DEPRECATED: remove in upcoming release
+      realX: 5, realY: 6,
+      originalEvent: { prop3: true }
+    });
+    touchPointB = e.touchPoints[0];
+    originalEventB = touchPointB.originalEvent;
+    _.strictEqual(e.touchPoints.length, 1, "One touchPoint exists");
+    _.strictEqual(touchPointB, touchPointA, "touchPoint objects are reused");
+    _.strictEqual(touchPointB.originalEvent, touchPointA.originalEvent, "originalEvent is not a clone, but merely a reference");
+    _.notEqual(originalEventB, originalEventA, "originalEvent reference changed");
+    _.strictEqual(touchPointB.originalEvent.prop3, true);
+    _.strictEqual(touchPointB.eventName, "TouchMove");
+    _.strictEqual(touchPointB.identifier, -3);
+    _.strictEqual(touchPointB.target, 'c');
+    _.strictEqual(touchPointB.entity, 'c');
+    _.strictEqual(touchPointB.realX, 5);
+    _.strictEqual(touchPointB.realY, 6);
+    touchPointA = touchPointB;
+    originalEventA = touchPointA.originalEvent;
+
+    // after e receives valid TouchStart for another finger, first touchPoint should not change
+    e.triggerTouch("TouchStart", {
+      eventName: "TouchStart",
+      identifier: 11,
+      target: 'd',
+      entity: 'd', // DEPRECATED: remove in upcoming release
+      realX: 7, realY: 8,
+      originalEvent: { prop4: true }
+    });
+    touchPointB = e.touchPoints[0];
+    originalEventB = touchPointB.originalEvent;
+
+    _.strictEqual(e.touchPoints.length, 2, "Two touchPoints exist");
+    _.strictEqual(touchPointB, touchPointA, "touchPoint objects for first finger are reused");
+    _.deepEqual(touchPointB, touchPointA, "touchPoint objects for first finger have same content");
+
+    var otherTouchPoint = e.touchPoints[1];
+    _.ok(otherTouchPoint, "new touchPoint created for second finger");
+    _.notEqual(otherTouchPoint, touchPointB,  "different touchPoint objects for different fingers");
+    _.ok(otherTouchPoint.originalEvent, "new originalEvent created for second finger");
+    _.notEqual(otherTouchPoint.originalEvent, touchPointB.originalEvent, "originalEvent of second finger has nothing to do with originalEvent of first finger");
+    _.strictEqual(otherTouchPoint.originalEvent.prop4, true);
+    _.strictEqual(otherTouchPoint.eventName, "TouchStart");
+    _.strictEqual(otherTouchPoint.identifier, 11);
+    _.strictEqual(otherTouchPoint.target, 'd');
+    _.strictEqual(otherTouchPoint.entity, 'd');
+    _.strictEqual(otherTouchPoint.realX, 7);
+    _.strictEqual(otherTouchPoint.realY, 8);
+
+    touchPointA = touchPointB;
+    originalEventA = touchPointA.originalEvent;
+
+    // after e receives valid TouchEnd, touchPoint for first finger should be removed
+    e.triggerTouch("TouchEnd", {
+      eventName: "TouchEnd",
+      identifier: -3,
+      target: 'e',
+      entity: 'e', // DEPRECATED: remove in upcoming release
+      realX: 9, realY: 0,
+      originalEvent: { prop5: true }
+    });
+    _.strictEqual(e.touchPoints.length, 1, "One touchPoints exists");
+    _.strictEqual(e.touchPoints[0], otherTouchPoint, "touchPoint objects for second finger are reused");
+    _.deepEqual(e.touchPoints[0], otherTouchPoint, "touchPoint objects for second finger have same content");
+  });
+
   test("Multiway and Fourway", function(_) {
     var e = Crafty.e("2D, Fourway")
                   .attr({ x: 0, y: 0});

--- a/tests/unit/controls/controls.js
+++ b/tests/unit/controls/controls.js
@@ -257,8 +257,9 @@
     e.triggerMouse("MouseDown", {
       eventName: "MouseDown",
       mouseButton: Crafty.mouseButtons.LEFT,
+      target: 'a',
       realX: 1, realY: 2,
-      clientX: 3, clientY: 4,
+      clientX: 3, clientY: 4, // DEPRECATED: remove in upcoming release
       originalEvent: { prop1: true }
     });
     lastMouseEventB = e.lastMouseEvent;
@@ -269,6 +270,7 @@
     _.strictEqual(lastMouseEventB.originalEvent.prop1, true);
     _.strictEqual(lastMouseEventB.eventName, "MouseDown");
     _.strictEqual(lastMouseEventB.mouseButton, Crafty.mouseButtons.LEFT);
+    _.strictEqual(lastMouseEventB.target, 'a');
     _.strictEqual(lastMouseEventB.realX, 1);
     _.strictEqual(lastMouseEventB.realY, 2);
     _.strictEqual(lastMouseEventB.clientX, 3);
@@ -280,8 +282,9 @@
     e.triggerMouse("MouseDown", {
       eventName: "MouseDown",
       mouseButton: Crafty.mouseButtons.LEFT,
+      target: 'b',
       realX: 5, realY: 6,
-      clientX: 7, clientY: 8,
+      clientX: 7, clientY: 8, // DEPRECATED: remove in upcoming release
       originalEvent: { prop2: true }
     });
     lastMouseEventB = e.lastMouseEvent;
@@ -295,8 +298,9 @@
     e.triggerMouse("MouseUp", {
       eventName: "MouseUp",
       mouseButton: Crafty.mouseButtons.LEFT,
+      target: 'c',
       realX: 9, realY: 0,
-      clientX: -1, clientY: -2,
+      clientX: -1, clientY: -2, // DEPRECATED: remove in upcoming release
       originalEvent: { prop3: true }
     });
     lastMouseEventB = e.lastMouseEvent;
@@ -307,6 +311,7 @@
     _.strictEqual(lastMouseEventB.originalEvent.prop3, true);
     _.strictEqual(lastMouseEventB.eventName, "MouseUp");
     _.strictEqual(lastMouseEventB.mouseButton, Crafty.mouseButtons.LEFT);
+    _.strictEqual(lastMouseEventB.target, 'c');
     _.strictEqual(lastMouseEventB.realX, 9);
     _.strictEqual(lastMouseEventB.realY, 0);
     _.strictEqual(lastMouseEventB.clientX, -1);

--- a/tests/unit/controls/controls.js
+++ b/tests/unit/controls/controls.js
@@ -79,41 +79,19 @@
     _.strictEqual(keyDownsF, 1);
     _.strictEqual(keyUpsF, 0);
 
-    // after e receives valid KeyUp for different key, check if it messes with both
-    e.triggerKey("KeyUp", { eventName: "KeyUp", key: Crafty.keys.DOWN_ARROW });
-    _.strictEqual(e.isKeyDown(Crafty.keys.UP_ARROW), true);
+    // after e.resetKeyDown is invoked, both keys should be reset
+    e.resetKeyDown();
+    _.strictEqual(e.isKeyDown(Crafty.keys.UP_ARROW), false);
     _.strictEqual(e.isKeyDown(Crafty.keys.DOWN_ARROW), false);
     _.strictEqual(keyDownsE, 2);
-    _.strictEqual(keyUpsE, 1);
+    _.strictEqual(keyUpsE, 2);
     _.strictEqual(f.isKeyDown(Crafty.keys.UP_ARROW), true);
     _.strictEqual(e.isKeyDown(Crafty.keys.DOWN_ARROW), false);
     _.strictEqual(keyDownsF, 1);
     _.strictEqual(keyUpsF, 0);
 
-    // after f receives invalid KeyUp for different key, check if it messes with both
-    f.triggerKey("KeyUp", { eventName: "KeyUp", key: Crafty.keys.DOWN_ARROW });
-    _.strictEqual(e.isKeyDown(Crafty.keys.UP_ARROW), true);
-    _.strictEqual(e.isKeyDown(Crafty.keys.DOWN_ARROW), false);
-    _.strictEqual(keyDownsE, 2);
-    _.strictEqual(keyUpsE, 1);
-    _.strictEqual(f.isKeyDown(Crafty.keys.UP_ARROW), true);
-    _.strictEqual(e.isKeyDown(Crafty.keys.DOWN_ARROW), false);
-    _.strictEqual(keyDownsF, 1);
-    _.strictEqual(keyUpsF, 0);
-
-    // after f receives valid KeyUp, check if it messes with e
+    // after f receives valid KeyUp, check final status
     f.triggerKey("KeyUp", { eventName: "KeyUp", key: Crafty.keys.UP_ARROW });
-    _.strictEqual(e.isKeyDown(Crafty.keys.UP_ARROW), true);
-    _.strictEqual(e.isKeyDown(Crafty.keys.DOWN_ARROW), false);
-    _.strictEqual(keyDownsE, 2);
-    _.strictEqual(keyUpsE, 1);
-    _.strictEqual(f.isKeyDown(Crafty.keys.UP_ARROW), false);
-    _.strictEqual(e.isKeyDown(Crafty.keys.DOWN_ARROW), false);
-    _.strictEqual(keyDownsF, 1);
-    _.strictEqual(keyUpsF, 1);
-
-    // after e receives valid KeyUp, check final status
-    e.triggerKey("KeyUp", { eventName: "KeyUp", key: Crafty.keys.UP_ARROW });
     _.strictEqual(e.isKeyDown(Crafty.keys.UP_ARROW), false);
     _.strictEqual(e.isKeyDown(Crafty.keys.DOWN_ARROW), false);
     _.strictEqual(keyDownsE, 2);
@@ -199,41 +177,19 @@
     _.strictEqual(buttonDownsF, 1);
     _.strictEqual(buttonUpsF, 0);
 
-    // after e receives valid MouseUp for different mouseButton, check if it messes with both
-    e.triggerMouse("MouseUp", { eventName: "MouseUp", mouseButton: Crafty.mouseButtons.RIGHT });
-    _.strictEqual(e.isButtonDown(Crafty.mouseButtons.LEFT), true);
+    // after e.resetButtonDown is invoked, both buttons should be reset
+    e.resetButtonDown();
+    _.strictEqual(e.isButtonDown(Crafty.mouseButtons.LEFT), false);
     _.strictEqual(e.isButtonDown(Crafty.mouseButtons.RIGHT), false);
     _.strictEqual(buttonDownsE, 2);
-    _.strictEqual(buttonUpsE, 1);
+    _.strictEqual(buttonUpsE, 2);
     _.strictEqual(f.isButtonDown(Crafty.mouseButtons.LEFT), true);
     _.strictEqual(e.isButtonDown(Crafty.mouseButtons.RIGHT), false);
     _.strictEqual(buttonDownsF, 1);
     _.strictEqual(buttonUpsF, 0);
 
-    // after f receives invalid MouseUp for different mouseButton, check if it messes with both
-    f.triggerMouse("MouseUp", { eventName: "MouseUp", mouseButton: Crafty.mouseButtons.RIGHT });
-    _.strictEqual(e.isButtonDown(Crafty.mouseButtons.LEFT), true);
-    _.strictEqual(e.isButtonDown(Crafty.mouseButtons.RIGHT), false);
-    _.strictEqual(buttonDownsE, 2);
-    _.strictEqual(buttonUpsE, 1);
-    _.strictEqual(f.isButtonDown(Crafty.mouseButtons.LEFT), true);
-    _.strictEqual(e.isButtonDown(Crafty.mouseButtons.RIGHT), false);
-    _.strictEqual(buttonDownsF, 1);
-    _.strictEqual(buttonUpsF, 0);
-
-    // after f receives valid MouseUp, check if it messes with e
+    // after f receives valid MouseUp, check final status
     f.triggerMouse("MouseUp", { eventName: "MouseUp", mouseButton: Crafty.mouseButtons.LEFT });
-    _.strictEqual(e.isButtonDown(Crafty.mouseButtons.LEFT), true);
-    _.strictEqual(e.isButtonDown(Crafty.mouseButtons.RIGHT), false);
-    _.strictEqual(buttonDownsE, 2);
-    _.strictEqual(buttonUpsE, 1);
-    _.strictEqual(f.isButtonDown(Crafty.mouseButtons.LEFT), false);
-    _.strictEqual(e.isButtonDown(Crafty.mouseButtons.RIGHT), false);
-    _.strictEqual(buttonDownsF, 1);
-    _.strictEqual(buttonUpsF, 1);
-
-    // after e receives valid MouseUp, check final status
-    e.triggerMouse("MouseUp", { eventName: "MouseUp", mouseButton: Crafty.mouseButtons.LEFT });
     _.strictEqual(e.isButtonDown(Crafty.mouseButtons.LEFT), false);
     _.strictEqual(e.isButtonDown(Crafty.mouseButtons.RIGHT), false);
     _.strictEqual(buttonDownsE, 2);

--- a/tests/unit/inputs/inputs.js
+++ b/tests/unit/inputs/inputs.js
@@ -35,19 +35,21 @@
       var touchStartsOverEntities = 0,
           touchEndsOverEntities = 0;
       Crafty.e('2D, Renderable, DOM, Touch')
+              .setName('EntityA')
               .attr({ x: 100, y: 100, w:200, h:200, z:1 })
-              .bind('TouchStart',function(){ 
+              .bind('TouchOver',function() {
                   touchStartsOverEntities++;
               })
-              .bind('TouchEnd',function(){ 
+              .bind('TouchOut',function() {
                   touchEndsOverEntities++;
               });
       Crafty.e('2D, Renderable, DOM, Touch')
+              .setName('EntityB')
               .attr({ x: 40, y: 150, w:90, h:300, z:2 })
-              .bind('TouchStart',function(){ 
+              .bind('TouchOver',function() {
                   touchStartsOverEntities++;
               })
-              .bind('TouchEnd',function(){ 
+              .bind('TouchOut',function() {
                   touchEndsOverEntities++;
               });
       var elem = Crafty.stage.elem,
@@ -58,36 +60,177 @@
          touchEnd2 = createTouchEvent(elem, "touchend", [[200 + sx, 50 + sy, 2]]),
          touchStart2 = createTouchEvent(elem, "touchstart", [[100 + sx, 80 + sy, 4]]),
          touchEnd3 = createTouchEvent(elem, "touchend", [[150 + sx, 150 + sy, 1]]),
+         touchMove1 = createTouchEvent(elem, "touchmove", [[150 + sx, 150 + sy, 4]]),
          touchEnd4 = createTouchEvent(elem, "touchend", [[100 + sx, 80 + sy, 0]]),
+         touchMove2 = createTouchEvent(elem, "touchmove", [[100 + sx, 80 + sy, 4]]),
          touchEnd5 = createTouchEvent(elem, "touchend", [[100 + sx, 80 + sy, 4]]);
 
+      var touchPoint, touchPoints = Crafty.s('Touch').touchPoints;
+
+      /** touchStart1 **/
       touchStart1();
-    
-      _.equal(Crafty.s('Touch')._touchHandler.fingers.length, 4, "Four fingers currently touching stage");
-    
+      _.strictEqual(touchPoints.length, 4, "Four fingers currently touching stage");
+      // id 0
+      touchPoint = touchPoints[0];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 0);
+      _.strictEqual(touchPoint.realX, 100);
+      _.strictEqual(touchPoint.realY, 80);
+      _.strictEqual(touchPoint.target, null);
+      // id 1
+      touchPoint = touchPoints[1];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 1);
+      _.strictEqual(touchPoint.realX, 150);
+      _.strictEqual(touchPoint.realY, 150);
+      _.strictEqual(touchPoint.target.getName(), "EntityA");
+      // id 2
+      touchPoint = touchPoints[2];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 2);
+      _.strictEqual(touchPoint.realX, 200);
+      _.strictEqual(touchPoint.realY, 50);
+      _.strictEqual(touchPoint.target, null);
+      // id 3
+      touchPoint = touchPoints[3];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 3);
+      _.strictEqual(touchPoint.realX, 65);
+      _.strictEqual(touchPoint.realY, 275);
+      _.strictEqual(touchPoint.target.getName(), "EntityB");
+
+      /** touchEnd1 **/
       touchEnd1();
+      _.strictEqual(touchPoints.length, 3, "Three fingers currently touching stage");
+      // id 0
+      touchPoint = touchPoints[0];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 0);
+      _.strictEqual(touchPoint.realX, 100);
+      _.strictEqual(touchPoint.realY, 80);
+      _.strictEqual(touchPoint.target, null);
+      // id 1
+      touchPoint = touchPoints[1];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 1);
+      _.strictEqual(touchPoint.realX, 150);
+      _.strictEqual(touchPoint.realY, 150);
+      _.strictEqual(touchPoint.target.getName(), "EntityA");
+      // id 2
+      touchPoint = touchPoints[2];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 2);
+      _.strictEqual(touchPoint.realX, 200);
+      _.strictEqual(touchPoint.realY, 50);
+      _.strictEqual(touchPoint.target, null);
 
-      _.equal(Crafty.s('Touch')._touchHandler.fingers.length, 3, "Three fingers currently touching stage");
-    
+      /** touchEnd2 **/
       touchEnd2();
+      _.strictEqual(touchPoints.length, 2, "Two fingers currently touching stage");
+      // id 0
+      touchPoint = touchPoints[0];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 0);
+      _.strictEqual(touchPoint.realX, 100);
+      _.strictEqual(touchPoint.realY, 80);
+      _.strictEqual(touchPoint.target, null);
+      // id 1
+      touchPoint = touchPoints[1];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 1);
+      _.strictEqual(touchPoint.realX, 150);
+      _.strictEqual(touchPoint.realY, 150);
+      _.strictEqual(touchPoint.target.getName(), "EntityA");
+
+      /** touchStart2 **/
       touchStart2();
-      
-      _.equal(Crafty.s('Touch')._touchHandler.fingers.length, 3, "Three fingers currently touching stage");
-    
+      _.strictEqual(touchPoints.length, 3, "Three fingers currently touching stage");
+      // id 0
+      touchPoint = touchPoints[0];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 0);
+      _.strictEqual(touchPoint.realX, 100);
+      _.strictEqual(touchPoint.realY, 80);
+      _.strictEqual(touchPoint.target, null);
+      // id 1
+      touchPoint = touchPoints[1];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 1);
+      _.strictEqual(touchPoint.realX, 150);
+      _.strictEqual(touchPoint.realY, 150);
+      _.strictEqual(touchPoint.target.getName(), "EntityA");
+      // id 4
+      touchPoint = touchPoints[2];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 4);
+      _.strictEqual(touchPoint.realX, 100);
+      _.strictEqual(touchPoint.realY, 80);
+      _.strictEqual(touchPoint.target, null);
+
+      /** touchEnd3 **/
       touchEnd3();
-    
-      _.equal(Crafty.s('Touch')._touchHandler.fingers.length, 2, "Two fingers currently touching stage");
+      _.strictEqual(touchPoints.length, 2, "Two fingers currently touching stage");
+      // id 0
+      touchPoint = touchPoints[0];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 0);
+      _.strictEqual(touchPoint.realX, 100);
+      _.strictEqual(touchPoint.realY, 80);
+      _.strictEqual(touchPoint.target, null);
+      // id 4
+      touchPoint = touchPoints[1];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 4);
+      _.strictEqual(touchPoint.realX, 100);
+      _.strictEqual(touchPoint.realY, 80);
+      _.strictEqual(touchPoint.target, null);
 
+      /** touchMove1 **/
+      touchMove1();
+      _.strictEqual(touchPoints.length, 2, "Two fingers currently touching stage");
+      // id 0
+      touchPoint = touchPoints[0];
+      _.strictEqual(touchPoint.eventName, "TouchStart");
+      _.strictEqual(touchPoint.identifier, 0);
+      _.strictEqual(touchPoint.realX, 100);
+      _.strictEqual(touchPoint.realY, 80);
+      _.strictEqual(touchPoint.target, null);
+      // id 4
+      touchPoint = touchPoints[1];
+      _.strictEqual(touchPoint.eventName, "TouchMove");
+      _.strictEqual(touchPoint.identifier, 4);
+      _.strictEqual(touchPoint.realX, 150);
+      _.strictEqual(touchPoint.realY, 150);
+      _.strictEqual(touchPoint.target.getName(), "EntityA");
+
+      /** touchEnd4 **/
       touchEnd4();
-      
-      _.equal(Crafty.s('Touch')._touchHandler.fingers.length, 1, "One finger currently touching stage");
+      _.strictEqual(touchPoints.length, 1, "One finger currently touching stage");
+      // id 4
+      touchPoint = touchPoints[0];
+      _.strictEqual(touchPoint.eventName, "TouchMove");
+      _.strictEqual(touchPoint.identifier, 4);
+      _.strictEqual(touchPoint.realX, 150);
+      _.strictEqual(touchPoint.realY, 150);
+      _.strictEqual(touchPoint.target.getName(), "EntityA");
 
+      /** touchMove2 **/
+      touchMove2();
+      _.strictEqual(touchPoints.length, 1, "One finger currently touching stage");
+      // id 4
+      touchPoint = touchPoints[0];
+      _.strictEqual(touchPoint.eventName, "TouchMove");
+      _.strictEqual(touchPoint.identifier, 4);
+      _.strictEqual(touchPoint.realX, 100);
+      _.strictEqual(touchPoint.realY, 80);
+      _.strictEqual(touchPoint.target, null);
+
+      /** touchEnd5 **/
       touchEnd5();
-    
-      _.equal(Crafty.s('Touch')._touchHandler.fingers.length, 0, "No fingers currently touching stage");
+      _.strictEqual(touchPoints.length, 0, "No fingers currently touching stage");
       
-      _.equal(touchStartsOverEntities, 2, "Two entities recieved TouchStart");
-      _.equal(touchEndsOverEntities, 2, "Two entities recieved TouchEnd");
+      _.strictEqual(touchStartsOverEntities, 3, "Two entities received TouchStart, one received it twice");
+      _.strictEqual(touchEndsOverEntities, 3, "Two entities received TouchEnd, one received it twice");
     });
     
     test("stopKeyPropagation", function(_) {
@@ -108,9 +251,10 @@
         returnValue: false,
       };
 
+      var origSelected = Crafty.selected;
       Crafty.selected = true;
       Crafty.s('Keyboard').processEvent(mockEvent);
-      Crafty.selected = false;
+      Crafty.selected = origSelected;
       
       _.ok(stopPropCalled, "stopPropagation Not Called");
       _.ok(preventDefaultCalled, "preventDefault Not Called");

--- a/tests/unit/lib/mockTouchEvents.js
+++ b/tests/unit/lib/mockTouchEvents.js
@@ -74,7 +74,7 @@ function createTouchList(target, list) {
         list = [list];
     }
     list = list.map(function (entry, index) {
-        var x = entry[0], y = entry[1], id = entry[2] ? entry[2] : index + 1;
+        var x = entry[0], y = entry[1], id = entry[2] || index;
         return createTouch(x, y, target, id);
     });
     return document.createTouchList.apply(document, list);
@@ -83,7 +83,7 @@ function createTouchList(target, list) {
 function createTouch(x, y, target, id) {
     return document.createTouch(window, target,
         //identifier
-        id || 1,
+        id || 0,
         //pageX / clientX
         x,
         //pageY / clientY


### PR DESCRIPTION
# Follow-up of #1121 

* Change `MouseWheel` and `Mouse` events to wrap original events in a standard Crafty event object (similar to what KeyboardDispatch does). Additional reason: _"Some browsers (mobile Safari, for one) re-use touch objects between events, so it's best to copy the bits you care about, rather than referencing the entire object."_ ([source](https://developer.mozilla.org/en/docs/Web/API/Touch_events#Copying_a_touch_object))
* Add `target` property to these events, which is a reference to closest entity to pointer event, otherwise `null`
* Convert TouchSystem into a first-class EventDispatcher: Split state handling (TouchState) from DOM event data normalization and dispatch (TouchSystem)
* Fixes Draggable and Crafty.viewport.mouselook to work again together. Also fixes #1013 .
* Updates the documentation.
* **Breaking change:** 
  * TouchStart and TouchEnd are no longer triggered
when a finger enters or leaves entity. They are now triggered only
once, when a finger is pressed or raised on the touch surface, no
matter which entity was targeted.
  * TouchOver and TouchOut replace those events, which are triggered
when a finger enters or leaves the entity.

# About input events
Input events can be organized into two categories:
* Global-context events
  * MouseDown, MouseMove, MouseUp
  * TouchStart, TouchMove, TouchEnd, TouchCancel
  * MouseWheelScroll
  * KeyDown, KeyUp
* Entity-specific events
  * Click, DoubleClick, MouseOver, MouseOut
  * TouchOver, TouchOut

If the input events get triggered globally in future, it wouldn't make much sense to trigger entity-specific events globally, too. For example, a Click is specific to an entity - MouseDown and MouseUp must occur while mouse pointer is over the entity. They should in my opinion either be removed or continue to be triggered on individual entities (probably latter option is better for users?).

One way to handle this would be to make entity-specific input events optional:
* There could be e.g. a `Crafty.setting` which would opt-in / opt-out from triggering any events on individual entities.
* Another option would be to trigger global-context events globally, but also trigger entity-specific events on individual entities. If there are no `Mouse` entities (`mouseObjs === 0`) or `Touch` entities (`touchObjs === 0`), then there is no need to generate or trigger any entity-specific events. (I vote for this option)
* Third option is to leave it as it is now: global-context events get triggered on the MouseSystem / TouchSystem / KeyboardSystem. These also get triggered on the target entity if it exists. Entity-specific events get triggered on the appropriate target entity.

If entity-specific events become optional or get removed, that would allow for additional performance optimization. The current `target` property, which is computed on every pointer event, could be made a lazy getter. Global-context events are handled by MouseState and TouchState and are `target`-agnostic. Entity-specific events are generated by MouseSystem and TouchSystem (mostly in response to global-context events) and need to examine the target entity of the pointer event. Therefore the call to the computation-heavy `findPointerEventTargetByComponent` could be avoided in many cases.

# Keep TouchCancel?

The `TouchCancel` event is fired _"when a touch event has been disrupted in some way"_, e.g. if a popup occurs or (for the moment) when Crafty looses focus it is triggered by `resetTouchDown`.  
The event cause is different, but internally it is handled exactly the same as the `TouchEnd` event, that occurs _"when a finger has been raised from the touch surface"_.  
Should `TouchCancel` be removed and should just `TouchEnd` be called? Or is there a conceivable use-case where a game dev would like to know the difference?

------

Still need to fix some tests and add some test cases, but opened this PR for discussion about the general direction and implementation.