### PR TITLE
Don't create the class when loading the dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,9 +31,10 @@ module.exports = function (grunt) {
         grunt.log.writeln("Wrote api data to " + outputFile);
     };
 
-    var apiServer = require("./build/api-gen/dynamic-server.js");
+    
     function runApiServer() {
       this.async();
+      var apiServer = require("./build/api-gen/dynamic-server.js");
       apiServer(grunt, "./build/api.json");
       setTimeout(function(){
         open("http://localhost:8080");

--- a/build/api-gen/dynamic-server.js
+++ b/build/api-gen/dynamic-server.js
@@ -5,7 +5,7 @@ var http = require('http'),
 var React = require('react');
 var ReactDOMServer = require('react-dom/server');
 require('node-jsx').install({extension: '.jsx'});
-var StaticPage = require('./server-side'); // React component
+var StaticPageCreator = require('./server-side'); // React component
 
 var createIndex = require("./index-docs");
 var cleanName = require("./clean-name");
@@ -19,7 +19,7 @@ function startServer(grunt, input){
     function createPage(selector, filename) {
       filename = filename || cleanName(selector) + ".html";
       props.selector = selector;
-      var page = React.createElement(StaticPage, props);
+      var page = React.createElement(StaticPageCreator.create(), props);
       var raw = ReactDOMServer.renderToStaticMarkup(page);
       if (pages[selector]) {
         var title = pages[selector].main.name;

--- a/build/api-gen/server-side.jsx
+++ b/build/api-gen/server-side.jsx
@@ -8,39 +8,41 @@ var EventPage = docComp.EventPage;
 
 // We create a StaticPage component for generating the page
 // Unlike in thre dynamic case, we assume we can just pass the necessary state directly
-var StaticPage = React.createClass({
-	render: function() {
-		var pages = this.props.index.pages;
-		var selector = this.props.selector;
-		var dict = this.props.index.dictionary;
-		
-		if (selector == "events") {
-			var content =  <EventPage data = {this.props.data} />
-		} else {
-			var page = pages[selector];
-			if (page) {
-				var content = <DocPage page={page} dict={dict} />
-			} else {
-				var content = <div/>
-			}
-		}
+var StaticPageCreator = function () {
+    return React.createClass({
+        render: function () {
+            var pages = this.props.index.pages;
+            var selector = this.props.selector;
+            var dict = this.props.index.dictionary;
 
-		return <div id="docs">
-			<div className="toc-holder" id = "doc-nav">
-				<ToC data = {this.props.data} index = {this.props.index} primary = "Core"/>
-			</div>
-			<div id="doc-content" className="doc-page-holder">
-				{content}
-			</div>
-		</div>
-	}
+            if (selector == "events") {
+                var content = <EventPage data={this.props.data} />
+            } else {
+                var page = pages[selector];
+                if (page) {
+                    var content = <DocPage page={page} dict={dict} />
+                } else {
+                    var content = <div />
+                }
+            }
+
+            return <div id="docs">
+                <div className="toc-holder" id="doc-nav">
+                    <ToC data={this.props.data} index={this.props.index} primary="Core" />
+                </div>
+                <div id="doc-content" className="doc-page-holder">
+                    {content}
+                </div>
+            </div>
+        }
+    });
+}
 
 
-})
 
-var StaticFactory = React.createFactory(StaticPage);
-
-module.exports = StaticPage;
+module.exports = {
+    create: StaticPageCreator
+}
 
 
 


### PR DESCRIPTION
This was causing a React deprecation warning to print anytime a grunt task was run.

We should probably fix that warning at some point, but we also probably shouldn't be creating the React class when the dependency is loaded.