### PR TITLE
Fix issue with removing a component that was not there

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -470,7 +470,9 @@ Crafty.fn = Crafty.prototype = {
         }
         delete this.__c[id];
         // update map from component to (entityId -> entity)
-        delete compEntities[id][this[0]];
+        if (compEntities[id]) {
+            delete compEntities[id][this[0]];
+        }
 
         return this;
     },

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -57,6 +57,7 @@
     first.removeComponent("comp", false);
     _.strictEqual(!first.added && !first.has("comp"), true, "hard-removed component (properties are gone)");
 
+    first.removeComponent("nonAddedComponent");
   });
 
   test("remove", function(_) {


### PR DESCRIPTION
When removing a component that was never added, Crafty produces an error.

```
Uncaught TypeError: Cannot convert undefined or null to object
    at init.removeComponent (crafty.js:2699)
```