### PR TITLE
Color was creating an array in the inner render loop

### DIFF
--- a/src/graphics/color.js
+++ b/src/graphics/color.js
@@ -182,6 +182,9 @@ Crafty.c("Color", {
     ready: true,
 
     init: function () {
+        // Necessary for some rendering layers
+        this.__coord = this.__coord || [0, 0, 0, 0];
+        
         this.bind("Draw", this._drawColor);
         if (this._drawLayer) {
             this._setupColor(this._drawLayer);


### PR DESCRIPTION
A very simple performance fix -- the color entity was creating extra garbage because of [this line](https://github.com/craftyjs/Crafty/blob/develop/src/graphics/webgl.js#L232) (and similar lines in other render layers.)