### PR TITLE
Add speed property to delay and tween

### DIFF
--- a/src/core/time.js
+++ b/src/core/time.js
@@ -8,6 +8,14 @@
  * This syncs with Crafty's internal clock, and so should generally be preferred to using methods such as `setTimeout`.
  */
 module.exports = {
+    /**@
+     * #.delaySpeed
+     * @comp Delay
+     *
+     * The rate of the delay.  This property defaults to 1.
+     */
+    delaySpeed: 1,
+
     init: function () {
         this._delays = [];
         this._delaysPaused = false;
@@ -20,7 +28,7 @@ module.exports = {
                     // remove canceled item from array
                     this._delays.splice(index, 1);
                 } else {
-                    item.accumulator+=frameData.dt;
+                    item.accumulator += frameData.dt * this.delaySpeed;
                     // The while loop handles the (pathological) case where dt>delay
                     while(item.accumulator >= item.delay && item.repeat >= 0){
                         item.accumulator -= item.delay;

--- a/src/core/time.js
+++ b/src/core/time.js
@@ -12,7 +12,9 @@ module.exports = {
      * #.delaySpeed
      * @comp Delay
      *
-     * The rate of the delay.  This property defaults to 1.
+     * The rate of the delay. This property defaults to 1.
+     * When setting delaySpeed to 0.5, delays will take twice as long,
+     * setting it to 2.0 will make them twice as short
      */
     delaySpeed: 1,
 

--- a/src/core/tween.js
+++ b/src/core/tween.js
@@ -12,6 +12,14 @@ var Crafty = require('../core/core.js');
  */
 module.exports = {
 
+  /**@
+   * #.tweenSpeed
+   * @comp Tween
+   *
+   * The rate of the tween.  This property defaults to 1.
+   */
+  tweenSpeed: 1,
+
   init: function(){
     this.tweenGroup = {};
     this.tweenStart = {};
@@ -24,7 +32,7 @@ module.exports = {
     var tween, v, i;
     for ( i = this.tweens.length-1; i>=0; i--){
       tween = this.tweens[i];
-      tween.easing.tick(frameData.dt);
+      tween.easing.tick(frameData.dt * this.tweenSpeed);
       v  = tween.easing.value();
       this._doTween(tween.props, v);
       if (tween.easing.complete) {

--- a/src/core/tween.js
+++ b/src/core/tween.js
@@ -16,7 +16,9 @@ module.exports = {
    * #.tweenSpeed
    * @comp Tween
    *
-   * The rate of the tween.  This property defaults to 1.
+   * The rate of the tween. This property defaults to 1.
+   * When setting tweenSpeed to 0.5, tweens will take twice as long,
+   * setting it to 2.0 will make them twice as short
    */
   tweenSpeed: 1,
 

--- a/tests/unit/core/time.js
+++ b/tests/unit/core/time.js
@@ -122,6 +122,31 @@
     Crafty.timer.simulateFrames(5);
     _.strictEqual(counter, 1, "delayed function should have executed once");
     _.strictEqual(ent._delays.length, 0, "no more scheduled delays");
+
+    //test delaySpeed being 0.5
+    counter = 0;
+    ent.delay(incr, 99);
+    ent.delaySpeed = 0.5;
+    Crafty.timer.simulateFrames(5); // 5 * 20ms = 100ms
+    _.strictEqual(counter, 0, "delayed function should not have executed");
+    _.strictEqual(ent._delays.length, 1, "one pending delay");
+    Crafty.timer.simulateFrames(5); // 5 * 20ms = 100ms
+    _.strictEqual(counter, 1, "delayed function should have executed once");
+    _.strictEqual(ent._delays.length, 0, "no more scheduled delays");
+    ent.delaySpeed = 1.0;
+
+    //test delaySpeed being 0.5 halfway through
+    counter = 0;
+    ent.delay(incr, 99);
+    Crafty.timer.simulateFrames(3); // 3 * 20ms = 60ms
+    ent.delaySpeed = 0.5;
+    Crafty.timer.simulateFrames(3); // 3 * 10ms = 30ms
+    _.strictEqual(counter, 0, "delayed function should not have executed");
+    _.strictEqual(ent._delays.length, 1, "one pending delay");
+    Crafty.timer.simulateFrames(1); // 1 * 10ms = 100ms
+    _.strictEqual(counter, 1, "delayed function should have executed once");
+    _.strictEqual(ent._delays.length, 0, "no more scheduled delays");
+
   });
 
   module("Crafty.timer", {

--- a/tests/unit/core/tween.js
+++ b/tests/unit/core/tween.js
@@ -143,6 +143,33 @@
     _.strictEqual(e.z, 300, "end position");
   });
 
+  test('.tweenSpeed', function(_) {
+    var actualTweens = [],
+        fired = 0;
+
+    var e = Crafty.e('2D, Tween')
+      .tween({ y: 50, z: 300 }, 200) // 10 frames = 200ms by default
+      .bind('TweenEnd', function(props) {
+        ++fired;
+        actualTweens = actualTweens.concat(Object.keys(props).sort());
+      });
+
+    // no progress if paused
+    e.tweenSpeed = 0.5;
+    Crafty.timer.simulateFrames(10);
+    _.strictEqual(fired, 0, "no events fired");
+    _.deepEqual(actualTweens, [], "no tweens finished");
+    _.strictEqual(e.y, 25, "mid position");
+    _.strictEqual(e.z, 150, "mid position");
+
+    e.tweenSpeed = 1.0;
+    Crafty.timer.simulateFrames(5+1);
+    _.strictEqual(fired, 1, "1 event fired");
+    _.deepEqual(actualTweens, ['y', 'z'], "y and z tween finished");
+    _.strictEqual(e.y, 50, "end position");
+    _.strictEqual(e.z, 300, "end position");
+  });
+
   test('cancel tween', function(_) {
     _.expect(12); // 3[x,y,z-start] + 2[x,z]*3[TweenEnd] + 3[x,y,z-end] assertions
 


### PR DESCRIPTION
Fixes https://github.com/craftyjs/Crafty/issues/1160

This adds a `.delaySpeed` and `.tweenSpeed` property to the `Delay` and `Tween` components.

This works like the `.animationSpeed` for `SpriteAnimation`. The default is 1, setting it to 2 makes everything twice as fast, setting it to 0.5 makes it twice as slow. This can be applied when delays and tweens are in progress, and is useful to create slow-motion effects in games.