### PR TITLE
Don't generate objects on each rotation

### DIFF
--- a/src/spatial/collision.js
+++ b/src/spatial/collision.js
@@ -279,14 +279,12 @@ Crafty.c("Collision", {
 
         // If the entity is currently rotated, the points in the hitbox must also be rotated
         if (this.rotation) {
-            polygon.rotate({
-                cos: Math.cos(-this.rotation * DEG_TO_RAD),
-                sin: Math.sin(-this.rotation * DEG_TO_RAD),
-                o: {
-                    x: this._origin.x,
-                    y: this._origin.y
-                }
-            });
+            polygon.rotate(
+                this.rotation,
+                this._origin.x,
+                this._origin.y,
+                Math.cos(-this.rotation * DEG_TO_RAD),
+                Math.sin(-this.rotation * DEG_TO_RAD));
         }
 
         // Finally, assign the hitbox, and attach it to the "Collision" entity


### PR DESCRIPTION
Right now rotation info is passed around as an object that is constructed each time, which is somewhat expensive.

To avoid this:
- Alter the `rotate` method so that rotation paramters are arguments of the function, rather than properties of the object
- Don't generate a rotation object when triggering the "Rotate" event, instead passing through the amount of rotation
- Split rotation cascade into its own method, and generate more complex rotation parameters only when it's called

This also required updating other calls to `rotate`, but I think this is a general improvement.

An alternative approach I'd considered was to use an object pool, as is done for the 'Move' event.  However, it didn't seem like we actually needed that complexity here.