### PR TITLE
Refactor common layer code

### DIFF
--- a/src/graphics/canvas-layer.js
+++ b/src/graphics/canvas-layer.js
@@ -93,9 +93,21 @@ Crafty._registerLayerTemplate("Canvas", {
      */
      _canvas: null,
 
+    events: {
+        // Respond to init & remove events
+        "LayerInit": "layerInit",
+        "LayerRemove": "layerRemove",
+        // Bind scene rendering (see drawing.js)
+        "RenderScene": "_render",
+        // Listen for pixelart changes
+        "PixelartSet": "_setPixelart",
+        // Handle viewport modifications
+        "ViewportResize": "_resize"
+    },
+
     // When the system is first created, create the necessary canvas element and initial state
     // Bind to the necessary events
-    init: function () {
+    layerInit: function () {
         //check if canvas is supported
         if (!Crafty.support.canvas) {
             Crafty.trigger("NoCanvas");
@@ -133,7 +145,7 @@ Crafty._registerLayerTemplate("Canvas", {
     },
 
     // When the system is destroyed, remove related resources
-    remove: function() {
+    layerRemove: function() {
         this._canvas.parentNode.removeChild(this._canvas);
     },
 

--- a/src/graphics/dom-layer.js
+++ b/src/graphics/dom-layer.js
@@ -24,7 +24,20 @@ Crafty._registerLayerTemplate("DOM", {
      */
     _div: null,
 
-    init: function () {
+    events: {
+        // Respond to init & remove events
+        "LayerInit": "layerInit",
+        "LayerRemove": "layerRemove",
+        // Bind scene rendering (see drawing.js)
+        "RenderScene": "_render",
+        // Listen for pixelart changes
+        "PixelartSet": "_setPixelart"
+        // Layers should generally listen for resize events,
+        // but the DOM layers automatically inherit the stage's dimensions
+        //"ViewportResize": "_resize"
+    },
+
+    layerInit: function () {
         // Avoid shared state between systems
         this._changedObjs = [];
 
@@ -38,13 +51,8 @@ Crafty._registerLayerTemplate("DOM", {
     },
 
     // Cleanup the DOM when the layer is destroyed
-    remove: function() {
+    layerRemove: function() {
         this._div.parentNode.removeChild(this._div);
-    },
-
-    // Layers should generally listen for resize events,
-    // but the DOM layers automatically inherit the stage's dimensions
-    _resize: function() {
     },
 
     // Handle whether images should be smoothed or not

--- a/src/graphics/webgl-layer.js
+++ b/src/graphics/webgl-layer.js
@@ -256,7 +256,19 @@ Crafty._registerLayerTemplate("WebGL", {
         return this.texture_manager.makeTexture(url, image, repeating);
     },
 
-    init: function() {
+    events: {
+        // Respond to init & remove events
+        "LayerInit": "layerInit",
+        "LayerRemove": "layerRemove",
+        // Bind scene rendering (see drawing.js)
+        "RenderScene": "_render",
+        // Listen for pixelart changes
+        "PixelartSet": "_setPixelart",
+        // Handle viewport modifications
+        "ViewportResize": "_resize"
+    },
+
+    layerInit: function() {
 
         //check if we support webgl is supported
         if (!Crafty.support.webgl) {
@@ -311,7 +323,7 @@ Crafty._registerLayerTemplate("WebGL", {
     },
 
     // Cleanup the DOM when the system is destroyed
-    remove: function() {
+    layerRemove: function() {
         this._canvas.parentNode.removeChild(this._canvas);
     },
 


### PR DESCRIPTION
**Note:** currently not working, see #1126 

Let individual layers define optional event callbacks in the events block.
Trigger "LayerInit" and "LayerRemove" in the common layer's template init and remove method respectively.