### PR TITLE
Cleanup no longer used controls

### DIFF
--- a/src/controls/controls-system.js
+++ b/src/controls/controls-system.js
@@ -81,8 +81,9 @@ ToggleInputGroup.prototype = {
  * @trigger TriggerInputDown - When a trigger group is activated - {name}
  * @trigger TriggerInputUp - When a trigger group is released - {name, downFor}
  * @trigger DirectionalInput - When a directional input changes - {name, x, y}
- * 
- * 
+ *
+ * @trigger ControlDefined - When a control input is defined - {type, name}
+ * @trigger ControlDestroyed - When a control input is destroyed - {type, name}
  */
 Crafty.s("Controls", {
     init: function () {
@@ -139,7 +140,7 @@ Crafty.s("Controls", {
      * #.defineTriggerGroup
      * @comp Controls
      * @kind Method
-     * 
+     *
      * @sign defineTriggerGroup(string name, obj definition)
      * @param name - a name for the trigger group
      * @param definition - an object which defines the inputs for the trigger
@@ -190,6 +191,8 @@ Crafty.s("Controls", {
             downFor: 0,
             active: false
         };
+
+        Crafty.trigger("ControlDefined", { type: "TriggerGroup", name: name });
     },
 
     /**@
@@ -208,6 +211,7 @@ Crafty.s("Controls", {
         if (this._triggers[name]) {
             this._triggers[name].input.destroy();
             delete this._triggers[name];
+            Crafty.trigger("ControlDestroyed", { type: "TriggerGroup", name: name });
         }
     },
 
@@ -283,6 +287,8 @@ Crafty.s("Controls", {
             normalize: options.normalize,
             multipleDirectionBehavior: options.multipleDirectionBehavior
         };
+
+        Crafty.trigger("ControlDefined", { type: "Dpad", name: name });
     },
 
     /**@
@@ -303,6 +309,7 @@ Crafty.s("Controls", {
                 this._dpads[name].parsedDefinition[d].input.destroy();
             }
             delete this._dpads[name];
+            Crafty.trigger("ControlDestroyed", { type: "Dpad", name: name });
         }
     },
 

--- a/src/controls/controls-system.js
+++ b/src/controls/controls-system.js
@@ -160,7 +160,8 @@ Crafty.s("Controls", {
      *   keys: [Crafty.keys.A, Crafty.keys.B]
      * });
      * ~~~
-     * 
+     *
+     * @see .destroyTriggerGroup
      * @see Crafty.mouseButtons
      * @see Crafty.keys
      * @see Controllable
@@ -182,15 +183,32 @@ Crafty.s("Controls", {
                 }
             }
         }
-        if (this._triggers[name]) {
-            this._triggers[name].input.destroy();
-        }
+        this.destroyTriggerGroup(name);
         this._triggers[name] = {
             name: name,
             input: new ToggleInputGroup(inputs),
             downFor: 0,
             active: false
         };
+    },
+
+    /**@
+     * #.destroyTriggerGroup
+     * @comp Controls
+     * @kind Method
+     *
+     * @sign destroyTriggerGroup(string name)
+     * @param name - the name of the trigger group
+     *
+     * Destroys a previously defined trigger group.
+     *
+     * @see .defineTriggerGroup
+     */
+    destroyTriggerGroup: function(name) {
+        if (this._triggers[name]) {
+            this._triggers[name].input.destroy();
+            delete this._triggers[name];
+        }
     },
 
     /**@
@@ -214,7 +232,8 @@ Crafty.s("Controls", {
      * // Define a two-direction dpad, with two keys each bound to the right and left directions
      * Crafty.s("Controls").defineDpad("MyDpad", {RIGHT_ARROW: 0, LEFT_ARROW: 180, D: 0, A: 180});
      * ~~~
-     * 
+     *
+     * @see .destroyDpad
      * @see Crafty.keys
      * @see Controllable
      * @see Multiway
@@ -251,13 +270,8 @@ Crafty.s("Controls", {
             options.multipleDirectionBehavior = "all";
         }
         // Create the fully realized dpad object
-          // Store the name/definition pair
-        if (this._dpads[name]) {
-            for (d in this._dpads[name].parsedDefinition) {
-                this._dpads[name].parsedDefinition[d].input.destroy();
-            }
-            delete this._dpads[name];
-        }
+        // Store the name/definition pair
+        this.destroyDpad(name);
         this._dpads[name] = {
             name: name,
             directions: parsedDefinition,
@@ -269,6 +283,27 @@ Crafty.s("Controls", {
             normalize: options.normalize,
             multipleDirectionBehavior: options.multipleDirectionBehavior
         };
+    },
+
+    /**@
+     * #.destroyDpad
+     * @comp Controls
+     * @kind Method
+     *
+     * @sign destroyDpad(string name)
+     * @param name - the name of the dpad input
+     *
+     * Destroys a previously defined dpad.
+     *
+     * @see .defineDpad
+     */
+    destroyDpad: function (name) {
+        if (this._dpads[name]) {
+            for (var d in this._dpads[name].parsedDefinition) {
+                this._dpads[name].parsedDefinition[d].input.destroy();
+            }
+            delete this._dpads[name];
+        }
     },
 
     // Takes an amount in degrees and converts it to an x/y object.

--- a/src/controls/controls.js
+++ b/src/controls/controls.js
@@ -191,7 +191,7 @@ Crafty.c("Controllable", {
      * @example
      * ~~~~
      * // Create a trigger bound to the `b` key
-     * Crafty.s("Controls").defineTriggerInput("BlushTrigger", {keys:['b']});
+     * Crafty.s("Controls").defineTriggerGroup("BlushTrigger", {keys:['b']});
      * // Create a blue square that turns pink when the trigger is pressed
      * Crafty.e("2D, Canvas, Color, Controllable")
      *   .attr({x:10, y:10, h:10, w:10}).color("blue")
@@ -297,6 +297,8 @@ Crafty.c("Multiway", {
 
     remove: function() {
         if (!this.disableControls) this.vx = this.vy = 0;
+        this.unlinkInput("DirectionalInput", this._dpadName);
+        Crafty.s("Controls").destroyDpad(this._dpadName);
     },
 
     events: {
@@ -441,10 +443,9 @@ Crafty.c("Jumper", {
         this.requires("Supportable, Motion, Controllable");
     },
 
-    
-
     remove: function() {
         this.unlinkInput("TriggerInputDown", this._jumpTriggerName);
+        Crafty.s("Controls").destroyTriggerGroup(this._jumpTriggerName);
     },
 
     _keydown_jumper: function (e) {


### PR DESCRIPTION
Introduce undefineTriggerGroup and undefineDpad.  
I'm not sure about the names, would e.g. destroyDpad be better?

Fixes part of #1128 .