### PR TITLE
Fix pointer entity tracking for areamap

### DIFF
--- a/src/inputs/pointer.js
+++ b/src/inputs/pointer.js
@@ -129,8 +129,8 @@ Crafty.c("AreaMap", {
         }
     },
 
-    remove: function () {
-        if (this.has("Renderable") && this._drawLayer) {
+    remove: function (isDestruction) {
+        if (!isDestruction && this.has("Renderable") && this._drawLayer) {
             this._drawLayer._pointerEntities--;
         }
     },

--- a/tests/unit/inputs/inputs.js
+++ b/tests/unit/inputs/inputs.js
@@ -27,6 +27,40 @@
     _.strictEqual(areaMapEvents, 3, "NewAreaMap event triggered 3 times");
   });
 
+  test("AreaMap's layer correctly tracks pointer entities on destruction", function(_) {
+      var e = Crafty.e("2D, Mouse, DOM, Color");
+      var layer = Crafty.s("DefaultDOMLayer");
+      _.strictEqual(layer._pointerEntities, 1, "Single entity when created");
+      e.destroy();
+      _.strictEqual(layer._pointerEntities, 0, "Zero pointer entities when destroyed");
+    });
+
+    test("AreaMap's layer correctly tracks pointer entities when removing components", function(_) {
+      var e = Crafty.e("2D, Mouse, DOM, Color");
+      var layer = Crafty.s("DefaultDOMLayer");
+      _.strictEqual(layer._pointerEntities, 1, "Single entity when created");
+      e.removeComponent("AreaMap");
+      _.strictEqual(layer._pointerEntities, 0, "Zero pointer entities once component is removed");
+      e.destroy();
+      _.strictEqual(layer._pointerEntities, 0, "Zero pointer entities when destroyed");
+    });
+
+    test("Layer correctly tracks pointer entities on AreaMap component addition", function(_) {
+      var e = Crafty.e("2D, DOM, Color");
+      var layer = Crafty.s("DefaultDOMLayer");
+      _.strictEqual(layer._pointerEntities, 0, "No entities before component is added");
+      e.addComponent("AreaMap");
+      _.strictEqual(layer._pointerEntities, 1, "Single entity after component is added");
+    });
+
+    test("AreaMap's layer correctly tracks pointer entities on layer addition", function(_) {
+      var e = Crafty.e("2D, AreaMap, Color");
+      var layer = Crafty.s("DefaultDOMLayer");
+      _.strictEqual(layer._pointerEntities, 0, "No entities before layer is added");
+      e.addComponent("DOM");
+      _.strictEqual(layer._pointerEntities, 1, "Single entity after layer is added");
+    });
+
   // mock-phantom-touch-events is a PhantomJS plugin, thus the test below is skipped if enviroment is not PhantomJS
   if (navigator.userAgent.indexOf("PhantomJS") !== -1)
     test('Multitouch simulation', function(_) {


### PR DESCRIPTION
We need to decrement the number of pointer entities when detached from a layer, or when the component is removed.

However, when the entity is destroyed and both these conditions are true, only decrement once.

Several unit tests added for this behavior.

Fixes #1140 (The sensitivity to the order of components was because of the "Renderable" check in AreaMap's `remove()`.)