### PR TITLE
Simplify draw signature for performance reasons

### DIFF
--- a/src/graphics/canvas.js
+++ b/src/graphics/canvas.js
@@ -44,7 +44,7 @@ Crafty.c("Canvas", {
      * @comp Canvas
      * @kind Method
      * 
-     * @sign public this .draw([[Context ctx, ]Number x, Number y, Number w, Number h])
+     * @sign public this .draw([Context ctx, Number x, Number y, Number w, Number h])
      * @param ctx - Canvas 2D context if drawing on another canvas is required
      * @param x - X offset for drawing a segment
      * @param y - Y offset for drawing a segment
@@ -70,13 +70,6 @@ Crafty.c("Canvas", {
 
     draw: function (ctx, x, y, w, h) {
         if (!this.ready) return;
-        if (arguments.length === 4) {
-            h = w;
-            w = y;
-            y = x;
-            x = ctx;
-            ctx = this._drawContext;
-        }
 
         var pos = this.drawVars.pos;
         pos._x = (this._x + (x || 0));

--- a/src/graphics/webgl.js
+++ b/src/graphics/webgl.js
@@ -202,39 +202,26 @@ Crafty.c("WebGL", {
      * @kind Method
      * @private
      * 
-     * @sign public this .draw([[Context ctx, ]Number x, Number y, Number w, Number h])
-     * @param ctx - Optionally supply a different r 2D context if drawing on another canvas is required
-     * @param x - X offset for drawing a segment
-     * @param y - Y offset for drawing a segment
-     * @param w - Width of the segment to draw
-     * @param h - Height of the segment to draw
+     * @sign public this .draw()
      *
      * An internal method to draw the entity on the webgl canvas element. Rather then rendering directly, it writes relevent information into a buffer to allow batch rendering.
      */
-    draw: function (ctx, x, y, w, h) {
+    draw: function () {
 
         if (!this.ready) return;
 
-        if (arguments.length === 4) {
-            h = w;
-            w = y;
-            y = x;
-            x = ctx;
-            ctx = this._drawLayer.context;
-        }
-
         var pos = this.drawVars.pos;
-        pos._x = (this._x + (x || 0));
-        pos._y = (this._y + (y || 0));
-        pos._w = (w || this._w);
-        pos._h = (h || this._h);
+        pos._x = this._x;
+        pos._y = this._y;
+        pos._w = this._w;
+        pos._h = this._h;
 
         var coord = this.__coord || [0, 0, 0, 0];
         var co = this.drawVars.co;
-        co.x = coord[0] + (x || 0);
-        co.y = coord[1] + (y || 0);
-        co.w = w || coord[2];
-        co.h = h || coord[3];
+        co.x = coord[0];
+        co.y = coord[1];
+        co.w = coord[2];
+        co.h = coord[3];
 
         // Handle flipX, flipY
         // (Just swap the positions of e.g. x and x+w)


### PR DESCRIPTION
When using an entity pool, I discovered that the single largest source of allocations in Firefox (~90%) seemed to be instantiating the `arguments` object in the webgl `draw` method.

That method accepts optional arguments, but they're not used anywhere in Crafty, and I'm fairly certain they wouldn't work correctly if you tried to pass them in -- the signature and surrounding logic was cloned from the canvas implementation, and never cleaned up.

So
- Remove the arguments completely from the webgl `draw` method.
- Remove the reference to `arguments.length` from the canvas `draw` method, and simplify the signature