### PR TITLE
Dev setup uses prepare instead of postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "browser": "src/crafty.js",
   "scripts": {
     "test": "grunt check",
-    "postinstall": "(node -e \"process.env.NODE_ENV !== 'production' && process.exit()\" && grunt copy:lib) || node -v",
+    "prepare": "(node -e \"process.env.NODE_ENV !== 'production' && process.exit()\" && grunt copy:lib) || node -v",
     "precommit": "pretty-quick --staged"
   },
   "browserify": {


### PR DESCRIPTION
We want the dev setup script to use the prepare trigger instead of postinstall.
This will prevent folk who install the package as a node module running into grunt errors.