### PR TITLE
Cancel touch events when treating them as mouse events

### DIFF
--- a/src/inputs/touch.js
+++ b/src/inputs/touch.js
@@ -19,9 +19,10 @@ Crafty.extend({
      *
      * If this is set to true, it is expected that your entities have the `Touch` component instead of the `Mouse` component.
      * If false (default), then only entities with the Mouse component will respond to touch.
-     * It's recommended to add the `Button` component instead, which requires the proper component depending on this feature.
+     * For simple use cases, tt's recommended to add the `Button` component instead, which requires the proper component depending on this feature.
      *
      * @note The multitouch feature is currently incompatible with the `Draggable` component and `Crafty.viewport.mouselook`.
+     * @note When multitouch is not enabled, Crafty will cancel touch events when forwarding them to the mouse system.
      *
      * @example
      * ~~~
@@ -97,6 +98,7 @@ Crafty.extend({
                     first.target.dispatchEvent(simulatedEvent);
                 }
             }
+            e.preventDefault();
         }
 
         return function(e) {


### PR DESCRIPTION
While doing some cross-browser testing, I noticed that Crafty's mouse events were being triggered twice on mobile.  I'm fairly certain this is because the browser was *also* mapping touch events to mouse events.

The best solution seems to be to call `preventDefault()` on the touch event when forwarding to the mouse system.  I believe that when Crafty itself handles touch/mouse this is already done; it's just missing when we forward touch events to mouse events.

Tagging @mucaho since he's done much more work the touch/mouse systems than I have.