### PR TITLE
Update the github token travis uses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   global:
   - SAUCE_BRANCH=testing
   # GitHub token
-  - secure: p6SeAGd+Gohr6XeDkb5JPSQBu88UxAjljSMK0BNLJQgr8GkoA3mSJWy4uX0YjNq93VX4UMFxr0D4MlkcWZpX+cdN8K9PpxOgTq8Ml1Ljs355zbX9U/CdY99okiwzHktY4qKXBPsHLiEuCBeJ6pxs/v7m9z88mkjwDSunJG7F1oo=
+  - secure: nMIM+zttVf8rmBrI4RSvWcZiqN1rwFPt9xIY89QkRuHJeAvju9HM5N5RoossvDBQ+b/Z5Sm3L3aq+U2KfWnW5mSnAvmE2j2T4HfaQABnTiVzGhpailaX9O7ACZuLnsQ9hgbIxPOSlk68cDcAp3HWnofBYigauhWbEwbuBGWl/iU=
   # OpenSauce credentials: for pre-relase testing
   - secure: NO+7PK5P0XLGbnvdSDBlrlnzqM/hMTy3wxxAp8ZtzEuS2ZOXn8q0KjOO/cAs1NorG1SOl8+XfFZBTR5W504GrHYLP8fNkLJOAyKMfFeTojwQ+385ShVr/NejZFejsc+xJZymIeDsEzBZqosxPOi+8k7jljDK4mzLdKMpt8flWUw=
   - secure: iGO+VCkCq/26Dqrc6+G1nX8Dk+tTqhcINuiIVhxGtMARcY+WIzcyEK/cfXRaLnvIzIxQ0xUoGGnM9xe4DQT8L+BGzo8AGnVbzxITzceWTlhsFepcbOTgqOg0ZGMxQVQ6VBh888Cdks8KsOgtTNhzd+oVgcStsyxZPCVD/7VgNTE=


### PR DESCRIPTION
The token for @craftyjs-machine-user was no longer working, I assume due to [this security issue](https://blog.travis-ci.com/2017-05-08-security-advisory) (the timing is about right.)  This prevented the most recent build from being pushed.

I generated a new token and added it to the travis.yml.

*e:* Oops, pulled in some incorrect changes.  Fixing.