### PR TITLE
Fix dpad rounding errors

### DIFF
--- a/src/controls/controls-system.js
+++ b/src/controls/controls-system.js
@@ -282,23 +282,31 @@ Crafty.s("Controls", {
 
     // dpad definition is a map of directions to keys array and active flag
     updateActiveDirection: function (dpad, normalize) {
-        dpad.x = 0;
-        dpad.y = 0;
+        var x = 0, y = 0;
+
+        // Sum up all active directions
         for (var d in dpad.directions) {
             var dir = dpad.directions[d];
             if (!dir.active) continue;
-            dpad.x += dir.n.x;
-            dpad.y += dir.n.y;
+            x += dir.n.x;
+            y += dir.n.y;
         }
+
+        // Mitigate rounding errors when close to zero movement
+        x = (-1e-10 < x && x < 1e-10) ? 0 : x;
+        y = (-1e-10 < y && y < 1e-10) ? 0 : y;
 
         // Normalize
         if (normalize) {
-            var m = Math.sqrt(dpad.x * dpad.x + dpad.y * dpad.y);
+            var m = Math.sqrt(x * x + y * y);
             if (m > 0) {
-                dpad.x = dpad.x / m;
-                dpad.y = dpad.y / m;
+                x /= m;
+                y /= m;
             }
         }
+
+        dpad.x = x;
+        dpad.y = y;
     },
 
     updateTriggerInput: function (trigger) {

--- a/tests/unit/controls/controls.js
+++ b/tests/unit/controls/controls.js
@@ -498,6 +498,12 @@
     Crafty.timer.simulateFrames(1);
     _.strictEqual(e._vx, 0, "vx = 0 when NUMPAD_8 & NUMPAD_2 pressed");
     _.strictEqual(e._vy, 0, "vy = 0 when NUMPAD_8 & NUMPAD_2 pressed");
+    // pressing two more keys of opposite diagonal directions still cancels out all movement
+    keysDown(Crafty.keys.NUMPAD_7, Crafty.keys.NUMPAD_3);
+    Crafty.timer.simulateFrames(1);
+    _.strictEqual(e._vx, 0, "vx = 0 when NUMPAD_8 & NUMPAD_2 & NUMPAD_7 & NUMPAD_3 pressed");
+    _.strictEqual(e._vy, 0, "vy = 0 when NUMPAD_8 & NUMPAD_2 & NUMPAD_7 & NUMPAD_3 pressed");
+    keysUp(Crafty.keys.NUMPAD_7, Crafty.keys.NUMPAD_3);
     keysUp(Crafty.keys.NUMPAD_2, Crafty.keys.NUMPAD_8);
 
     // pressing 2 diagonal keys in one direction does not cancel out 1 vertical key in opposite direction


### PR DESCRIPTION
Fix dpad rounding errors when sum of vectors is close to zero.
This prevents movement at still state and prevents normalization
to convert a should-be zero vector to a unit vector.

Fixes part of #1128 .