### PR TITLE
Setup event callbacks before init

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -323,10 +323,6 @@ Crafty.fn = Crafty.prototype = {
                     Object.defineProperty(this, propertyName, props[propertyName]);
                 }
             }
-            // Call constructor function
-            if (comp && "init" in comp) {
-                comp.init.call(this);
-            }
             // Bind events
             if (comp && "events" in comp){
                 var auto = comp.events;
@@ -334,6 +330,10 @@ Crafty.fn = Crafty.prototype = {
                     var fn = typeof auto[eventName] === "function" ? auto[eventName] : comp[auto[eventName]];
                     this.bind(eventName, fn);
                 }
+            }
+            // Call constructor function
+            if (comp && "init" in comp) {
+                comp.init.call(this);
             }
         }
 

--- a/src/core/systems.js
+++ b/src/core/systems.js
@@ -115,11 +115,6 @@ Crafty.CraftySystem = (function() {
                 Object.defineProperty(this, propertyName, props[propertyName]);
             }
         }
-
-        // Run any instantiation code
-        if (typeof this.init === "function") {
-            this.init(name);
-        }
         // If an events object is provided, bind the listed event handlers
         if ("events" in template) {
             var auto = template.events;
@@ -127,6 +122,10 @@ Crafty.CraftySystem = (function() {
                 var fn = typeof auto[eventName] === "function" ? auto[eventName] : template[auto[eventName]];
                 this.bind(eventName, fn);
             }
+        }
+        // Run any instantiation code
+        if (typeof this.init === "function") {
+            this.init(name);
         }
     };
 })();


### PR DESCRIPTION
Setup event callbacks defined in the events object before calling
the init method in component and system definition.
This allows triggering bound callbacks in the init method.

see #1126 