### PR TITLE
Allocate fewer objects when searching

### DIFF
--- a/src/graphics/canvas-layer.js
+++ b/src/graphics/canvas-layer.js
@@ -223,8 +223,8 @@ Crafty._registerLayerTemplate("Canvas", {
             rect._w = dirtyRects[i + 2];
             rect._h = dirtyRects[i + 3];
 
-            // Draw the rectangle, collision search doesn't need to check for duplicates
-            this._drawRect(rect, false);
+            // Draw the rectangle
+            this._drawRect(rect);
         }
 
         // Draw dirty rectangles for debugging, if that flag is set
@@ -261,11 +261,11 @@ Crafty._registerLayerTemplate("Canvas", {
     _drawAll: function (view) {
         var viewportRect = this._viewportRect(); // this updates the viewportRect for later cached use
 
-        // Draw the whole layer rectangle, collision search should check for duplicates
-        this._drawRect(view || viewportRect, true);
+        // Draw the whole layer rectangle
+        this._drawRect(view || viewportRect);
     },
 
-    _drawRect: function(rect, checkDupes) {
+    _drawRect: function(rect) {
         var i, l, q, obj, previousGlobalZ,
             integerBounds = Crafty.rectManager.integerBounds,
             ctx = this.context,
@@ -293,7 +293,7 @@ Crafty._registerLayerTemplate("Canvas", {
         searchRect._y = rect._y;
         searchRect._w = rect._w - 1;
         searchRect._h = rect._h - 1;
-        q = Crafty.map.search(searchRect, checkDupes);
+        q = Crafty.map.search(searchRect);
         // Sort objects by z level, duplicate objs will be ordered next to each other due to same _globalZ
         q.sort(this._sort);
 

--- a/src/inputs/pointer.js
+++ b/src/inputs/pointer.js
@@ -57,12 +57,12 @@ Crafty.extend({
 
                 // Get the position in this layer
                 pos = Crafty.domHelper.translate(x, y, layer);
-                q = Crafty.map.search({
+                q = Crafty.map.unfilteredSearch({
                     _x: pos.x,
                     _y: pos.y,
                     _w: 1,
                     _h: 1
-                }, false);
+                });
 
                 for (i = 0, l = q.length; i < l; ++i) {
                     current = q[i];

--- a/src/spatial/collision.js
+++ b/src/spatial/collision.js
@@ -487,7 +487,7 @@ Crafty.c("Collision", {
      */
     hit: function (component) {
         var area = this._cbr || this._mbr || this,
-            results = Crafty.map.search(area, false),
+            results = Crafty.map.unfilteredSearch(area),
             i = 0,
             l = results.length,
             dupes = {},

--- a/src/spatial/platform.js
+++ b/src/spatial/platform.js
@@ -161,7 +161,7 @@ Crafty.c("Supportable", {
         // check if we land (also possible to land on other ground object in same frame after lift-off from current ground object)
         if (!ground) {
             var obj, oarea,
-                results = Crafty.map.search(area, false),
+                results = Crafty.map.unfilteredSearch(area),
                 i = 0,
                 l = results.length;
 


### PR DESCRIPTION
A few changes to Crafty.map.search

- Maximum of one array created per search
- Possibility to provide 'output' array
- Split filtererd/unfiltered search into two separate methods

Because of the last two points, I still need to update some of the docs/comments, but figured I'd check whether we wanted to change the api like this first.

(I also have a follow-up PR that simplifies a couple of the core 'Collision' methods in a similar way.)